### PR TITLE
chore: 로컬 개발용 MySQL Docker Compose 구성 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - '3306:3306'
     volumes:
       - caquick-mysql-data:/var/lib/mysql
+      - ./docker/mysql/init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: caquick-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: CaQuick
+      MYSQL_USER: caquick
+      MYSQL_PASSWORD: caquick
+    ports:
+      - '3306:3306'
+    volumes:
+      - caquick-mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ['CMD', 'mysqladmin', 'ping', '-h', 'localhost']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  caquick-mysql-data:

--- a/docker/mysql/init/01-grant-shadow-db.sql
+++ b/docker/mysql/init/01-grant-shadow-db.sql
@@ -1,0 +1,4 @@
+-- Prisma migrate dev는 shadow database를 임시 생성/삭제하므로
+-- caquick 유저에게 DB 생성 권한을 부여한다.
+GRANT ALL PRIVILEGES ON *.* TO 'caquick'@'%';
+FLUSH PRIVILEGES;


### PR DESCRIPTION
<!-- pr-ai-summary:start -->
## PR Summary
로컬 개발 환경에서 MySQL을 쉽게 실행할 수 있도록 Docker Compose 구성을 추가했습니다.
Prisma migrate dev 사용 시 필요한 shadow database 생성 권한을 부여하는 초기화 스크립트도 포함되어 있습니다.

- MySQL 8.0 버전 기반 Docker Compose 설정 추가
- MySQL 컨테이너의 환경 변수 및 포트 설정 포함
- 데이터 영속성을 위한 볼륨 마운트 설정
- Prisma migrate dev를 위한 shadow database 권한 부여 SQL 스크립트 추가

## Changes
> 2 files changed

| File | Changes |
|------|---------|
| `docker-compose.yml` | MySQL 8.0 컨테이너를 위한 Docker Compose 설정 파일을 추가했습니다. 환경 변수, 포트, 볼륨, 헬스체크가 포함되어 있습니다. |
| `docker/mysql/init/01-grant-shadow-db.sql` | Prisma migrate dev에서 사용하는 shadow database 생성 권한을 부여하는 SQL 초기화 스크립트를 추가했습니다. |

## Impact
- 로컬 개발 환경에서 MySQL 데이터베이스를 손쉽게 실행 및 관리할 수 있습니다.
- Prisma migrate dev 명령어 사용 시 shadow database 생성 권한 문제를 해결합니다.

## Checklist
- [ ] Docker Compose로 MySQL 컨테이너가 정상적으로 실행되는지 확인하세요.
- [ ] 초기화 스크립트가 정상적으로 실행되어 caquick 유저에게 권한이 부여되었는지 검증하세요.
- [ ] Prisma migrate dev 명령어가 권한 문제 없이 동작하는지 테스트하세요.
<!-- pr-ai-summary:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Docker Compose를 통한 MySQL 데이터베이스 서비스 환경 설정 추가
  * 데이터베이스 초기화 및 권한 설정 스크립트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->