### PR TITLE
test: 전체 테스트 커버리지 대폭 개선 (243 → 386)

### DIFF
--- a/.github/workflows/pr-ai-description.yml
+++ b/.github/workflows/pr-ai-description.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   pr-ai-description:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: false # 임시 비활성화 — 원래 조건: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,17 @@ src/graphql/graphql.types.ts
 /public/index.html
 /public/javascripts/
 /public/stylesheets/
+
+# Claude
+.claude/
+CLAUDE.md
+
+# Codex
+AGENTS.md
+
+docs/*
+!docs/guide/
+
+.env.example
+caquick_ddl.sql
+src/features/example/*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 yarn lint-staged
+npx tsc --noEmit

--- a/src/common/utils/date-parser.spec.ts
+++ b/src/common/utils/date-parser.spec.ts
@@ -25,6 +25,28 @@ describe('date-parser', () => {
       const date = new Date('2024-01-01');
       expect(toDate(date)).toBe(date);
     });
+
+    it('빈 문자열이면 BadRequestException을 던져야 한다', () => {
+      expect(() => toDate('')).toThrow(BadRequestException);
+    });
+
+    it('타임존이 포함된 ISO 문자열이면 Date를 반환해야 한다', () => {
+      const result = toDate('2024-01-01T00:00:00Z');
+      expect(result).toBeInstanceOf(Date);
+      expect(result!.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    it('앞뒤 공백이 있는 날짜 문자열이면 Date를 반환해야 한다', () => {
+      const result = toDate('  2024-01-01  ');
+      expect(result).toBeInstanceOf(Date);
+    });
+
+    it('Unix epoch(new Date(0))을 그대로 반환해야 한다', () => {
+      const epoch = new Date(0);
+      const result = toDate(epoch);
+      expect(result).toBe(epoch);
+      expect(result!.getTime()).toBe(0);
+    });
   });
 
   describe('toDateRequired', () => {

--- a/src/common/utils/text-cleaner.spec.ts
+++ b/src/common/utils/text-cleaner.spec.ts
@@ -22,6 +22,18 @@ describe('text-cleaner', () => {
     it('유효한 텍스트를 트림하여 반환해야 한다', () => {
       expect(cleanRequiredText('  hello  ', 100)).toBe('hello');
     });
+
+    it('정확히 maxLength와 같은 길이면 통과해야 한다', () => {
+      expect(cleanRequiredText('12345', 5)).toBe('12345');
+    });
+
+    it('maxLength를 1만큼 초과하면 BadRequestException을 던져야 한다', () => {
+      expect(() => cleanRequiredText('123456', 5)).toThrow(BadRequestException);
+    });
+
+    it('앞뒤 공백을 제거한 결과를 반환해야 한다', () => {
+      expect(cleanRequiredText('  hello  ', 100)).toBe('hello');
+    });
   });
 
   describe('cleanNullableText', () => {
@@ -47,6 +59,10 @@ describe('text-cleaner', () => {
 
     it('유효한 텍스트를 트림하여 반환해야 한다', () => {
       expect(cleanNullableText('  hello  ', 100)).toBe('hello');
+    });
+
+    it('탭/개행/캐리지리턴만 있으면 null을 반환해야 한다', () => {
+      expect(cleanNullableText('\t\n\r', 100)).toBeNull();
     });
   });
 });

--- a/src/features/auth/auth.seller.service.spec.ts
+++ b/src/features/auth/auth.seller.service.spec.ts
@@ -135,6 +135,18 @@ describe('AuthService (seller)', () => {
       ).rejects.toThrow(UnauthorizedException);
     });
 
+    it('공백만 있는 비밀번호이면 UnauthorizedException을 던져야 한다', async () => {
+      // Act & Assert
+      await expect(
+        service.sellerLogin({
+          username: 'seller01',
+          password: '   ',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
     it('존재하지 않는 판매자이면 UnauthorizedException을 던져야 한다', async () => {
       // Arrange
       repo.findSellerCredentialByUsername.mockResolvedValue(null);

--- a/src/features/auth/auth.seller.service.spec.ts
+++ b/src/features/auth/auth.seller.service.spec.ts
@@ -1,6 +1,12 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AccountType } from '@prisma/client';
 import argon2 from 'argon2';
 import type { Request, Response } from 'express';
 
@@ -11,19 +17,45 @@ import { OidcClientService } from '@/features/auth/services/oidc-client.service'
 describe('AuthService (seller)', () => {
   let service: AuthService;
   let repo: jest.Mocked<AuthRepository>;
+  let mockConfig: jest.Mocked<ConfigService>;
+
+  const mockReq = {
+    headers: { 'user-agent': 'Mozilla/5.0 TestBrowser' },
+    ip: '127.0.0.1',
+    cookies: {},
+  } as unknown as Request;
+
+  const mockRes = {
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+  } as unknown as Response;
 
   beforeEach(async () => {
     repo = {
       findSellerCredentialByUsername: jest.fn(),
+      findSellerCredentialByAccountId: jest.fn(),
       updateSellerLastLogin: jest.fn(),
+      updateSellerPasswordHash: jest.fn(),
+      revokeAllRefreshSessions: jest.fn(),
       createRefreshSession: jest.fn(),
+      createAuditLog: jest.fn(),
+      findActiveRefreshSessionByHash: jest.fn(),
+      rotateRefreshSession: jest.fn(),
+      revokeRefreshSession: jest.fn(),
     } as unknown as jest.Mocked<AuthRepository>;
+
+    mockConfig = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ConfigService>;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
-        { provide: ConfigService, useValue: { get: jest.fn() } },
-        { provide: JwtService, useValue: { sign: jest.fn(() => 'token') } },
+        { provide: ConfigService, useValue: mockConfig },
+        {
+          provide: JwtService,
+          useValue: { sign: jest.fn(() => 'mock-access-token') },
+        },
         { provide: OidcClientService, useValue: {} },
         { provide: AuthRepository, useValue: repo },
       ],
@@ -32,34 +64,768 @@ describe('AuthService (seller)', () => {
     service = module.get<AuthService>(AuthService);
   });
 
-  it('판매자 로그인 성공 시 accountStatus를 반환해야 한다', async () => {
-    const verifySpy = jest.spyOn(argon2, 'verify').mockResolvedValue(true);
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-    repo.findSellerCredentialByUsername.mockResolvedValue({
-      seller_account_id: BigInt(1),
-      password_hash: 'hashed',
+  describe('sellerLogin', () => {
+    const validCredential = {
+      id: BigInt(1),
+      seller_account_id: BigInt(10),
+      username: 'seller01',
+      password_hash: '$argon2id$v=19$m=65536,t=3,p=4$abc$hashedPw',
+      password_updated_at: new Date('2025-03-01'),
+      last_login_at: new Date('2025-06-10'),
+      created_at: new Date('2025-01-01'),
+      updated_at: new Date('2025-06-10'),
+      deleted_at: null,
       seller_account: {
-        account_type: 'SELLER',
-        status: 'PENDING',
+        id: BigInt(10),
+        account_type: AccountType.SELLER,
+        status: 'PENDING' as const,
+        store: { id: BigInt(5) },
       },
-    } as never);
+    };
 
-    const req = {
-      headers: {},
-      ip: '127.0.0.1',
-    } as unknown as Request;
-    const res = {
-      cookie: jest.fn(),
-    } as unknown as Response;
+    it('판매자 로그인 성공 시 accessToken과 accountStatus를 반환해야 한다', async () => {
+      // Arrange
+      jest.spyOn(argon2, 'verify').mockResolvedValue(true);
+      repo.findSellerCredentialByUsername.mockResolvedValue(
+        validCredential as never,
+      );
 
-    const result = await service.sellerLogin({
-      username: 'seller',
-      password: 'Password!123',
-      req,
-      res,
+      // Act
+      const result = await service.sellerLogin({
+        username: 'seller01',
+        password: 'Password!123',
+        req: mockReq,
+        res: mockRes,
+      });
+
+      // Assert
+      expect(result.accessToken).toBe('mock-access-token');
+      expect(result.accountStatus).toBe('PENDING');
+      expect(repo.updateSellerLastLogin).toHaveBeenCalledWith(
+        BigInt(10),
+        expect.any(Date),
+      );
     });
 
-    expect(result.accountStatus).toBe('PENDING');
-    verifySpy.mockRestore();
+    it('username이 빈 문자열이면 UnauthorizedException을 던져야 한다', async () => {
+      // Act & Assert
+      await expect(
+        service.sellerLogin({
+          username: '   ',
+          password: 'Password!123',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('password가 빈 문자열이면 UnauthorizedException을 던져야 한다', async () => {
+      // Act & Assert
+      await expect(
+        service.sellerLogin({
+          username: 'seller01',
+          password: '',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('존재하지 않는 판매자이면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      repo.findSellerCredentialByUsername.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.sellerLogin({
+          username: 'nonexistent',
+          password: 'Password!123',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.sellerLogin({
+          username: 'nonexistent',
+          password: 'Password!123',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow('Invalid seller credentials.');
+    });
+
+    it('account_type이 SELLER가 아니면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const nonSellerCredential = {
+        ...validCredential,
+        seller_account: {
+          ...validCredential.seller_account,
+          account_type: AccountType.USER,
+        },
+      };
+      repo.findSellerCredentialByUsername.mockResolvedValue(
+        nonSellerCredential as never,
+      );
+
+      // Act & Assert
+      await expect(
+        service.sellerLogin({
+          username: 'seller01',
+          password: 'Password!123',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.sellerLogin({
+          username: 'seller01',
+          password: 'Password!123',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow('Invalid seller credentials.');
+    });
+
+    it('비밀번호가 틀리면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      jest.spyOn(argon2, 'verify').mockResolvedValue(false);
+      repo.findSellerCredentialByUsername.mockResolvedValue(
+        validCredential as never,
+      );
+
+      // Act & Assert
+      await expect(
+        service.sellerLogin({
+          username: 'seller01',
+          password: 'WrongPassword!123',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.sellerLogin({
+          username: 'seller01',
+          password: 'WrongPassword!123',
+          req: mockReq,
+          res: mockRes,
+        }),
+      ).rejects.toThrow('Invalid seller credentials.');
+    });
+  });
+
+  describe('changeSellerPassword', () => {
+    const sellerCredential = {
+      id: BigInt(1),
+      seller_account_id: BigInt(10),
+      username: 'seller01',
+      password_hash: '$argon2id$v=19$m=65536,t=3,p=4$abc$currentHash',
+      password_updated_at: new Date('2025-03-01'),
+      last_login_at: new Date('2025-06-10'),
+      created_at: new Date('2025-01-01'),
+      updated_at: new Date('2025-06-10'),
+      deleted_at: null,
+      seller_account: {
+        id: BigInt(10),
+        account_type: AccountType.SELLER,
+        status: 'ACTIVE' as const,
+        store: { id: BigInt(5) },
+      },
+    };
+
+    it('비밀번호를 성공적으로 변경해야 한다', async () => {
+      // Arrange
+      repo.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential as never,
+      );
+      // 첫 번째 호출: 현재 비밀번호 확인 (true)
+      // 두 번째 호출: 새 비밀번호 동일 여부 확인 (false = 다른 비밀번호)
+      jest
+        .spyOn(argon2, 'verify')
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      jest
+        .spyOn(argon2, 'hash')
+        .mockResolvedValue('$argon2id$v=19$m=65536,t=3,p=4$new$newHash');
+
+      // Act
+      await service.changeSellerPassword({
+        accountId: BigInt(10),
+        currentPassword: 'OldPassword!123',
+        newPassword: 'NewPassword!456',
+        req: mockReq,
+      });
+
+      // Assert
+      expect(repo.updateSellerPasswordHash).toHaveBeenCalledWith({
+        sellerAccountId: BigInt(10),
+        passwordHash: '$argon2id$v=19$m=65536,t=3,p=4$new$newHash',
+        now: expect.any(Date),
+      });
+      expect(repo.revokeAllRefreshSessions).toHaveBeenCalledWith(
+        BigInt(10),
+        expect.any(Date),
+      );
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(10),
+          storeId: BigInt(5),
+          targetId: BigInt(10),
+        }),
+      );
+    });
+
+    it('판매자를 찾을 수 없으면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      repo.findSellerCredentialByAccountId.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(999),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'NewPassword!456',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(999),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'NewPassword!456',
+          req: mockReq,
+        }),
+      ).rejects.toThrow('Seller not found.');
+    });
+
+    it('account_type이 SELLER가 아니면 ForbiddenException을 던져야 한다', async () => {
+      // Arrange
+      const nonSellerCredential = {
+        ...sellerCredential,
+        seller_account: {
+          ...sellerCredential.seller_account,
+          account_type: AccountType.USER,
+        },
+      };
+      repo.findSellerCredentialByAccountId.mockResolvedValue(
+        nonSellerCredential as never,
+      );
+
+      // Act & Assert
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'NewPassword!456',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'NewPassword!456',
+          req: mockReq,
+        }),
+      ).rejects.toThrow('Only SELLER account is allowed.');
+    });
+
+    it('현재 비밀번호가 빈 문자열이면 BadRequestException을 던져야 한다', async () => {
+      // Arrange
+      repo.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential as never,
+      );
+
+      // Act & Assert
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: '',
+          newPassword: 'NewPassword!456',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: '',
+          newPassword: 'NewPassword!456',
+          req: mockReq,
+        }),
+      ).rejects.toThrow('Current and new password are required.');
+    });
+
+    it('새 비밀번호가 빈 문자열이면 BadRequestException을 던져야 한다', async () => {
+      // Arrange
+      repo.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential as never,
+      );
+
+      // Act & Assert
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'OldPassword!123',
+          newPassword: '',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('현재 비밀번호가 틀리면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      repo.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential as never,
+      );
+      jest.spyOn(argon2, 'verify').mockResolvedValue(false);
+
+      // Act & Assert
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'WrongPassword!123',
+          newPassword: 'NewPassword!456',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'WrongPassword!123',
+          newPassword: 'NewPassword!456',
+          req: mockReq,
+        }),
+      ).rejects.toThrow('Current password is invalid.');
+    });
+
+    it('새 비밀번호가 정책(8~64자, 대소문자/숫자/특수문자)을 위반하면 BadRequestException을 던져야 한다', async () => {
+      // Arrange
+      repo.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential as never,
+      );
+      jest.spyOn(argon2, 'verify').mockResolvedValue(true);
+
+      // 너무 짧은 비밀번호
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'Ab1!',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      // 소문자 없음
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'ABCDEFGH!123',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      // 대문자 없음
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'abcdefgh!123',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      // 숫자 없음
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'Abcdefgh!xyz',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      // 특수문자 없음
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'OldPassword!123',
+          newPassword: 'Abcdefgh1234',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('새 비밀번호가 기존 비밀번호와 동일하면 BadRequestException을 던져야 한다', async () => {
+      // Arrange
+      repo.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential as never,
+      );
+      // 현재 비밀번호 확인: true, 새 비밀번호 동일 여부: true (같은 비밀번호)
+      jest
+        .spyOn(argon2, 'verify')
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+
+      // Act & Assert
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'SamePassword!123',
+          newPassword: 'SamePassword!123',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.changeSellerPassword({
+          accountId: BigInt(10),
+          currentPassword: 'SamePassword!123',
+          newPassword: 'SamePassword!123',
+          req: mockReq,
+        }),
+      ).rejects.toThrow(
+        'New password must be different from current password.',
+      );
+    });
+  });
+
+  describe('refreshSeller', () => {
+    it('판매자 refresh 재발급 시 accessToken과 accountStatus를 반환해야 한다', async () => {
+      // Arrange
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'valid-refresh-token' },
+        headers: { 'user-agent': 'Mozilla/5.0 TestBrowser' },
+        ip: '127.0.0.1',
+      } as unknown as Request;
+
+      repo.findActiveRefreshSessionByHash.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        token_hash: 'hashed-token',
+        user_agent: 'Mozilla/5.0 TestBrowser',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2030-01-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01'),
+        deleted_at: null,
+      } as never);
+
+      repo.rotateRefreshSession.mockResolvedValue({
+        id: BigInt(2),
+        account_id: BigInt(10),
+        token_hash: 'new-hash',
+      } as never);
+
+      repo.findSellerCredentialByAccountId.mockResolvedValue({
+        id: BigInt(1),
+        seller_account_id: BigInt(10),
+        username: 'seller01',
+        password_hash: '$argon2id$v=19$m=65536,t=3,p=4$abc$hash',
+        password_updated_at: new Date('2025-03-01'),
+        last_login_at: new Date('2025-06-10'),
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-10'),
+        deleted_at: null,
+        seller_account: {
+          id: BigInt(10),
+          account_type: AccountType.SELLER,
+          status: 'ACTIVE' as const,
+          store: { id: BigInt(5) },
+        },
+      } as never);
+
+      // Act
+      const result = await service.refreshSeller(reqWithCookie, mockRes);
+
+      // Assert
+      expect(result.accessToken).toBe('mock-access-token');
+      expect(result.accountStatus).toBe('ACTIVE');
+    });
+
+    it('refresh 토큰이 없으면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const reqNoCookie = {
+        cookies: {},
+      } as unknown as Request;
+
+      // Act & Assert
+      await expect(service.refreshSeller(reqNoCookie, mockRes)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.refreshSeller(reqNoCookie, mockRes)).rejects.toThrow(
+        'Missing refresh token.',
+      );
+    });
+
+    it('유효하지 않은 refresh 토큰이면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'invalid-refresh-token' },
+      } as unknown as Request;
+
+      repo.findActiveRefreshSessionByHash.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.refreshSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.refreshSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow('Invalid refresh token.');
+    });
+
+    it('판매자 자격정보가 없으면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'valid-refresh-token' },
+        headers: { 'user-agent': 'Mozilla/5.0' },
+        ip: '127.0.0.1',
+      } as unknown as Request;
+
+      repo.findActiveRefreshSessionByHash.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        token_hash: 'hashed-token',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2030-01-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01'),
+        deleted_at: null,
+      } as never);
+
+      repo.rotateRefreshSession.mockResolvedValue({
+        id: BigInt(2),
+        account_id: BigInt(10),
+        token_hash: 'new-hash',
+      } as never);
+
+      repo.findSellerCredentialByAccountId.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.refreshSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.refreshSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow('Invalid seller refresh token.');
+    });
+
+    it('account_type이 SELLER가 아니면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'valid-refresh-token' },
+        headers: { 'user-agent': 'Mozilla/5.0' },
+        ip: '127.0.0.1',
+      } as unknown as Request;
+
+      repo.findActiveRefreshSessionByHash.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        token_hash: 'hashed-token',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2030-01-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01'),
+        deleted_at: null,
+      } as never);
+
+      repo.rotateRefreshSession.mockResolvedValue({
+        id: BigInt(2),
+        account_id: BigInt(10),
+        token_hash: 'new-hash',
+      } as never);
+
+      repo.findSellerCredentialByAccountId.mockResolvedValue({
+        id: BigInt(1),
+        seller_account_id: BigInt(10),
+        username: 'seller01',
+        password_hash: '$argon2id$v=19$hash',
+        seller_account: {
+          id: BigInt(10),
+          account_type: AccountType.USER, // SELLER가 아님
+          status: 'ACTIVE' as const,
+          store: null,
+        },
+      } as never);
+
+      // Act & Assert
+      await expect(
+        service.refreshSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.refreshSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow('Invalid seller refresh token.');
+    });
+  });
+
+  describe('logoutSeller', () => {
+    it('판매자 로그아웃 시 세션을 revoke하고 쿠키를 삭제해야 한다', async () => {
+      // Arrange
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'valid-refresh-token' },
+      } as unknown as Request;
+
+      repo.findActiveRefreshSessionByHash.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        token_hash: 'hashed-token',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2030-01-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01'),
+        deleted_at: null,
+      } as never);
+
+      repo.findSellerCredentialByAccountId.mockResolvedValue({
+        id: BigInt(1),
+        seller_account_id: BigInt(10),
+        username: 'seller01',
+        password_hash: '$argon2id$v=19$hash',
+        password_updated_at: new Date('2025-03-01'),
+        last_login_at: new Date('2025-06-10'),
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-10'),
+        deleted_at: null,
+        seller_account: {
+          id: BigInt(10),
+          account_type: AccountType.SELLER,
+          status: 'ACTIVE' as const,
+          store: { id: BigInt(5) },
+        },
+      } as never);
+
+      repo.revokeRefreshSession.mockResolvedValue({
+        id: BigInt(1),
+        revoked_at: new Date(),
+      } as never);
+
+      // Act
+      await service.logoutSeller(reqWithCookie, mockRes);
+
+      // Assert
+      expect(repo.revokeRefreshSession).toHaveBeenCalledWith(BigInt(1));
+      expect(mockRes.clearCookie).toHaveBeenCalled();
+    });
+
+    it('refresh 토큰이 없으면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const reqNoCookie = {
+        cookies: {},
+      } as unknown as Request;
+
+      // Act & Assert
+      await expect(service.logoutSeller(reqNoCookie, mockRes)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.logoutSeller(reqNoCookie, mockRes)).rejects.toThrow(
+        'Missing refresh token.',
+      );
+    });
+
+    it('유효하지 않은 refresh 토큰이면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'invalid-token' },
+      } as unknown as Request;
+
+      repo.findActiveRefreshSessionByHash.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.logoutSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.logoutSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow('Invalid refresh token.');
+    });
+
+    it('판매자 자격정보가 없으면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'valid-refresh-token' },
+      } as unknown as Request;
+
+      repo.findActiveRefreshSessionByHash.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        token_hash: 'hashed-token',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2030-01-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01'),
+        deleted_at: null,
+      } as never);
+
+      repo.findSellerCredentialByAccountId.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(
+        service.logoutSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.logoutSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow('Invalid seller refresh token.');
+    });
+
+    it('account_type이 SELLER가 아니면 UnauthorizedException을 던져야 한다', async () => {
+      // Arrange
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'valid-refresh-token' },
+      } as unknown as Request;
+
+      repo.findActiveRefreshSessionByHash.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        token_hash: 'hashed-token',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2030-01-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01'),
+        deleted_at: null,
+      } as never);
+
+      repo.findSellerCredentialByAccountId.mockResolvedValue({
+        id: BigInt(1),
+        seller_account_id: BigInt(10),
+        username: 'seller01',
+        password_hash: '$argon2id$v=19$hash',
+        seller_account: {
+          id: BigInt(10),
+          account_type: AccountType.USER, // SELLER가 아님
+          status: 'ACTIVE' as const,
+          store: null,
+        },
+      } as never);
+
+      // Act & Assert
+      await expect(
+        service.logoutSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.logoutSeller(reqWithCookie, mockRes),
+      ).rejects.toThrow('Invalid seller refresh token.');
+    });
   });
 });

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -154,7 +154,7 @@ export class AuthService {
     res: Response;
   }): Promise<{ accessToken: string; accountStatus: AccountStatus }> {
     const username = args.username.trim();
-    const password = args.password;
+    const password = args.password.trim();
 
     if (!username || !password) {
       throw new UnauthorizedException('Invalid seller credentials.');

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -154,9 +154,9 @@ export class AuthService {
     res: Response;
   }): Promise<{ accessToken: string; accountStatus: AccountStatus }> {
     const username = args.username.trim();
-    const password = args.password.trim();
+    const password = args.password;
 
-    if (!username || !password) {
+    if (!username || !password.trim()) {
       throw new UnauthorizedException('Invalid seller credentials.');
     }
 

--- a/src/features/auth/repositories/auth.repository.spec.ts
+++ b/src/features/auth/repositories/auth.repository.spec.ts
@@ -1,5 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { AccountType, IdentityProvider } from '@prisma/client';
+import {
+  AccountType,
+  AuditActionType,
+  AuditTargetType,
+  IdentityProvider,
+  Prisma,
+} from '@prisma/client';
 
 import { AuthRepository } from '@/features/auth/repositories/auth.repository';
 import { PrismaService } from '@/prisma';
@@ -24,6 +30,14 @@ describe('AuthRepository', () => {
       create: jest.Mock;
       findFirst: jest.Mock;
       update: jest.Mock;
+      updateMany: jest.Mock;
+    };
+    sellerCredential: {
+      findFirst: jest.Mock;
+      update: jest.Mock;
+    };
+    auditLog: {
+      create: jest.Mock;
     };
     $transaction: jest.Mock;
   };
@@ -47,6 +61,14 @@ describe('AuthRepository', () => {
         create: jest.fn(),
         findFirst: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn(),
+      },
+      sellerCredential: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      auditLog: {
+        create: jest.fn(),
       },
       $transaction: jest.fn((callback) => callback(mockPrisma)),
     };
@@ -59,6 +81,128 @@ describe('AuthRepository', () => {
     }).compile();
 
     repository = module.get<AuthRepository>(AuthRepository);
+  });
+
+  describe('findIdentityByProviderSubject', () => {
+    it('provider + subject로 AccountIdentity를 조회해야 한다', async () => {
+      // Arrange
+      const identity = {
+        id: BigInt(1),
+        account_id: BigInt(10),
+        provider: IdentityProvider.GOOGLE,
+        provider_subject: 'google-sub-123',
+        provider_email: 'user@example.com',
+        provider_display_name: 'Test User',
+        provider_profile_image_url: 'https://example.com/photo.jpg',
+        last_login_at: new Date('2025-06-01'),
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-01'),
+        deleted_at: null,
+        account: {
+          id: BigInt(10),
+          account_type: AccountType.USER,
+          status: 'ACTIVE',
+          email: 'user@example.com',
+          name: 'Test User',
+          created_at: new Date('2025-01-01'),
+          updated_at: new Date('2025-06-01'),
+          deleted_at: null,
+          user_profile: {
+            account_id: BigInt(10),
+            nickname: 'testuser',
+            profile_image_url: 'https://example.com/photo.jpg',
+            birth_date: null,
+            phone_number: null,
+          },
+        },
+      };
+
+      mockPrisma.accountIdentity.findFirst.mockResolvedValue(identity);
+
+      // Act
+      const result = await repository.findIdentityByProviderSubject(
+        IdentityProvider.GOOGLE,
+        'google-sub-123',
+      );
+
+      // Assert
+      expect(result).toEqual(identity);
+      expect(mockPrisma.accountIdentity.findFirst).toHaveBeenCalledWith({
+        where: {
+          provider: IdentityProvider.GOOGLE,
+          provider_subject: 'google-sub-123',
+        },
+        include: {
+          account: {
+            include: {
+              user_profile: true,
+            },
+          },
+        },
+      });
+    });
+
+    it('존재하지 않는 identity는 null을 반환해야 한다', async () => {
+      // Arrange
+      mockPrisma.accountIdentity.findFirst.mockResolvedValue(null);
+
+      // Act
+      const result = await repository.findIdentityByProviderSubject(
+        IdentityProvider.KAKAO,
+        'non-existent-subject',
+      );
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findAccountByEmail', () => {
+    it('이메일로 계정을 조회해야 한다', async () => {
+      // Arrange
+      const account = {
+        id: BigInt(5),
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: 'test@example.com',
+        name: 'Test User',
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-01'),
+        deleted_at: null,
+        user_profile: {
+          account_id: BigInt(5),
+          nickname: 'testuser',
+          profile_image_url: null,
+          birth_date: null,
+          phone_number: null,
+        },
+      };
+
+      mockPrisma.account.findFirst.mockResolvedValue(account);
+
+      // Act
+      const result = await repository.findAccountByEmail('test@example.com');
+
+      // Assert
+      expect(result).toEqual(account);
+      expect(mockPrisma.account.findFirst).toHaveBeenCalledWith({
+        where: { email: 'test@example.com' },
+        include: { user_profile: true },
+      });
+    });
+
+    it('존재하지 않는 이메일은 null을 반환해야 한다', async () => {
+      // Arrange
+      mockPrisma.account.findFirst.mockResolvedValue(null);
+
+      // Act
+      const result = await repository.findAccountByEmail(
+        'nonexistent@example.com',
+      );
+
+      // Assert
+      expect(result).toBeNull();
+    });
   });
 
   describe('upsertUserByOidcIdentity', () => {
@@ -80,11 +224,31 @@ describe('AuthRepository', () => {
       };
 
       mockPrisma.accountIdentity.findFirst.mockResolvedValue(existingIdentity);
-      mockPrisma.accountIdentity.update.mockResolvedValue({});
-      mockPrisma.account.update.mockResolvedValue({});
+      mockPrisma.accountIdentity.update.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        provider: IdentityProvider.GOOGLE,
+        provider_subject: 'google-123',
+        provider_email: 'new@example.com',
+        provider_display_name: 'New Name',
+        provider_profile_image_url: 'https://example.com/photo.jpg',
+        last_login_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      } as never);
+      mockPrisma.account.update.mockResolvedValue({
+        id: BigInt(10),
+        email: 'old@example.com',
+        name: 'Old Name',
+      } as never);
       mockPrisma.account.findFirst.mockResolvedValue({
         id: BigInt(10),
-        email: 'new@example.com',
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: 'old@example.com',
+        name: 'Old Name',
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-01'),
+        deleted_at: null,
         user_profile: { nickname: 'olduser' },
       });
 
@@ -126,12 +290,35 @@ describe('AuthRepository', () => {
       };
 
       mockPrisma.accountIdentity.findFirst.mockResolvedValue(existingIdentity);
-      mockPrisma.accountIdentity.update.mockResolvedValue({});
-      mockPrisma.account.update.mockResolvedValue({});
-      mockPrisma.userProfile.create.mockResolvedValue({});
+      mockPrisma.accountIdentity.update.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        provider_email: 'test@example.com',
+        provider_display_name: 'Test User',
+        provider_profile_image_url: null,
+        last_login_at: expect.any(Date),
+        updated_at: expect.any(Date),
+      } as never);
+      mockPrisma.account.update.mockResolvedValue({
+        id: BigInt(10),
+        email: 'test@example.com',
+        name: 'Test User',
+      } as never);
+      mockPrisma.userProfile.create.mockResolvedValue({
+        account_id: BigInt(10),
+        nickname: 'Test User',
+        profile_image_url: null,
+      } as never);
       mockPrisma.account.findFirst.mockResolvedValue({
         id: BigInt(10),
-        user_profile: { nickname: 'test' },
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: 'test@example.com',
+        name: 'Test User',
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-01'),
+        deleted_at: null,
+        user_profile: { nickname: 'Test User' },
       });
 
       const args = {
@@ -159,12 +346,44 @@ describe('AuthRepository', () => {
       // Arrange
       mockPrisma.accountIdentity.findFirst.mockResolvedValue(null); // 신규
 
-      mockPrisma.accountIdentity.create.mockResolvedValue({});
-      mockPrisma.account.create.mockResolvedValue({ id: BigInt(30) } as never);
-      mockPrisma.userProfile.create.mockResolvedValue({});
+      mockPrisma.accountIdentity.create.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(30),
+        provider: IdentityProvider.GOOGLE,
+        provider_subject: 'google-new-user',
+        provider_email: 'existing@example.com',
+        provider_display_name: 'New User',
+        provider_profile_image_url: null,
+        last_login_at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      } as never);
+      mockPrisma.account.create.mockResolvedValue({
+        id: BigInt(30),
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: 'existing@example.com',
+        name: 'New User',
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      } as never);
+      mockPrisma.userProfile.create.mockResolvedValue({
+        account_id: BigInt(30),
+        nickname: 'New User',
+        profile_image_url: null,
+      } as never);
       mockPrisma.account.findFirst.mockResolvedValue({
         id: BigInt(30),
-        user_profile: { nickname: 'new' },
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: 'existing@example.com',
+        name: 'New User',
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+        user_profile: { nickname: 'New User' },
       });
 
       const args = {
@@ -210,13 +429,39 @@ describe('AuthRepository', () => {
         status: 'ACTIVE',
         email: 'new@example.com',
         name: 'New User',
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
       };
       mockPrisma.account.create.mockResolvedValue(newAccount);
-      mockPrisma.userProfile.create.mockResolvedValue({});
-      mockPrisma.accountIdentity.create.mockResolvedValue({});
+      mockPrisma.userProfile.create.mockResolvedValue({
+        account_id: BigInt(30),
+        nickname: 'New User',
+        profile_image_url: null,
+      } as never);
+      mockPrisma.accountIdentity.create.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(30),
+        provider: IdentityProvider.KAKAO,
+        provider_subject: 'kakao-new-user',
+        provider_email: 'new@example.com',
+        provider_display_name: 'New User',
+        provider_profile_image_url: null,
+        last_login_at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      } as never);
       mockPrisma.account.findFirst.mockResolvedValue({
         id: BigInt(30),
-        user_profile: { nickname: 'new' },
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: 'new@example.com',
+        name: 'New User',
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+        user_profile: { nickname: 'New User' },
       });
 
       const args = {
@@ -260,13 +505,45 @@ describe('AuthRepository', () => {
       // Arrange
       mockPrisma.accountIdentity.findFirst.mockResolvedValue(null);
 
-      const newAccount = { id: BigInt(50) };
+      const newAccount = {
+        id: BigInt(50),
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: null,
+        name: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      };
       mockPrisma.account.create.mockResolvedValue(newAccount as never);
-      mockPrisma.userProfile.create.mockResolvedValue({});
-      mockPrisma.accountIdentity.create.mockResolvedValue({});
+      mockPrisma.userProfile.create.mockResolvedValue({
+        account_id: BigInt(50),
+        nickname: 'testuser',
+        profile_image_url: null,
+      } as never);
+      mockPrisma.accountIdentity.create.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(50),
+        provider: IdentityProvider.GOOGLE,
+        provider_subject: 'google-unverified',
+        provider_email: 'test@example.com',
+        provider_display_name: null,
+        provider_profile_image_url: null,
+        last_login_at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      } as never);
       mockPrisma.account.findFirst.mockResolvedValue({
         id: BigInt(50),
-        user_profile: {},
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: null,
+        name: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+        user_profile: { nickname: 'testuser', profile_image_url: null },
       });
 
       const args = {
@@ -299,13 +576,45 @@ describe('AuthRepository', () => {
       mockPrisma.accountIdentity.findFirst.mockResolvedValue(null);
       mockPrisma.account.findFirst.mockResolvedValue(null);
 
-      const newAccount = { id: BigInt(60) };
+      const newAccount = {
+        id: BigInt(60),
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: 'testuser@example.com',
+        name: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      };
       mockPrisma.account.create.mockResolvedValue(newAccount as never);
-      mockPrisma.userProfile.create.mockResolvedValue({});
-      mockPrisma.accountIdentity.create.mockResolvedValue({});
+      mockPrisma.userProfile.create.mockResolvedValue({
+        account_id: BigInt(60),
+        nickname: 'testuser',
+        profile_image_url: null,
+      } as never);
+      mockPrisma.accountIdentity.create.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(60),
+        provider: IdentityProvider.GOOGLE,
+        provider_subject: 'google-no-name',
+        provider_email: 'testuser@example.com',
+        provider_display_name: null,
+        provider_profile_image_url: null,
+        last_login_at: new Date(),
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      } as never);
       mockPrisma.account.findFirst.mockResolvedValue({
         id: BigInt(60),
-        user_profile: {},
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
+        email: 'testuser@example.com',
+        name: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+        user_profile: { nickname: 'testuser', profile_image_url: null },
       });
 
       const args = {
@@ -341,7 +650,16 @@ describe('AuthRepository', () => {
 
       mockPrisma.authRefreshSession.create.mockResolvedValue({
         id: BigInt(100),
-        ...args,
+        account_id: BigInt(1),
+        token_hash: 'hashed-token',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2025-02-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01'),
+        deleted_at: null,
       });
 
       // Act
@@ -366,11 +684,16 @@ describe('AuthRepository', () => {
       // Arrange
       const session = {
         id: BigInt(1),
-        token_hash: 'valid-hash',
         account_id: BigInt(1),
-        deleted_at: null,
-        revoked_at: null,
+        token_hash: 'valid-hash',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
         expires_at: new Date('2030-01-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01'),
+        deleted_at: null,
       };
 
       mockPrisma.authRefreshSession.findFirst.mockResolvedValue(session);
@@ -419,10 +742,25 @@ describe('AuthRepository', () => {
         id: BigInt(2),
         account_id: BigInt(10),
         token_hash: 'new-hash',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2025-03-01'),
+        revoked_at: null,
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-15'),
+        updated_at: new Date('2025-01-15'),
+        deleted_at: null,
       };
 
       mockPrisma.authRefreshSession.create.mockResolvedValue(newSession);
-      mockPrisma.authRefreshSession.update.mockResolvedValue({});
+      mockPrisma.authRefreshSession.update.mockResolvedValue({
+        id: BigInt(1),
+        account_id: BigInt(10),
+        token_hash: 'old-hash',
+        revoked_at: expect.any(Date),
+        replaced_by_session_id: BigInt(2),
+        updated_at: expect.any(Date),
+      } as never);
 
       // Act
       const result = await repository.rotateRefreshSession(args);
@@ -443,10 +781,21 @@ describe('AuthRepository', () => {
   describe('revokeRefreshSession', () => {
     it('세션을 revoke해야 한다', async () => {
       // Arrange
-      mockPrisma.authRefreshSession.update.mockResolvedValue({
+      const revokedSession = {
         id: BigInt(1),
+        account_id: BigInt(10),
+        token_hash: 'some-hash',
+        user_agent: 'Mozilla/5.0',
+        ip_address: '127.0.0.1',
+        expires_at: new Date('2025-06-01'),
         revoked_at: new Date(),
-      });
+        replaced_by_session_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date(),
+        deleted_at: null,
+      };
+
+      mockPrisma.authRefreshSession.update.mockResolvedValue(revokedSession);
 
       // Act
       const result = await repository.revokeRefreshSession(BigInt(1));
@@ -463,14 +812,58 @@ describe('AuthRepository', () => {
     });
   });
 
+  describe('revokeAllRefreshSessions', () => {
+    it('특정 계정의 활성 세션을 모두 revoke해야 한다', async () => {
+      // Arrange
+      const now = new Date('2025-06-15T10:00:00Z');
+      mockPrisma.authRefreshSession.updateMany.mockResolvedValue({ count: 3 });
+
+      // Act
+      await repository.revokeAllRefreshSessions(BigInt(10), now);
+
+      // Assert
+      expect(mockPrisma.authRefreshSession.updateMany).toHaveBeenCalledWith({
+        where: {
+          account_id: BigInt(10),
+          revoked_at: null,
+        },
+        data: {
+          revoked_at: now,
+          updated_at: now,
+        },
+      });
+    });
+
+    it('활성 세션이 없어도 에러 없이 완료해야 한다', async () => {
+      // Arrange
+      const now = new Date('2025-06-15T10:00:00Z');
+      mockPrisma.authRefreshSession.updateMany.mockResolvedValue({ count: 0 });
+
+      // Act & Assert
+      await expect(
+        repository.revokeAllRefreshSessions(BigInt(999), now),
+      ).resolves.toBeUndefined();
+    });
+  });
+
   describe('findAccountForMe', () => {
     it('account를 profile과 함께 조회해야 한다', async () => {
       // Arrange
       const account = {
         id: BigInt(1),
+        account_type: AccountType.USER,
+        status: 'ACTIVE',
         email: 'test@example.com',
+        name: 'Test User',
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-01'),
+        deleted_at: null,
         user_profile: {
+          account_id: BigInt(1),
           nickname: 'testuser',
+          profile_image_url: 'https://example.com/photo.jpg',
+          birth_date: new Date('1990-01-01'),
+          phone_number: '010-1234-5678',
         },
       };
 
@@ -500,11 +893,12 @@ describe('AuthRepository', () => {
   });
 
   describe('findAccountForJwt', () => {
-    it('account id와 status만 조회해야 한다', async () => {
+    it('account id, status, account_type만 조회해야 한다', async () => {
       // Arrange
       const account = {
         id: BigInt(1),
         status: 'ACTIVE',
+        account_type: AccountType.USER,
       };
 
       mockPrisma.account.findFirst.mockResolvedValue(account);
@@ -517,6 +911,333 @@ describe('AuthRepository', () => {
       expect(mockPrisma.account.findFirst).toHaveBeenCalledWith({
         where: { id: BigInt(1) },
         select: { id: true, status: true, account_type: true },
+      });
+    });
+  });
+
+  describe('findSellerCredentialByUsername', () => {
+    it('username으로 판매자 자격정보를 조회해야 한다', async () => {
+      // Arrange
+      const credential = {
+        id: BigInt(1),
+        seller_account_id: BigInt(20),
+        username: 'seller01',
+        password_hash: '$argon2id$v=19$m=65536,t=3,p=4$abc123$hashed',
+        password_updated_at: new Date('2025-03-01'),
+        last_login_at: new Date('2025-06-10'),
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-10'),
+        deleted_at: null,
+        seller_account: {
+          id: BigInt(20),
+          account_type: AccountType.SELLER,
+          status: 'ACTIVE',
+          store: {
+            id: BigInt(5),
+          },
+        },
+      };
+
+      mockPrisma.sellerCredential.findFirst.mockResolvedValue(credential);
+
+      // Act
+      const result =
+        await repository.findSellerCredentialByUsername('seller01');
+
+      // Assert
+      expect(result).toEqual(credential);
+      expect(mockPrisma.sellerCredential.findFirst).toHaveBeenCalledWith({
+        where: { username: 'seller01' },
+        include: {
+          seller_account: {
+            select: {
+              id: true,
+              account_type: true,
+              status: true,
+              store: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('존재하지 않는 username은 null을 반환해야 한다', async () => {
+      // Arrange
+      mockPrisma.sellerCredential.findFirst.mockResolvedValue(null);
+
+      // Act
+      const result =
+        await repository.findSellerCredentialByUsername('nonexistent');
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findSellerCredentialByAccountId', () => {
+    it('계정 ID로 판매자 자격정보를 조회해야 한다', async () => {
+      // Arrange
+      const credential = {
+        id: BigInt(1),
+        seller_account_id: BigInt(20),
+        username: 'seller01',
+        password_hash: '$argon2id$v=19$m=65536,t=3,p=4$abc123$hashed',
+        password_updated_at: new Date('2025-03-01'),
+        last_login_at: new Date('2025-06-10'),
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-06-10'),
+        deleted_at: null,
+        seller_account: {
+          id: BigInt(20),
+          account_type: AccountType.SELLER,
+          status: 'ACTIVE',
+          store: {
+            id: BigInt(5),
+          },
+        },
+      };
+
+      mockPrisma.sellerCredential.findFirst.mockResolvedValue(credential);
+
+      // Act
+      const result = await repository.findSellerCredentialByAccountId(
+        BigInt(20),
+      );
+
+      // Assert
+      expect(result).toEqual(credential);
+      expect(mockPrisma.sellerCredential.findFirst).toHaveBeenCalledWith({
+        where: {
+          seller_account_id: BigInt(20),
+        },
+        include: {
+          seller_account: {
+            select: {
+              id: true,
+              account_type: true,
+              status: true,
+              store: {
+                select: {
+                  id: true,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('존재하지 않는 계정 ID는 null을 반환해야 한다', async () => {
+      // Arrange
+      mockPrisma.sellerCredential.findFirst.mockResolvedValue(null);
+
+      // Act
+      const result = await repository.findSellerCredentialByAccountId(
+        BigInt(999),
+      );
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateSellerLastLogin', () => {
+    it('판매자 최근 로그인 시각을 갱신해야 한다', async () => {
+      // Arrange
+      const now = new Date('2025-06-15T10:30:00Z');
+      mockPrisma.sellerCredential.update.mockResolvedValue({
+        id: BigInt(1),
+        seller_account_id: BigInt(20),
+        username: 'seller01',
+        password_hash: '$argon2id$v=19$m=65536,t=3,p=4$abc123$hashed',
+        password_updated_at: new Date('2025-03-01'),
+        last_login_at: now,
+        created_at: new Date('2025-01-01'),
+        updated_at: now,
+        deleted_at: null,
+      } as never);
+
+      // Act
+      await repository.updateSellerLastLogin(BigInt(20), now);
+
+      // Assert
+      expect(mockPrisma.sellerCredential.update).toHaveBeenCalledWith({
+        where: { seller_account_id: BigInt(20) },
+        data: {
+          last_login_at: now,
+          updated_at: now,
+        },
+      });
+    });
+  });
+
+  describe('updateSellerPasswordHash', () => {
+    it('판매자 비밀번호 해시를 갱신해야 한다', async () => {
+      // Arrange
+      const now = new Date('2025-06-15T11:00:00Z');
+      const newHash = '$argon2id$v=19$m=65536,t=3,p=4$newSalt$newHash';
+      mockPrisma.sellerCredential.update.mockResolvedValue({
+        id: BigInt(1),
+        seller_account_id: BigInt(20),
+        username: 'seller01',
+        password_hash: newHash,
+        password_updated_at: now,
+        last_login_at: new Date('2025-06-15T10:30:00Z'),
+        created_at: new Date('2025-01-01'),
+        updated_at: now,
+        deleted_at: null,
+      } as never);
+
+      // Act
+      await repository.updateSellerPasswordHash({
+        sellerAccountId: BigInt(20),
+        passwordHash: newHash,
+        now,
+      });
+
+      // Assert
+      expect(mockPrisma.sellerCredential.update).toHaveBeenCalledWith({
+        where: { seller_account_id: BigInt(20) },
+        data: {
+          password_hash: newHash,
+          password_updated_at: now,
+          updated_at: now,
+        },
+      });
+    });
+  });
+
+  describe('createAuditLog', () => {
+    it('감사 로그를 생성해야 한다', async () => {
+      // Arrange
+      const args = {
+        actorAccountId: BigInt(20),
+        storeId: BigInt(5),
+        targetType: AuditTargetType.CHANGE_PASSWORD,
+        targetId: BigInt(20),
+        action: AuditActionType.UPDATE,
+        beforeJson: null,
+        afterJson: { changedAt: '2025-06-15T11:00:00.000Z' },
+        ipAddress: '192.168.0.1',
+        userAgent: 'Mozilla/5.0',
+      };
+
+      mockPrisma.auditLog.create.mockResolvedValue({
+        id: BigInt(100),
+        actor_account_id: BigInt(20),
+        store_id: BigInt(5),
+        target_type: AuditTargetType.CHANGE_PASSWORD,
+        target_id: BigInt(20),
+        action: AuditActionType.UPDATE,
+        before_json: null,
+        after_json: { changedAt: '2025-06-15T11:00:00.000Z' },
+        ip_address: '192.168.0.1',
+        user_agent: 'Mozilla/5.0',
+        created_at: new Date('2025-06-15'),
+      } as never);
+
+      // Act
+      await repository.createAuditLog(args);
+
+      // Assert
+      expect(mockPrisma.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          actor_account_id: BigInt(20),
+          store_id: BigInt(5),
+          target_type: AuditTargetType.CHANGE_PASSWORD,
+          target_id: BigInt(20),
+          action: AuditActionType.UPDATE,
+          before_json: Prisma.JsonNull,
+          after_json: { changedAt: '2025-06-15T11:00:00.000Z' },
+          ip_address: '192.168.0.1',
+          user_agent: 'Mozilla/5.0',
+        },
+      });
+    });
+
+    it('선택 필드가 없으면 null로 저장해야 한다', async () => {
+      // Arrange
+      const args = {
+        actorAccountId: BigInt(20),
+        targetType: AuditTargetType.CHANGE_PASSWORD,
+        targetId: BigInt(20),
+        action: AuditActionType.UPDATE,
+      };
+
+      mockPrisma.auditLog.create.mockResolvedValue({
+        id: BigInt(101),
+        actor_account_id: BigInt(20),
+        store_id: null,
+        target_type: AuditTargetType.CHANGE_PASSWORD,
+        target_id: BigInt(20),
+        action: AuditActionType.UPDATE,
+        before_json: null,
+        after_json: null,
+        ip_address: null,
+        user_agent: null,
+        created_at: new Date('2025-06-15'),
+      } as never);
+
+      // Act
+      await repository.createAuditLog(args);
+
+      // Assert
+      expect(mockPrisma.auditLog.create).toHaveBeenCalledWith({
+        data: {
+          actor_account_id: BigInt(20),
+          store_id: null,
+          target_type: AuditTargetType.CHANGE_PASSWORD,
+          target_id: BigInt(20),
+          action: AuditActionType.UPDATE,
+          before_json: undefined,
+          after_json: undefined,
+          ip_address: null,
+          user_agent: null,
+        },
+      });
+    });
+
+    it('beforeJson과 afterJson이 명시적 null이면 Prisma.JsonNull로 변환해야 한다', async () => {
+      // Arrange
+      const args = {
+        actorAccountId: BigInt(20),
+        storeId: null,
+        targetType: AuditTargetType.CHANGE_PASSWORD,
+        targetId: BigInt(20),
+        action: AuditActionType.UPDATE,
+        beforeJson: null,
+        afterJson: null,
+        ipAddress: '10.0.0.1',
+        userAgent: 'TestAgent/1.0',
+      };
+
+      mockPrisma.auditLog.create.mockResolvedValue({
+        id: BigInt(102),
+        actor_account_id: BigInt(20),
+        store_id: null,
+        target_type: AuditTargetType.CHANGE_PASSWORD,
+        target_id: BigInt(20),
+        action: AuditActionType.UPDATE,
+        before_json: null,
+        after_json: null,
+        ip_address: '10.0.0.1',
+        user_agent: 'TestAgent/1.0',
+        created_at: new Date('2025-06-15'),
+      } as never);
+
+      // Act
+      await repository.createAuditLog(args);
+
+      // Assert
+      expect(mockPrisma.auditLog.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          before_json: Prisma.JsonNull,
+          after_json: Prisma.JsonNull,
+        }),
       });
     });
   });

--- a/src/features/seller/resolvers/seller.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller.resolver.spec.ts
@@ -162,7 +162,7 @@ describe('SellerResolvers', () => {
     describe('sellerProducts', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
         const input = { limit: 10 };
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         productService.sellerProducts.mockResolvedValue(expected as never);
 
         const result = await productQueryResolver.sellerProducts(user, input);
@@ -175,7 +175,7 @@ describe('SellerResolvers', () => {
       });
 
       it('input 없이 호출할 수 있어야 한다', async () => {
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         productService.sellerProducts.mockResolvedValue(expected as never);
 
         await productQueryResolver.sellerProducts(user);
@@ -724,7 +724,7 @@ describe('SellerResolvers', () => {
     describe('sellerBanners', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
         const input = { limit: 5 };
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         contentService.sellerBanners.mockResolvedValue(expected as never);
 
         const result = await contentQueryResolver.sellerBanners(user, input);
@@ -737,7 +737,7 @@ describe('SellerResolvers', () => {
       });
 
       it('input 없이 호출할 수 있어야 한다', async () => {
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         contentService.sellerBanners.mockResolvedValue(expected as never);
 
         await contentQueryResolver.sellerBanners(user);
@@ -752,7 +752,7 @@ describe('SellerResolvers', () => {
     describe('sellerAuditLogs', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
         const input = { limit: 20 };
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         contentService.sellerAuditLogs.mockResolvedValue(expected as never);
 
         const result = await contentQueryResolver.sellerAuditLogs(user, input);
@@ -765,7 +765,7 @@ describe('SellerResolvers', () => {
       });
 
       it('input 없이 호출할 수 있어야 한다', async () => {
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         contentService.sellerAuditLogs.mockResolvedValue(expected as never);
 
         await contentQueryResolver.sellerAuditLogs(user);
@@ -952,7 +952,7 @@ describe('SellerResolvers', () => {
     describe('sellerStoreSpecialClosures', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
         const input = { limit: 10 };
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         storeService.sellerStoreSpecialClosures.mockResolvedValue(
           expected as never,
         );
@@ -970,7 +970,7 @@ describe('SellerResolvers', () => {
       });
 
       it('input 없이 호출할 수 있어야 한다', async () => {
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         storeService.sellerStoreSpecialClosures.mockResolvedValue(
           expected as never,
         );
@@ -987,7 +987,7 @@ describe('SellerResolvers', () => {
     describe('sellerStoreDailyCapacities', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
         const input = { limit: 10 };
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         storeService.sellerStoreDailyCapacities.mockResolvedValue(
           expected as never,
         );
@@ -1005,7 +1005,7 @@ describe('SellerResolvers', () => {
       });
 
       it('input 없이 호출할 수 있어야 한다', async () => {
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         storeService.sellerStoreDailyCapacities.mockResolvedValue(
           expected as never,
         );
@@ -1186,7 +1186,7 @@ describe('SellerResolvers', () => {
     describe('sellerConversations', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
         const input = { limit: 10 };
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         conversationService.sellerConversations.mockResolvedValue(
           expected as never,
         );
@@ -1204,7 +1204,7 @@ describe('SellerResolvers', () => {
       });
 
       it('input 없이 호출할 수 있어야 한다', async () => {
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         conversationService.sellerConversations.mockResolvedValue(
           expected as never,
         );
@@ -1231,7 +1231,7 @@ describe('SellerResolvers', () => {
     describe('sellerConversationMessages', () => {
       it('conversationId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
         const input = { limit: 20 };
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         conversationService.sellerConversationMessages.mockResolvedValue(
           expected as never,
         );
@@ -1250,7 +1250,7 @@ describe('SellerResolvers', () => {
       });
 
       it('input 없이 호출할 수 있어야 한다', async () => {
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         conversationService.sellerConversationMessages.mockResolvedValue(
           expected as never,
         );
@@ -1310,7 +1310,7 @@ describe('SellerResolvers', () => {
     describe('sellerOrderList', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
         const input = { limit: 10 };
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         orderService.sellerOrderList.mockResolvedValue(expected as never);
 
         const result = await orderQueryResolver.sellerOrderList(user, input);
@@ -1323,7 +1323,7 @@ describe('SellerResolvers', () => {
       });
 
       it('input 없이 호출할 수 있어야 한다', async () => {
-        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        const expected = { items: [], nextCursor: null };
         orderService.sellerOrderList.mockResolvedValue(expected as never);
 
         await orderQueryResolver.sellerOrderList(user);

--- a/src/features/seller/resolvers/seller.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller.resolver.spec.ts
@@ -161,7 +161,7 @@ describe('SellerResolvers', () => {
   describe('SellerProductQueryResolver', () => {
     describe('sellerProducts', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-        const input = { first: 10 };
+        const input = { limit: 10 };
         const expected = { edges: [], pageInfo: { hasNextPage: false } };
         productService.sellerProducts.mockResolvedValue(expected as never);
 
@@ -723,7 +723,7 @@ describe('SellerResolvers', () => {
 
     describe('sellerBanners', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-        const input = { first: 5 };
+        const input = { limit: 5 };
         const expected = { edges: [], pageInfo: { hasNextPage: false } };
         contentService.sellerBanners.mockResolvedValue(expected as never);
 
@@ -751,7 +751,7 @@ describe('SellerResolvers', () => {
 
     describe('sellerAuditLogs', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-        const input = { first: 20 };
+        const input = { limit: 20 };
         const expected = { edges: [], pageInfo: { hasNextPage: false } };
         contentService.sellerAuditLogs.mockResolvedValue(expected as never);
 
@@ -951,7 +951,7 @@ describe('SellerResolvers', () => {
 
     describe('sellerStoreSpecialClosures', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-        const input = { first: 10 };
+        const input = { limit: 10 };
         const expected = { edges: [], pageInfo: { hasNextPage: false } };
         storeService.sellerStoreSpecialClosures.mockResolvedValue(
           expected as never,
@@ -986,7 +986,7 @@ describe('SellerResolvers', () => {
 
     describe('sellerStoreDailyCapacities', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-        const input = { first: 10 };
+        const input = { limit: 10 };
         const expected = { edges: [], pageInfo: { hasNextPage: false } };
         storeService.sellerStoreDailyCapacities.mockResolvedValue(
           expected as never,
@@ -1185,7 +1185,7 @@ describe('SellerResolvers', () => {
   describe('SellerConversationQueryResolver', () => {
     describe('sellerConversations', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-        const input = { first: 10 };
+        const input = { limit: 10 };
         const expected = { edges: [], pageInfo: { hasNextPage: false } };
         conversationService.sellerConversations.mockResolvedValue(
           expected as never,
@@ -1230,7 +1230,7 @@ describe('SellerResolvers', () => {
 
     describe('sellerConversationMessages', () => {
       it('conversationId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-        const input = { first: 20 };
+        const input = { limit: 20 };
         const expected = { edges: [], pageInfo: { hasNextPage: false } };
         conversationService.sellerConversationMessages.mockResolvedValue(
           expected as never,
@@ -1309,7 +1309,7 @@ describe('SellerResolvers', () => {
   describe('SellerOrderQueryResolver', () => {
     describe('sellerOrderList', () => {
       it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-        const input = { first: 10 };
+        const input = { limit: 10 };
         const expected = { edges: [], pageInfo: { hasNextPage: false } };
         orderService.sellerOrderList.mockResolvedValue(expected as never);
 

--- a/src/features/seller/resolvers/seller.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller.resolver.spec.ts
@@ -1,84 +1,1412 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { SellerContentMutationResolver } from '@/features/seller/resolvers/seller-content-mutation.resolver';
+import { SellerContentQueryResolver } from '@/features/seller/resolvers/seller-content-query.resolver';
+import { SellerConversationMutationResolver } from '@/features/seller/resolvers/seller-conversation-mutation.resolver';
+import { SellerConversationQueryResolver } from '@/features/seller/resolvers/seller-conversation-query.resolver';
+import { SellerOrderMutationResolver } from '@/features/seller/resolvers/seller-order-mutation.resolver';
+import { SellerOrderQueryResolver } from '@/features/seller/resolvers/seller-order-query.resolver';
 import { SellerProductMutationResolver } from '@/features/seller/resolvers/seller-product-mutation.resolver';
 import { SellerProductQueryResolver } from '@/features/seller/resolvers/seller-product-query.resolver';
+import { SellerStoreMutationResolver } from '@/features/seller/resolvers/seller-store-mutation.resolver';
+import { SellerStoreQueryResolver } from '@/features/seller/resolvers/seller-store-query.resolver';
 import { SellerContentService } from '@/features/seller/services/seller-content.service';
+import { SellerConversationService } from '@/features/seller/services/seller-conversation.service';
 import { SellerCustomTemplateService } from '@/features/seller/services/seller-custom-template.service';
 import { SellerOptionService } from '@/features/seller/services/seller-option.service';
+import { SellerOrderService } from '@/features/seller/services/seller-order.service';
 import { SellerProductCrudService } from '@/features/seller/services/seller-product-crud.service';
+import { SellerStoreService } from '@/features/seller/services/seller-store.service';
+
+// ---------- 공통 헬퍼 ----------
+
+const user = { accountId: '11' };
 
 describe('SellerResolvers', () => {
-  let queryResolver: SellerProductQueryResolver;
-  let mutationResolver: SellerContentMutationResolver;
+  // ── Resolvers ──
+  let productQueryResolver: SellerProductQueryResolver;
+  let productMutationResolver: SellerProductMutationResolver;
+  let contentQueryResolver: SellerContentQueryResolver;
+  let contentMutationResolver: SellerContentMutationResolver;
+  let storeQueryResolver: SellerStoreQueryResolver;
+  let storeMutationResolver: SellerStoreMutationResolver;
+  let conversationQueryResolver: SellerConversationQueryResolver;
+  let conversationMutationResolver: SellerConversationMutationResolver;
+  let orderQueryResolver: SellerOrderQueryResolver;
+  let orderMutationResolver: SellerOrderMutationResolver;
+
+  // ── Services (mocked) ──
   let productService: jest.Mocked<SellerProductCrudService>;
-  let contentService: jest.Mocked<SellerContentService>;
   let optionService: jest.Mocked<SellerOptionService>;
   let templateService: jest.Mocked<SellerCustomTemplateService>;
+  let contentService: jest.Mocked<SellerContentService>;
+  let storeService: jest.Mocked<SellerStoreService>;
+  let conversationService: jest.Mocked<SellerConversationService>;
+  let orderService: jest.Mocked<SellerOrderService>;
 
   beforeEach(async () => {
     productService = {
+      sellerProducts: jest.fn(),
       sellerProduct: jest.fn(),
+      sellerCreateProduct: jest.fn(),
+      sellerUpdateProduct: jest.fn(),
+      sellerDeleteProduct: jest.fn(),
+      sellerSetProductActive: jest.fn(),
+      sellerAddProductImage: jest.fn(),
+      sellerDeleteProductImage: jest.fn(),
+      sellerReorderProductImages: jest.fn(),
+      sellerSetProductCategories: jest.fn(),
+      sellerSetProductTags: jest.fn(),
     } as unknown as jest.Mocked<SellerProductCrudService>;
 
+    optionService = {
+      sellerCreateOptionGroup: jest.fn(),
+      sellerUpdateOptionGroup: jest.fn(),
+      sellerDeleteOptionGroup: jest.fn(),
+      sellerReorderOptionGroups: jest.fn(),
+      sellerCreateOptionItem: jest.fn(),
+      sellerUpdateOptionItem: jest.fn(),
+      sellerDeleteOptionItem: jest.fn(),
+      sellerReorderOptionItems: jest.fn(),
+    } as unknown as jest.Mocked<SellerOptionService>;
+
+    templateService = {
+      sellerUpsertProductCustomTemplate: jest.fn(),
+      sellerSetProductCustomTemplateActive: jest.fn(),
+      sellerUpsertProductCustomTextToken: jest.fn(),
+      sellerDeleteProductCustomTextToken: jest.fn(),
+      sellerReorderProductCustomTextTokens: jest.fn(),
+    } as unknown as jest.Mocked<SellerCustomTemplateService>;
+
     contentService = {
+      sellerFaqTopics: jest.fn(),
+      sellerCreateFaqTopic: jest.fn(),
+      sellerUpdateFaqTopic: jest.fn(),
+      sellerDeleteFaqTopic: jest.fn(),
+      sellerBanners: jest.fn(),
+      sellerCreateBanner: jest.fn(),
+      sellerUpdateBanner: jest.fn(),
       sellerDeleteBanner: jest.fn(),
+      sellerAuditLogs: jest.fn(),
     } as unknown as jest.Mocked<SellerContentService>;
 
-    optionService = {} as unknown as jest.Mocked<SellerOptionService>;
-    templateService = {} as unknown as jest.Mocked<SellerCustomTemplateService>;
+    storeService = {
+      sellerMyStore: jest.fn(),
+      sellerStoreBusinessHours: jest.fn(),
+      sellerStoreSpecialClosures: jest.fn(),
+      sellerStoreDailyCapacities: jest.fn(),
+      sellerUpdateStoreBasicInfo: jest.fn(),
+      sellerUpsertStoreBusinessHour: jest.fn(),
+      sellerUpsertStoreSpecialClosure: jest.fn(),
+      sellerDeleteStoreSpecialClosure: jest.fn(),
+      sellerUpdatePickupPolicy: jest.fn(),
+      sellerUpsertStoreDailyCapacity: jest.fn(),
+      sellerDeleteStoreDailyCapacity: jest.fn(),
+    } as unknown as jest.Mocked<SellerStoreService>;
+
+    conversationService = {
+      sellerConversations: jest.fn(),
+      sellerConversationMessages: jest.fn(),
+      sellerSendConversationMessage: jest.fn(),
+    } as unknown as jest.Mocked<SellerConversationService>;
+
+    orderService = {
+      sellerOrderList: jest.fn(),
+      sellerOrder: jest.fn(),
+      sellerUpdateOrderStatus: jest.fn(),
+    } as unknown as jest.Mocked<SellerOrderService>;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        // Resolvers
         SellerProductQueryResolver,
         SellerProductMutationResolver,
+        SellerContentQueryResolver,
         SellerContentMutationResolver,
-        {
-          provide: SellerProductCrudService,
-          useValue: productService,
-        },
-        {
-          provide: SellerContentService,
-          useValue: contentService,
-        },
-        {
-          provide: SellerOptionService,
-          useValue: optionService,
-        },
-        {
-          provide: SellerCustomTemplateService,
-          useValue: templateService,
-        },
+        SellerStoreQueryResolver,
+        SellerStoreMutationResolver,
+        SellerConversationQueryResolver,
+        SellerConversationMutationResolver,
+        SellerOrderQueryResolver,
+        SellerOrderMutationResolver,
+        // Services
+        { provide: SellerProductCrudService, useValue: productService },
+        { provide: SellerOptionService, useValue: optionService },
+        { provide: SellerCustomTemplateService, useValue: templateService },
+        { provide: SellerContentService, useValue: contentService },
+        { provide: SellerStoreService, useValue: storeService },
+        { provide: SellerConversationService, useValue: conversationService },
+        { provide: SellerOrderService, useValue: orderService },
       ],
     }).compile();
 
-    queryResolver = module.get<SellerProductQueryResolver>(
-      SellerProductQueryResolver,
+    productQueryResolver = module.get(SellerProductQueryResolver);
+    productMutationResolver = module.get(SellerProductMutationResolver);
+    contentQueryResolver = module.get(SellerContentQueryResolver);
+    contentMutationResolver = module.get(SellerContentMutationResolver);
+    storeQueryResolver = module.get(SellerStoreQueryResolver);
+    storeMutationResolver = module.get(SellerStoreMutationResolver);
+    conversationQueryResolver = module.get(SellerConversationQueryResolver);
+    conversationMutationResolver = module.get(
+      SellerConversationMutationResolver,
     );
-    mutationResolver = module.get<SellerContentMutationResolver>(
-      SellerContentMutationResolver,
-    );
+    orderQueryResolver = module.get(SellerOrderQueryResolver);
+    orderMutationResolver = module.get(SellerOrderMutationResolver);
   });
 
-  it('sellerProduct는 productId를 BigInt로 전달해야 한다', async () => {
-    const user = { accountId: '11' };
+  // ================================================================
+  // SellerProductQueryResolver
+  // ================================================================
+  describe('SellerProductQueryResolver', () => {
+    describe('sellerProducts', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { first: 10 };
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        productService.sellerProducts.mockResolvedValue(expected as never);
 
-    await queryResolver.sellerProduct(user, '123');
+        const result = await productQueryResolver.sellerProducts(user, input);
 
-    expect(productService.sellerProduct).toHaveBeenCalledWith(
-      BigInt(11),
-      BigInt(123),
-    );
+        expect(productService.sellerProducts).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('input 없이 호출할 수 있어야 한다', async () => {
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        productService.sellerProducts.mockResolvedValue(expected as never);
+
+        await productQueryResolver.sellerProducts(user);
+
+        expect(productService.sellerProducts).toHaveBeenCalledWith(
+          BigInt(11),
+          undefined,
+        );
+      });
+    });
+
+    describe('sellerProduct', () => {
+      it('productId를 BigInt로 전달해야 한다', async () => {
+        const expected = { id: '123', name: 'test' };
+        productService.sellerProduct.mockResolvedValue(expected as never);
+
+        const result = await productQueryResolver.sellerProduct(user, '123');
+
+        expect(productService.sellerProduct).toHaveBeenCalledWith(
+          BigInt(11),
+          BigInt(123),
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        productService.sellerProduct.mockRejectedValue(
+          new NotFoundException('상품을 찾을 수 없습니다'),
+        );
+
+        await expect(
+          productQueryResolver.sellerProduct(user, '999'),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
   });
 
-  it('sellerDeleteBanner는 bannerId를 BigInt로 전달해야 한다', async () => {
-    const user = { accountId: '11' };
+  // ================================================================
+  // SellerProductMutationResolver
+  // ================================================================
+  describe('SellerProductMutationResolver', () => {
+    describe('sellerCreateProduct', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { name: '새 상품' };
+        const expected = { id: '1', name: '새 상품' };
+        productService.sellerCreateProduct.mockResolvedValue(expected as never);
 
-    await mutationResolver.sellerDeleteBanner(user, '77');
+        const result = await productMutationResolver.sellerCreateProduct(
+          user,
+          input as never,
+        );
 
-    expect(contentService.sellerDeleteBanner).toHaveBeenCalledWith(
-      BigInt(11),
-      BigInt(77),
-    );
+        expect(productService.sellerCreateProduct).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpdateProduct', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { productId: '10', name: '수정 상품' };
+        const expected = { id: '10', name: '수정 상품' };
+        productService.sellerUpdateProduct.mockResolvedValue(expected as never);
+
+        const result = await productMutationResolver.sellerUpdateProduct(
+          user,
+          input as never,
+        );
+
+        expect(productService.sellerUpdateProduct).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteProduct', () => {
+      it('productId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        productService.sellerDeleteProduct.mockResolvedValue(true);
+
+        const result = await productMutationResolver.sellerDeleteProduct(
+          user,
+          '55',
+        );
+
+        expect(productService.sellerDeleteProduct).toHaveBeenCalledWith(
+          BigInt(11),
+          BigInt(55),
+        );
+        expect(result).toBe(true);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        productService.sellerDeleteProduct.mockRejectedValue(
+          new ForbiddenException('권한이 없습니다'),
+        );
+
+        await expect(
+          productMutationResolver.sellerDeleteProduct(user, '55'),
+        ).rejects.toThrow(ForbiddenException);
+      });
+    });
+
+    describe('sellerSetProductActive', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { productId: '10', active: true };
+        const expected = { id: '10', active: true };
+        productService.sellerSetProductActive.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerSetProductActive(
+          user,
+          input as never,
+        );
+
+        expect(productService.sellerSetProductActive).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerAddProductImage', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { productId: '10', url: 'https://img.test/1.jpg' };
+        const expected = { id: '1', url: 'https://img.test/1.jpg' };
+        productService.sellerAddProductImage.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerAddProductImage(
+          user,
+          input as never,
+        );
+
+        expect(productService.sellerAddProductImage).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteProductImage', () => {
+      it('imageId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        productService.sellerDeleteProductImage.mockResolvedValue(true);
+
+        const result = await productMutationResolver.sellerDeleteProductImage(
+          user,
+          '88',
+        );
+
+        expect(productService.sellerDeleteProductImage).toHaveBeenCalledWith(
+          BigInt(11),
+          BigInt(88),
+        );
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('sellerReorderProductImages', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { productId: '10', imageIds: ['1', '2', '3'] };
+        const expected = [{ id: '1' }, { id: '2' }, { id: '3' }];
+        productService.sellerReorderProductImages.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerReorderProductImages(
+          user,
+          input as never,
+        );
+
+        expect(productService.sellerReorderProductImages).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerSetProductCategories', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { productId: '10', categoryIds: ['1', '2'] };
+        const expected = { id: '10' };
+        productService.sellerSetProductCategories.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerSetProductCategories(
+          user,
+          input as never,
+        );
+
+        expect(productService.sellerSetProductCategories).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerSetProductTags', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { productId: '10', tags: ['태그1', '태그2'] };
+        const expected = { id: '10' };
+        productService.sellerSetProductTags.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerSetProductTags(
+          user,
+          input as never,
+        );
+
+        expect(productService.sellerSetProductTags).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    // ── OptionService 위임 메서드 ──
+
+    describe('sellerCreateOptionGroup', () => {
+      it('accountId를 BigInt로 변환하여 optionService에 전달해야 한다', async () => {
+        const input = { productId: '10', name: '사이즈' };
+        const expected = { id: '1', name: '사이즈' };
+        optionService.sellerCreateOptionGroup.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerCreateOptionGroup(
+          user,
+          input as never,
+        );
+
+        expect(optionService.sellerCreateOptionGroup).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpdateOptionGroup', () => {
+      it('accountId를 BigInt로 변환하여 optionService에 전달해야 한다', async () => {
+        const input = { optionGroupId: '5', name: '색상' };
+        const expected = { id: '5', name: '색상' };
+        optionService.sellerUpdateOptionGroup.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerUpdateOptionGroup(
+          user,
+          input as never,
+        );
+
+        expect(optionService.sellerUpdateOptionGroup).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteOptionGroup', () => {
+      it('optionGroupId를 BigInt로 변환하여 optionService에 전달해야 한다', async () => {
+        optionService.sellerDeleteOptionGroup.mockResolvedValue(true);
+
+        const result = await productMutationResolver.sellerDeleteOptionGroup(
+          user,
+          '33',
+        );
+
+        expect(optionService.sellerDeleteOptionGroup).toHaveBeenCalledWith(
+          BigInt(11),
+          BigInt(33),
+        );
+        expect(result).toBe(true);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        optionService.sellerDeleteOptionGroup.mockRejectedValue(
+          new NotFoundException('옵션 그룹을 찾을 수 없습니다'),
+        );
+
+        await expect(
+          productMutationResolver.sellerDeleteOptionGroup(user, '33'),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    describe('sellerReorderOptionGroups', () => {
+      it('accountId를 BigInt로 변환하여 optionService에 전달해야 한다', async () => {
+        const input = { productId: '10', optionGroupIds: ['1', '2'] };
+        const expected = [{ id: '1' }, { id: '2' }];
+        optionService.sellerReorderOptionGroups.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerReorderOptionGroups(
+          user,
+          input as never,
+        );
+
+        expect(optionService.sellerReorderOptionGroups).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerCreateOptionItem', () => {
+      it('accountId를 BigInt로 변환하여 optionService에 전달해야 한다', async () => {
+        const input = { optionGroupId: '5', name: 'L' };
+        const expected = { id: '1', name: 'L' };
+        optionService.sellerCreateOptionItem.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerCreateOptionItem(
+          user,
+          input as never,
+        );
+
+        expect(optionService.sellerCreateOptionItem).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpdateOptionItem', () => {
+      it('accountId를 BigInt로 변환하여 optionService에 전달해야 한다', async () => {
+        const input = { optionItemId: '7', name: 'XL' };
+        const expected = { id: '7', name: 'XL' };
+        optionService.sellerUpdateOptionItem.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerUpdateOptionItem(
+          user,
+          input as never,
+        );
+
+        expect(optionService.sellerUpdateOptionItem).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteOptionItem', () => {
+      it('optionItemId를 BigInt로 변환하여 optionService에 전달해야 한다', async () => {
+        optionService.sellerDeleteOptionItem.mockResolvedValue(true);
+
+        const result = await productMutationResolver.sellerDeleteOptionItem(
+          user,
+          '44',
+        );
+
+        expect(optionService.sellerDeleteOptionItem).toHaveBeenCalledWith(
+          BigInt(11),
+          BigInt(44),
+        );
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('sellerReorderOptionItems', () => {
+      it('accountId를 BigInt로 변환하여 optionService에 전달해야 한다', async () => {
+        const input = { optionGroupId: '5', optionItemIds: ['1', '2'] };
+        const expected = [{ id: '1' }, { id: '2' }];
+        optionService.sellerReorderOptionItems.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await productMutationResolver.sellerReorderOptionItems(
+          user,
+          input as never,
+        );
+
+        expect(optionService.sellerReorderOptionItems).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    // ── TemplateService 위임 메서드 ──
+
+    describe('sellerUpsertProductCustomTemplate', () => {
+      it('accountId를 BigInt로 변환하여 templateService에 전달해야 한다', async () => {
+        const input = { productId: '10', body: '<div>template</div>' };
+        const expected = { id: '1', body: '<div>template</div>' };
+        templateService.sellerUpsertProductCustomTemplate.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await productMutationResolver.sellerUpsertProductCustomTemplate(
+            user,
+            input as never,
+          );
+
+        expect(
+          templateService.sellerUpsertProductCustomTemplate,
+        ).toHaveBeenCalledWith(BigInt(11), input);
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerSetProductCustomTemplateActive', () => {
+      it('accountId를 BigInt로 변환하여 templateService에 전달해야 한다', async () => {
+        const input = { productId: '10', active: true };
+        const expected = { id: '1', active: true };
+        templateService.sellerSetProductCustomTemplateActive.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await productMutationResolver.sellerSetProductCustomTemplateActive(
+            user,
+            input as never,
+          );
+
+        expect(
+          templateService.sellerSetProductCustomTemplateActive,
+        ).toHaveBeenCalledWith(BigInt(11), input);
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpsertProductCustomTextToken', () => {
+      it('accountId를 BigInt로 변환하여 templateService에 전달해야 한다', async () => {
+        const input = { productId: '10', key: 'NAME', value: '테스트' };
+        const expected = { id: '1', key: 'NAME', value: '테스트' };
+        templateService.sellerUpsertProductCustomTextToken.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await productMutationResolver.sellerUpsertProductCustomTextToken(
+            user,
+            input as never,
+          );
+
+        expect(
+          templateService.sellerUpsertProductCustomTextToken,
+        ).toHaveBeenCalledWith(BigInt(11), input);
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteProductCustomTextToken', () => {
+      it('tokenId를 BigInt로 변환하여 templateService에 전달해야 한다', async () => {
+        templateService.sellerDeleteProductCustomTextToken.mockResolvedValue(
+          true,
+        );
+
+        const result =
+          await productMutationResolver.sellerDeleteProductCustomTextToken(
+            user,
+            '99',
+          );
+
+        expect(
+          templateService.sellerDeleteProductCustomTextToken,
+        ).toHaveBeenCalledWith(BigInt(11), BigInt(99));
+        expect(result).toBe(true);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        templateService.sellerDeleteProductCustomTextToken.mockRejectedValue(
+          new NotFoundException('토큰을 찾을 수 없습니다'),
+        );
+
+        await expect(
+          productMutationResolver.sellerDeleteProductCustomTextToken(
+            user,
+            '99',
+          ),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    describe('sellerReorderProductCustomTextTokens', () => {
+      it('accountId를 BigInt로 변환하여 templateService에 전달해야 한다', async () => {
+        const input = { productId: '10', tokenIds: ['1', '2'] };
+        const expected = [{ id: '1' }, { id: '2' }];
+        templateService.sellerReorderProductCustomTextTokens.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await productMutationResolver.sellerReorderProductCustomTextTokens(
+            user,
+            input as never,
+          );
+
+        expect(
+          templateService.sellerReorderProductCustomTextTokens,
+        ).toHaveBeenCalledWith(BigInt(11), input);
+        expect(result).toBe(expected);
+      });
+    });
+  });
+
+  // ================================================================
+  // SellerContentQueryResolver
+  // ================================================================
+  describe('SellerContentQueryResolver', () => {
+    describe('sellerFaqTopics', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const expected = [{ id: '1', title: 'FAQ' }];
+        contentService.sellerFaqTopics.mockResolvedValue(expected as never);
+
+        const result = await contentQueryResolver.sellerFaqTopics(user);
+
+        expect(contentService.sellerFaqTopics).toHaveBeenCalledWith(BigInt(11));
+        expect(result).toBe(expected);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        contentService.sellerFaqTopics.mockRejectedValue(
+          new ForbiddenException('접근 권한이 없습니다'),
+        );
+
+        await expect(
+          contentQueryResolver.sellerFaqTopics(user),
+        ).rejects.toThrow(ForbiddenException);
+      });
+    });
+
+    describe('sellerBanners', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { first: 5 };
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        contentService.sellerBanners.mockResolvedValue(expected as never);
+
+        const result = await contentQueryResolver.sellerBanners(user, input);
+
+        expect(contentService.sellerBanners).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('input 없이 호출할 수 있어야 한다', async () => {
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        contentService.sellerBanners.mockResolvedValue(expected as never);
+
+        await contentQueryResolver.sellerBanners(user);
+
+        expect(contentService.sellerBanners).toHaveBeenCalledWith(
+          BigInt(11),
+          undefined,
+        );
+      });
+    });
+
+    describe('sellerAuditLogs', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { first: 20 };
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        contentService.sellerAuditLogs.mockResolvedValue(expected as never);
+
+        const result = await contentQueryResolver.sellerAuditLogs(user, input);
+
+        expect(contentService.sellerAuditLogs).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('input 없이 호출할 수 있어야 한다', async () => {
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        contentService.sellerAuditLogs.mockResolvedValue(expected as never);
+
+        await contentQueryResolver.sellerAuditLogs(user);
+
+        expect(contentService.sellerAuditLogs).toHaveBeenCalledWith(
+          BigInt(11),
+          undefined,
+        );
+      });
+    });
+  });
+
+  // ================================================================
+  // SellerContentMutationResolver
+  // ================================================================
+  describe('SellerContentMutationResolver', () => {
+    describe('sellerCreateFaqTopic', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { title: '새 FAQ 주제' };
+        const expected = { id: '1', title: '새 FAQ 주제' };
+        contentService.sellerCreateFaqTopic.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await contentMutationResolver.sellerCreateFaqTopic(
+          user,
+          input as never,
+        );
+
+        expect(contentService.sellerCreateFaqTopic).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpdateFaqTopic', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { topicId: '3', title: '수정 FAQ' };
+        const expected = { id: '3', title: '수정 FAQ' };
+        contentService.sellerUpdateFaqTopic.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await contentMutationResolver.sellerUpdateFaqTopic(
+          user,
+          input as never,
+        );
+
+        expect(contentService.sellerUpdateFaqTopic).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteFaqTopic', () => {
+      it('topicId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        contentService.sellerDeleteFaqTopic.mockResolvedValue(true);
+
+        const result = await contentMutationResolver.sellerDeleteFaqTopic(
+          user,
+          '66',
+        );
+
+        expect(contentService.sellerDeleteFaqTopic).toHaveBeenCalledWith(
+          BigInt(11),
+          BigInt(66),
+        );
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('sellerCreateBanner', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { title: '새 배너', imageUrl: 'https://img.test/b.jpg' };
+        const expected = { id: '1', title: '새 배너' };
+        contentService.sellerCreateBanner.mockResolvedValue(expected as never);
+
+        const result = await contentMutationResolver.sellerCreateBanner(
+          user,
+          input as never,
+        );
+
+        expect(contentService.sellerCreateBanner).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpdateBanner', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { bannerId: '5', title: '수정 배너' };
+        const expected = { id: '5', title: '수정 배너' };
+        contentService.sellerUpdateBanner.mockResolvedValue(expected as never);
+
+        const result = await contentMutationResolver.sellerUpdateBanner(
+          user,
+          input as never,
+        );
+
+        expect(contentService.sellerUpdateBanner).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteBanner', () => {
+      it('bannerId를 BigInt로 전달해야 한다', async () => {
+        contentService.sellerDeleteBanner.mockResolvedValue(true);
+
+        const result = await contentMutationResolver.sellerDeleteBanner(
+          user,
+          '77',
+        );
+
+        expect(contentService.sellerDeleteBanner).toHaveBeenCalledWith(
+          BigInt(11),
+          BigInt(77),
+        );
+        expect(result).toBe(true);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        contentService.sellerDeleteBanner.mockRejectedValue(
+          new NotFoundException('배너를 찾을 수 없습니다'),
+        );
+
+        await expect(
+          contentMutationResolver.sellerDeleteBanner(user, '77'),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+  });
+
+  // ================================================================
+  // SellerStoreQueryResolver
+  // ================================================================
+  describe('SellerStoreQueryResolver', () => {
+    describe('sellerMyStore', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const expected = { id: '1', name: '내 가게' };
+        storeService.sellerMyStore.mockResolvedValue(expected as never);
+
+        const result = await storeQueryResolver.sellerMyStore(user);
+
+        expect(storeService.sellerMyStore).toHaveBeenCalledWith(BigInt(11));
+        expect(result).toBe(expected);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        storeService.sellerMyStore.mockRejectedValue(
+          new NotFoundException('가게를 찾을 수 없습니다'),
+        );
+
+        await expect(storeQueryResolver.sellerMyStore(user)).rejects.toThrow(
+          NotFoundException,
+        );
+      });
+    });
+
+    describe('sellerStoreBusinessHours', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const expected = [{ dayOfWeek: 1, openTime: '09:00' }];
+        storeService.sellerStoreBusinessHours.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await storeQueryResolver.sellerStoreBusinessHours(user);
+
+        expect(storeService.sellerStoreBusinessHours).toHaveBeenCalledWith(
+          BigInt(11),
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerStoreSpecialClosures', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { first: 10 };
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        storeService.sellerStoreSpecialClosures.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await storeQueryResolver.sellerStoreSpecialClosures(
+          user,
+          input,
+        );
+
+        expect(storeService.sellerStoreSpecialClosures).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('input 없이 호출할 수 있어야 한다', async () => {
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        storeService.sellerStoreSpecialClosures.mockResolvedValue(
+          expected as never,
+        );
+
+        await storeQueryResolver.sellerStoreSpecialClosures(user);
+
+        expect(storeService.sellerStoreSpecialClosures).toHaveBeenCalledWith(
+          BigInt(11),
+          undefined,
+        );
+      });
+    });
+
+    describe('sellerStoreDailyCapacities', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { first: 10 };
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        storeService.sellerStoreDailyCapacities.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await storeQueryResolver.sellerStoreDailyCapacities(
+          user,
+          input,
+        );
+
+        expect(storeService.sellerStoreDailyCapacities).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('input 없이 호출할 수 있어야 한다', async () => {
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        storeService.sellerStoreDailyCapacities.mockResolvedValue(
+          expected as never,
+        );
+
+        await storeQueryResolver.sellerStoreDailyCapacities(user);
+
+        expect(storeService.sellerStoreDailyCapacities).toHaveBeenCalledWith(
+          BigInt(11),
+          undefined,
+        );
+      });
+    });
+  });
+
+  // ================================================================
+  // SellerStoreMutationResolver
+  // ================================================================
+  describe('SellerStoreMutationResolver', () => {
+    describe('sellerUpdateStoreBasicInfo', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { name: '수정된 가게' };
+        const expected = { id: '1', name: '수정된 가게' };
+        storeService.sellerUpdateStoreBasicInfo.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await storeMutationResolver.sellerUpdateStoreBasicInfo(
+          user,
+          input as never,
+        );
+
+        expect(storeService.sellerUpdateStoreBasicInfo).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpsertStoreBusinessHour', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { dayOfWeek: 1, openTime: '09:00', closeTime: '18:00' };
+        const expected = {
+          dayOfWeek: 1,
+          openTime: '09:00',
+          closeTime: '18:00',
+        };
+        storeService.sellerUpsertStoreBusinessHour.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await storeMutationResolver.sellerUpsertStoreBusinessHour(
+            user,
+            input as never,
+          );
+
+        expect(storeService.sellerUpsertStoreBusinessHour).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpsertStoreSpecialClosure', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { date: '2026-04-01', reason: '임시 휴업' };
+        const expected = { id: '1', date: '2026-04-01', reason: '임시 휴업' };
+        storeService.sellerUpsertStoreSpecialClosure.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await storeMutationResolver.sellerUpsertStoreSpecialClosure(
+            user,
+            input as never,
+          );
+
+        expect(
+          storeService.sellerUpsertStoreSpecialClosure,
+        ).toHaveBeenCalledWith(BigInt(11), input);
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteStoreSpecialClosure', () => {
+      it('closureId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        storeService.sellerDeleteStoreSpecialClosure.mockResolvedValue(true);
+
+        const result =
+          await storeMutationResolver.sellerDeleteStoreSpecialClosure(
+            user,
+            '22',
+          );
+
+        expect(
+          storeService.sellerDeleteStoreSpecialClosure,
+        ).toHaveBeenCalledWith(BigInt(11), BigInt(22));
+        expect(result).toBe(true);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        storeService.sellerDeleteStoreSpecialClosure.mockRejectedValue(
+          new NotFoundException('특별 휴일을 찾을 수 없습니다'),
+        );
+
+        await expect(
+          storeMutationResolver.sellerDeleteStoreSpecialClosure(user, '22'),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+
+    describe('sellerUpdatePickupPolicy', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { minPickupMinutes: 30 };
+        const expected = { id: '1', minPickupMinutes: 30 };
+        storeService.sellerUpdatePickupPolicy.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await storeMutationResolver.sellerUpdatePickupPolicy(
+          user,
+          input as never,
+        );
+
+        expect(storeService.sellerUpdatePickupPolicy).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerUpsertStoreDailyCapacity', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { date: '2026-04-01', capacity: 50 };
+        const expected = { id: '1', date: '2026-04-01', capacity: 50 };
+        storeService.sellerUpsertStoreDailyCapacity.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await storeMutationResolver.sellerUpsertStoreDailyCapacity(
+            user,
+            input as never,
+          );
+
+        expect(
+          storeService.sellerUpsertStoreDailyCapacity,
+        ).toHaveBeenCalledWith(BigInt(11), input);
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('sellerDeleteStoreDailyCapacity', () => {
+      it('capacityId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        storeService.sellerDeleteStoreDailyCapacity.mockResolvedValue(true);
+
+        const result =
+          await storeMutationResolver.sellerDeleteStoreDailyCapacity(
+            user,
+            '15',
+          );
+
+        expect(
+          storeService.sellerDeleteStoreDailyCapacity,
+        ).toHaveBeenCalledWith(BigInt(11), BigInt(15));
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  // ================================================================
+  // SellerConversationQueryResolver
+  // ================================================================
+  describe('SellerConversationQueryResolver', () => {
+    describe('sellerConversations', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { first: 10 };
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        conversationService.sellerConversations.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await conversationQueryResolver.sellerConversations(
+          user,
+          input,
+        );
+
+        expect(conversationService.sellerConversations).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('input 없이 호출할 수 있어야 한다', async () => {
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        conversationService.sellerConversations.mockResolvedValue(
+          expected as never,
+        );
+
+        await conversationQueryResolver.sellerConversations(user);
+
+        expect(conversationService.sellerConversations).toHaveBeenCalledWith(
+          BigInt(11),
+          undefined,
+        );
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        conversationService.sellerConversations.mockRejectedValue(
+          new ForbiddenException('접근 권한이 없습니다'),
+        );
+
+        await expect(
+          conversationQueryResolver.sellerConversations(user),
+        ).rejects.toThrow(ForbiddenException);
+      });
+    });
+
+    describe('sellerConversationMessages', () => {
+      it('conversationId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { first: 20 };
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        conversationService.sellerConversationMessages.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await conversationQueryResolver.sellerConversationMessages(
+            user,
+            '42',
+            input,
+          );
+
+        expect(
+          conversationService.sellerConversationMessages,
+        ).toHaveBeenCalledWith(BigInt(11), BigInt(42), input);
+        expect(result).toBe(expected);
+      });
+
+      it('input 없이 호출할 수 있어야 한다', async () => {
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        conversationService.sellerConversationMessages.mockResolvedValue(
+          expected as never,
+        );
+
+        await conversationQueryResolver.sellerConversationMessages(user, '42');
+
+        expect(
+          conversationService.sellerConversationMessages,
+        ).toHaveBeenCalledWith(BigInt(11), BigInt(42), undefined);
+      });
+    });
+  });
+
+  // ================================================================
+  // SellerConversationMutationResolver
+  // ================================================================
+  describe('SellerConversationMutationResolver', () => {
+    describe('sellerSendConversationMessage', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { conversationId: '42', body: '안녕하세요' };
+        const expected = { id: '1', body: '안녕하세요' };
+        conversationService.sellerSendConversationMessage.mockResolvedValue(
+          expected as never,
+        );
+
+        const result =
+          await conversationMutationResolver.sellerSendConversationMessage(
+            user,
+            input as never,
+          );
+
+        expect(
+          conversationService.sellerSendConversationMessage,
+        ).toHaveBeenCalledWith(BigInt(11), input);
+        expect(result).toBe(expected);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        conversationService.sellerSendConversationMessage.mockRejectedValue(
+          new NotFoundException('대화를 찾을 수 없습니다'),
+        );
+
+        await expect(
+          conversationMutationResolver.sellerSendConversationMessage(user, {
+            conversationId: '42',
+            body: '안녕하세요',
+          } as never),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+  });
+
+  // ================================================================
+  // SellerOrderQueryResolver
+  // ================================================================
+  describe('SellerOrderQueryResolver', () => {
+    describe('sellerOrderList', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { first: 10 };
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        orderService.sellerOrderList.mockResolvedValue(expected as never);
+
+        const result = await orderQueryResolver.sellerOrderList(user, input);
+
+        expect(orderService.sellerOrderList).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('input 없이 호출할 수 있어야 한다', async () => {
+        const expected = { edges: [], pageInfo: { hasNextPage: false } };
+        orderService.sellerOrderList.mockResolvedValue(expected as never);
+
+        await orderQueryResolver.sellerOrderList(user);
+
+        expect(orderService.sellerOrderList).toHaveBeenCalledWith(
+          BigInt(11),
+          undefined,
+        );
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        orderService.sellerOrderList.mockRejectedValue(
+          new ForbiddenException('주문 접근 권한이 없습니다'),
+        );
+
+        await expect(orderQueryResolver.sellerOrderList(user)).rejects.toThrow(
+          ForbiddenException,
+        );
+      });
+    });
+
+    describe('sellerOrder', () => {
+      it('orderId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const expected = { id: '100', status: 'PENDING' };
+        orderService.sellerOrder.mockResolvedValue(expected as never);
+
+        const result = await orderQueryResolver.sellerOrder(user, '100');
+
+        expect(orderService.sellerOrder).toHaveBeenCalledWith(
+          BigInt(11),
+          BigInt(100),
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        orderService.sellerOrder.mockRejectedValue(
+          new NotFoundException('주문을 찾을 수 없습니다'),
+        );
+
+        await expect(
+          orderQueryResolver.sellerOrder(user, '999'),
+        ).rejects.toThrow(NotFoundException);
+      });
+    });
+  });
+
+  // ================================================================
+  // SellerOrderMutationResolver
+  // ================================================================
+  describe('SellerOrderMutationResolver', () => {
+    describe('sellerUpdateOrderStatus', () => {
+      it('accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+        const input = { orderId: '100', status: 'CONFIRMED' };
+        const expected = { id: '100', status: 'CONFIRMED' };
+        orderService.sellerUpdateOrderStatus.mockResolvedValue(
+          expected as never,
+        );
+
+        const result = await orderMutationResolver.sellerUpdateOrderStatus(
+          user,
+          input as never,
+        );
+
+        expect(orderService.sellerUpdateOrderStatus).toHaveBeenCalledWith(
+          BigInt(11),
+          input,
+        );
+        expect(result).toBe(expected);
+      });
+
+      it('서비스 예외가 그대로 전파되어야 한다', async () => {
+        orderService.sellerUpdateOrderStatus.mockRejectedValue(
+          new ForbiddenException('주문 상태 변경 권한이 없습니다'),
+        );
+
+        await expect(
+          orderMutationResolver.sellerUpdateOrderStatus(user, {
+            orderId: '100',
+            status: 'CONFIRMED',
+          } as never),
+        ).rejects.toThrow(ForbiddenException);
+      });
+    });
   });
 });

--- a/src/features/seller/services/seller-content.service.spec.ts
+++ b/src/features/seller/services/seller-content.service.spec.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuditActionType, AuditTargetType } from '@prisma/client';
 
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
@@ -20,6 +21,8 @@ describe('SellerContentService', () => {
     status: 'ACTIVE',
     store: { id: BigInt(100) },
   };
+
+  const NOW = new Date('2026-03-30T00:00:00.000Z');
 
   beforeEach(async () => {
     repo = {
@@ -64,6 +67,108 @@ describe('SellerContentService', () => {
 
   // ─── FAQ Topic ────────────────────────────────────────────
 
+  describe('sellerFaqTopics', () => {
+    it('매장의 FAQ 토픽 목록을 반환해야 한다', async () => {
+      const faqRows = [
+        {
+          id: BigInt(10),
+          store_id: BigInt(100),
+          title: 'FAQ 1',
+          answer_html: '<p>답변1</p>',
+          sort_order: 0,
+          is_active: true,
+          created_at: NOW,
+          updated_at: NOW,
+        },
+        {
+          id: BigInt(11),
+          store_id: BigInt(100),
+          title: 'FAQ 2',
+          answer_html: '<p>답변2</p>',
+          sort_order: 1,
+          is_active: false,
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ];
+      repo.listFaqTopics.mockResolvedValue(faqRows as never);
+
+      const result = await service.sellerFaqTopics(BigInt(1));
+
+      expect(repo.listFaqTopics).toHaveBeenCalledWith(BigInt(100));
+      expect(result).toEqual([
+        {
+          id: '10',
+          storeId: '100',
+          title: 'FAQ 1',
+          answerHtml: '<p>답변1</p>',
+          sortOrder: 0,
+          isActive: true,
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+        {
+          id: '11',
+          storeId: '100',
+          title: 'FAQ 2',
+          answerHtml: '<p>답변2</p>',
+          sortOrder: 1,
+          isActive: false,
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ]);
+    });
+  });
+
+  describe('sellerCreateFaqTopic', () => {
+    it('FAQ 토픽을 생성하고 감사 로그를 기록해야 한다', async () => {
+      const createdRow = {
+        id: BigInt(20),
+        store_id: BigInt(100),
+        title: '새 FAQ',
+        answer_html: '<p>새 답변</p>',
+        sort_order: 0,
+        is_active: true,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      repo.createFaqTopic.mockResolvedValue(createdRow as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerCreateFaqTopic(BigInt(1), {
+        title: '새 FAQ',
+        answerHtml: '<p>새 답변</p>',
+      });
+
+      expect(repo.createFaqTopic).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        title: '새 FAQ',
+        answerHtml: '<p>새 답변</p>',
+        sortOrder: 0,
+        isActive: true,
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.STORE,
+        targetId: BigInt(100),
+        action: AuditActionType.CREATE,
+        afterJson: { topicId: '20' },
+      });
+      expect(result).toEqual({
+        id: '20',
+        storeId: '100',
+        title: '새 FAQ',
+        answerHtml: '<p>새 답변</p>',
+        sortOrder: 0,
+        isActive: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+    });
+  });
+
   describe('sellerUpdateFaqTopic', () => {
     it('FAQ 토픽이 존재하지 않으면 NotFoundException을 던져야 한다', async () => {
       repo.findFaqTopicById.mockResolvedValue(null);
@@ -75,6 +180,59 @@ describe('SellerContentService', () => {
         }),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('FAQ 토픽을 수정하고 감사 로그를 기록해야 한다', async () => {
+      const currentRow = {
+        id: BigInt(10),
+        store_id: BigInt(100),
+        title: '기존 제목',
+        answer_html: '<p>기존 답변</p>',
+        sort_order: 0,
+        is_active: true,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      const updatedRow = {
+        ...currentRow,
+        title: '수정된 제목',
+        updated_at: new Date('2026-03-30T01:00:00.000Z'),
+      };
+      repo.findFaqTopicById.mockResolvedValue(currentRow as never);
+      repo.updateFaqTopic.mockResolvedValue(updatedRow as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerUpdateFaqTopic(BigInt(1), {
+        topicId: '10',
+        title: '수정된 제목',
+      });
+
+      expect(repo.findFaqTopicById).toHaveBeenCalledWith({
+        topicId: BigInt(10),
+        storeId: BigInt(100),
+      });
+      expect(repo.updateFaqTopic).toHaveBeenCalledWith({
+        topicId: BigInt(10),
+        data: { title: '수정된 제목' },
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.STORE,
+        targetId: BigInt(100),
+        action: AuditActionType.UPDATE,
+        afterJson: { topicId: '10' },
+      });
+      expect(result).toEqual({
+        id: '10',
+        storeId: '100',
+        title: '수정된 제목',
+        answerHtml: '<p>기존 답변</p>',
+        sortOrder: 0,
+        isActive: true,
+        createdAt: NOW,
+        updatedAt: new Date('2026-03-30T01:00:00.000Z'),
+      });
+    });
   });
 
   describe('sellerDeleteFaqTopic', () => {
@@ -84,6 +242,343 @@ describe('SellerContentService', () => {
       await expect(
         service.sellerDeleteFaqTopic(BigInt(1), BigInt(999)),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('FAQ 토픽을 소프트 삭제하고 감사 로그를 기록해야 한다', async () => {
+      const currentRow = {
+        id: BigInt(10),
+        store_id: BigInt(100),
+        title: '삭제 대상',
+        answer_html: '<p>답변</p>',
+        sort_order: 0,
+        is_active: true,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      repo.findFaqTopicById.mockResolvedValue(currentRow as never);
+      repo.softDeleteFaqTopic.mockResolvedValue(undefined as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerDeleteFaqTopic(BigInt(1), BigInt(10));
+
+      expect(repo.findFaqTopicById).toHaveBeenCalledWith({
+        topicId: BigInt(10),
+        storeId: BigInt(100),
+      });
+      expect(repo.softDeleteFaqTopic).toHaveBeenCalledWith(BigInt(10));
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.STORE,
+        targetId: BigInt(100),
+        action: AuditActionType.DELETE,
+        beforeJson: { topicId: '10' },
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  // ─── Banner ─────────────────────────────────────────────────
+
+  describe('sellerBanners', () => {
+    it('배너 목록을 커서 기반 페이지네이션으로 반환해야 한다', async () => {
+      const bannerRows = [
+        {
+          id: BigInt(30),
+          placement: 'HOME_MAIN' as const,
+          title: '배너 1',
+          image_url: 'https://img.example.com/b1.png',
+          link_type: 'NONE' as const,
+          link_url: null,
+          link_product_id: null,
+          link_store_id: null,
+          link_category_id: null,
+          starts_at: null,
+          ends_at: null,
+          sort_order: 0,
+          is_active: true,
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ];
+      repo.listBannersByStore.mockResolvedValue(bannerRows as never);
+
+      const result = await service.sellerBanners(BigInt(1));
+
+      expect(repo.listBannersByStore).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        limit: 20,
+      });
+      expect(result).toEqual({
+        items: [
+          {
+            id: '30',
+            placement: 'HOME_MAIN',
+            title: '배너 1',
+            imageUrl: 'https://img.example.com/b1.png',
+            linkType: 'NONE',
+            linkUrl: null,
+            linkProductId: null,
+            linkStoreId: null,
+            linkCategoryId: null,
+            startsAt: null,
+            endsAt: null,
+            sortOrder: 0,
+            isActive: true,
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+        ],
+        nextCursor: null,
+      });
+    });
+  });
+
+  describe('sellerCreateBanner', () => {
+    it('linkType이 NONE인 배너를 생성하고 감사 로그를 기록해야 한다', async () => {
+      const createdRow = {
+        id: BigInt(40),
+        placement: 'HOME_MAIN' as const,
+        title: null,
+        image_url: 'https://img.example.com/new.png',
+        link_type: 'NONE' as const,
+        link_url: null,
+        link_product_id: null,
+        link_store_id: null,
+        link_category_id: null,
+        starts_at: null,
+        ends_at: null,
+        sort_order: 0,
+        is_active: true,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      repo.createBanner.mockResolvedValue(createdRow as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerCreateBanner(BigInt(1), {
+        placement: 'HOME_MAIN',
+        imageUrl: 'https://img.example.com/new.png',
+      });
+
+      expect(repo.createBanner).toHaveBeenCalledWith({
+        placement: 'HOME_MAIN',
+        title: null,
+        imageUrl: 'https://img.example.com/new.png',
+        linkType: 'NONE',
+        linkUrl: null,
+        linkProductId: null,
+        linkStoreId: null,
+        linkCategoryId: null,
+        startsAt: null,
+        endsAt: null,
+        sortOrder: 0,
+        isActive: true,
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.STORE,
+        targetId: BigInt(100),
+        action: AuditActionType.CREATE,
+        afterJson: { bannerId: '40' },
+      });
+      expect(result).toEqual({
+        id: '40',
+        placement: 'HOME_MAIN',
+        title: null,
+        imageUrl: 'https://img.example.com/new.png',
+        linkType: 'NONE',
+        linkUrl: null,
+        linkProductId: null,
+        linkStoreId: null,
+        linkCategoryId: null,
+        startsAt: null,
+        endsAt: null,
+        sortOrder: 0,
+        isActive: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+    });
+  });
+
+  describe('sellerUpdateBanner', () => {
+    it('배너가 존재하지 않으면 NotFoundException을 던져야 한다', async () => {
+      repo.findBannerByIdForStore.mockResolvedValue(null);
+
+      await expect(
+        service.sellerUpdateBanner(BigInt(1), {
+          bannerId: '999',
+          title: '수정 배너',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('배너를 수정하고 감사 로그를 기록해야 한다', async () => {
+      const currentRow = {
+        id: BigInt(30),
+        placement: 'HOME_MAIN' as const,
+        title: '기존 배너',
+        image_url: 'https://img.example.com/old.png',
+        link_type: 'NONE' as const,
+        link_url: null,
+        link_product_id: null,
+        link_store_id: null,
+        link_category_id: null,
+        starts_at: null,
+        ends_at: null,
+        sort_order: 0,
+        is_active: true,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      const updatedRow = {
+        ...currentRow,
+        title: '수정된 배너',
+        updated_at: new Date('2026-03-30T01:00:00.000Z'),
+      };
+      repo.findBannerByIdForStore.mockResolvedValue(currentRow as never);
+      repo.updateBanner.mockResolvedValue(updatedRow as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerUpdateBanner(BigInt(1), {
+        bannerId: '30',
+        title: '수정된 배너',
+      });
+
+      expect(repo.findBannerByIdForStore).toHaveBeenCalledWith({
+        bannerId: BigInt(30),
+        storeId: BigInt(100),
+      });
+      expect(repo.updateBanner).toHaveBeenCalledWith({
+        bannerId: BigInt(30),
+        data: { title: '수정된 배너' },
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.STORE,
+        targetId: BigInt(100),
+        action: AuditActionType.UPDATE,
+        afterJson: { bannerId: '30' },
+      });
+      expect(result).toEqual({
+        id: '30',
+        placement: 'HOME_MAIN',
+        title: '수정된 배너',
+        imageUrl: 'https://img.example.com/old.png',
+        linkType: 'NONE',
+        linkUrl: null,
+        linkProductId: null,
+        linkStoreId: null,
+        linkCategoryId: null,
+        startsAt: null,
+        endsAt: null,
+        sortOrder: 0,
+        isActive: true,
+        createdAt: NOW,
+        updatedAt: new Date('2026-03-30T01:00:00.000Z'),
+      });
+    });
+  });
+
+  describe('sellerDeleteBanner', () => {
+    it('배너가 존재하지 않으면 NotFoundException을 던져야 한다', async () => {
+      repo.findBannerByIdForStore.mockResolvedValue(null);
+
+      await expect(
+        service.sellerDeleteBanner(BigInt(1), BigInt(999)),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('배너를 소프트 삭제하고 감사 로그를 기록해야 한다', async () => {
+      const currentRow = {
+        id: BigInt(30),
+        placement: 'HOME_MAIN' as const,
+        title: '삭제 대상 배너',
+        image_url: 'https://img.example.com/del.png',
+        link_type: 'NONE' as const,
+        link_url: null,
+        link_product_id: null,
+        link_store_id: null,
+        link_category_id: null,
+        starts_at: null,
+        ends_at: null,
+        sort_order: 0,
+        is_active: true,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      repo.findBannerByIdForStore.mockResolvedValue(currentRow as never);
+      repo.softDeleteBanner.mockResolvedValue(undefined as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerDeleteBanner(BigInt(1), BigInt(30));
+
+      expect(repo.findBannerByIdForStore).toHaveBeenCalledWith({
+        bannerId: BigInt(30),
+        storeId: BigInt(100),
+      });
+      expect(repo.softDeleteBanner).toHaveBeenCalledWith(BigInt(30));
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.STORE,
+        targetId: BigInt(100),
+        action: AuditActionType.DELETE,
+        beforeJson: { bannerId: '30' },
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  // ─── Audit Logs ─────────────────────────────────────────────
+
+  describe('sellerAuditLogs', () => {
+    it('감사 로그 목록을 커서 기반 페이지네이션으로 반환해야 한다', async () => {
+      const auditRows = [
+        {
+          id: BigInt(50),
+          actor_account_id: BigInt(1),
+          store_id: BigInt(100),
+          target_type: 'STORE' as const,
+          target_id: BigInt(100),
+          action: 'CREATE' as const,
+          before_json: null,
+          after_json: { topicId: '20' },
+          ip_address: '127.0.0.1',
+          user_agent: 'TestAgent',
+          created_at: NOW,
+        },
+      ];
+      repo.listAuditLogsBySeller.mockResolvedValue(auditRows as never);
+
+      const result = await service.sellerAuditLogs(BigInt(1));
+
+      expect(repo.listAuditLogsBySeller).toHaveBeenCalledWith({
+        sellerAccountId: BigInt(1),
+        storeId: BigInt(100),
+        limit: 20,
+      });
+      expect(result).toEqual({
+        items: [
+          {
+            id: '50',
+            actorAccountId: '1',
+            storeId: '100',
+            targetType: 'STORE',
+            targetId: '100',
+            action: 'CREATE',
+            beforeJson: null,
+            afterJson: '{"topicId":"20"}',
+            ipAddress: '127.0.0.1',
+            userAgent: 'TestAgent',
+            createdAt: NOW,
+          },
+        ],
+        nextCursor: null,
+      });
     });
   });
 
@@ -152,31 +647,6 @@ describe('SellerContentService', () => {
           linkType: 'CATEGORY',
         }),
       ).rejects.toThrow(BadRequestException);
-    });
-  });
-
-  // ─── Banner CRUD 예외 ─────────────────────────────────────
-
-  describe('sellerUpdateBanner', () => {
-    it('배너가 존재하지 않으면 NotFoundException을 던져야 한다', async () => {
-      repo.findBannerByIdForStore.mockResolvedValue(null);
-
-      await expect(
-        service.sellerUpdateBanner(BigInt(1), {
-          bannerId: '999',
-          title: '수정 배너',
-        }),
-      ).rejects.toThrow(NotFoundException);
-    });
-  });
-
-  describe('sellerDeleteBanner', () => {
-    it('배너가 존재하지 않으면 NotFoundException을 던져야 한다', async () => {
-      repo.findBannerByIdForStore.mockResolvedValue(null);
-
-      await expect(
-        service.sellerDeleteBanner(BigInt(1), BigInt(999)),
-      ).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/src/features/seller/services/seller-conversation.service.spec.ts
+++ b/src/features/seller/services/seller-conversation.service.spec.ts
@@ -46,6 +46,80 @@ describe('SellerConversationService', () => {
     service = module.get<SellerConversationService>(SellerConversationService);
   });
 
+  // ─── sellerConversations ───
+
+  describe('sellerConversations', () => {
+    it('정상 조회 시 대화 목록과 nextCursor를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      conversationRepo.listConversationsByStore.mockResolvedValue([
+        {
+          id: BigInt(10),
+          account_id: BigInt(50),
+          store_id: BigInt(100),
+          last_message_at: new Date('2026-03-30T10:00:00Z'),
+          last_read_at: new Date('2026-03-30T09:00:00Z'),
+          updated_at: new Date('2026-03-30T10:00:00Z'),
+        },
+        {
+          id: BigInt(11),
+          account_id: BigInt(51),
+          store_id: BigInt(100),
+          last_message_at: null,
+          last_read_at: null,
+          updated_at: new Date('2026-03-29T15:00:00Z'),
+        },
+      ] as never);
+
+      const result = await service.sellerConversations(BigInt(1));
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].id).toBe('10');
+      expect(result.items[0].accountId).toBe('50');
+      expect(result.items[0].storeId).toBe('100');
+      expect(result.items[0].lastMessageAt).toEqual(
+        new Date('2026-03-30T10:00:00Z'),
+      );
+      expect(result.items[0].lastReadAt).toEqual(
+        new Date('2026-03-30T09:00:00Z'),
+      );
+      expect(result.items[1].id).toBe('11');
+      expect(result.items[1].lastMessageAt).toBeNull();
+      expect(result.items[1].lastReadAt).toBeNull();
+      expect(result.nextCursor).toBeNull();
+      expect(conversationRepo.listConversationsByStore).toHaveBeenCalledWith(
+        expect.objectContaining({ storeId: BigInt(100) }),
+      );
+    });
+
+    it('cursor와 limit을 전달하면 정규화된 값으로 repository를 호출해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      conversationRepo.listConversationsByStore.mockResolvedValue([] as never);
+
+      await service.sellerConversations(BigInt(1), {
+        limit: 5,
+        cursor: '30',
+      });
+
+      expect(conversationRepo.listConversationsByStore).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        limit: 5,
+        cursor: BigInt(30),
+      });
+    });
+
+    it('결과가 빈 배열이면 빈 items와 null nextCursor를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      conversationRepo.listConversationsByStore.mockResolvedValue([] as never);
+
+      const result = await service.sellerConversations(BigInt(1));
+
+      expect(result.items).toHaveLength(0);
+      expect(result.nextCursor).toBeNull();
+    });
+  });
+
+  // ─── sellerConversationMessages ───
+
   describe('sellerConversationMessages', () => {
     it('정상 조회 시 메시지 목록과 nextCursor를 반환해야 한다', async () => {
       repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);

--- a/src/features/seller/services/seller-custom-template.service.spec.ts
+++ b/src/features/seller/services/seller-custom-template.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuditActionType, AuditTargetType } from '@prisma/client';
 
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
@@ -72,6 +73,54 @@ describe('SellerCustomTemplateService', () => {
         }),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('유효한 입력으로 커스텀 템플릿을 upsert하고 결과를 반환해야 한다', async () => {
+      productRepo.findProductByIdIncludingInactive.mockResolvedValue({
+        id: BigInt(10),
+      } as never);
+
+      const upsertedRow = {
+        id: BigInt(20),
+        product_id: BigInt(10),
+        base_image_url: 'https://example.com/base.png',
+        is_active: true,
+        text_tokens: [],
+      };
+      productRepo.upsertProductCustomTemplate.mockResolvedValue(
+        upsertedRow as never,
+      );
+
+      const result = await service.sellerUpsertProductCustomTemplate(
+        BigInt(1),
+        {
+          productId: '10',
+          baseImageUrl: 'https://example.com/base.png',
+        },
+      );
+
+      expect(result).toEqual({
+        id: '20',
+        productId: '10',
+        baseImageUrl: 'https://example.com/base.png',
+        isActive: true,
+        textTokens: [],
+      });
+
+      expect(productRepo.upsertProductCustomTemplate).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        baseImageUrl: 'https://example.com/base.png',
+        isActive: true,
+      });
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.UPDATE,
+        afterJson: { templateId: '20' },
+      });
+    });
   });
 
   describe('sellerSetProductCustomTemplateActive', () => {
@@ -84,6 +133,55 @@ describe('SellerCustomTemplateService', () => {
           isActive: true,
         }),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('유효한 입력으로 템플릿 활성 상태를 변경하고 결과를 반환해야 한다', async () => {
+      productRepo.findCustomTemplateById.mockResolvedValue({
+        id: BigInt(20),
+        product_id: BigInt(10),
+        product: { store_id: BigInt(100) },
+      } as never);
+
+      const updatedRow = {
+        id: BigInt(20),
+        product_id: BigInt(10),
+        base_image_url: 'https://example.com/base.png',
+        is_active: false,
+        text_tokens: [],
+      };
+      productRepo.setCustomTemplateActive.mockResolvedValue(
+        updatedRow as never,
+      );
+
+      const result = await service.sellerSetProductCustomTemplateActive(
+        BigInt(1),
+        {
+          templateId: '20',
+          isActive: false,
+        },
+      );
+
+      expect(result).toEqual({
+        id: '20',
+        productId: '10',
+        baseImageUrl: 'https://example.com/base.png',
+        isActive: false,
+        textTokens: [],
+      });
+
+      expect(productRepo.setCustomTemplateActive).toHaveBeenCalledWith(
+        BigInt(20),
+        false,
+      );
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.STATUS_CHANGE,
+        afterJson: { templateId: '20', isActive: false },
+      });
     });
   });
 
@@ -118,6 +216,158 @@ describe('SellerCustomTemplateService', () => {
         }),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('tokenId 없이 새 토큰을 생성하고 결과를 반환해야 한다', async () => {
+      productRepo.findCustomTemplateById.mockResolvedValue({
+        id: BigInt(20),
+        product_id: BigInt(10),
+        product: { store_id: BigInt(100) },
+      } as never);
+
+      const createdRow = {
+        id: BigInt(40),
+        template_id: BigInt(20),
+        token_key: 'NAME',
+        default_text: '이름을 입력하세요',
+        max_length: 50,
+        sort_order: 0,
+        is_required: true,
+        pos_x: null,
+        pos_y: null,
+        width: null,
+        height: null,
+      };
+      productRepo.upsertCustomTextToken.mockResolvedValue(createdRow as never);
+
+      const result = await service.sellerUpsertProductCustomTextToken(
+        BigInt(1),
+        {
+          templateId: '20',
+          tokenKey: 'NAME',
+          defaultText: '이름을 입력하세요',
+          maxLength: 50,
+        },
+      );
+
+      expect(result).toEqual({
+        id: '40',
+        templateId: '20',
+        tokenKey: 'NAME',
+        defaultText: '이름을 입력하세요',
+        maxLength: 50,
+        sortOrder: 0,
+        isRequired: true,
+        posX: null,
+        posY: null,
+        width: null,
+        height: null,
+      });
+
+      expect(productRepo.upsertCustomTextToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokenId: undefined,
+          templateId: BigInt(20),
+          tokenKey: 'NAME',
+          defaultText: '이름을 입력하세요',
+          maxLength: 50,
+        }),
+      );
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.CREATE,
+        afterJson: { tokenId: '40', tokenKey: 'NAME' },
+      });
+    });
+
+    it('tokenId가 있으면 기존 토큰을 업데이트하고 결과를 반환해야 한다', async () => {
+      productRepo.findCustomTemplateById.mockResolvedValue({
+        id: BigInt(20),
+        product_id: BigInt(10),
+        product: { store_id: BigInt(100) },
+      } as never);
+      productRepo.findCustomTextTokenById.mockResolvedValue({
+        id: BigInt(40),
+        template: {
+          id: BigInt(20),
+          product: { store_id: BigInt(100) },
+        },
+      } as never);
+
+      const updatedRow = {
+        id: BigInt(40),
+        template_id: BigInt(20),
+        token_key: 'UPDATED_NAME',
+        default_text: '수정된 기본값',
+        max_length: 100,
+        sort_order: 1,
+        is_required: false,
+        pos_x: 10,
+        pos_y: 20,
+        width: 200,
+        height: 50,
+      };
+      productRepo.upsertCustomTextToken.mockResolvedValue(updatedRow as never);
+
+      const result = await service.sellerUpsertProductCustomTextToken(
+        BigInt(1),
+        {
+          templateId: '20',
+          tokenId: '40',
+          tokenKey: 'UPDATED_NAME',
+          defaultText: '수정된 기본값',
+          maxLength: 100,
+          sortOrder: 1,
+          isRequired: false,
+          posX: 10,
+          posY: 20,
+          width: 200,
+          height: 50,
+        },
+      );
+
+      expect(result).toEqual({
+        id: '40',
+        templateId: '20',
+        tokenKey: 'UPDATED_NAME',
+        defaultText: '수정된 기본값',
+        maxLength: 100,
+        sortOrder: 1,
+        isRequired: false,
+        posX: 10,
+        posY: 20,
+        width: 200,
+        height: 50,
+      });
+
+      expect(productRepo.upsertCustomTextToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokenId: BigInt(40),
+          templateId: BigInt(20),
+          tokenKey: 'UPDATED_NAME',
+          defaultText: '수정된 기본값',
+          maxLength: 100,
+          sortOrder: 1,
+          isRequired: false,
+          posX: 10,
+          posY: 20,
+          width: 200,
+          height: 50,
+        }),
+      );
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.UPDATE,
+        afterJson: { tokenId: '40', tokenKey: 'UPDATED_NAME' },
+      });
+    });
   });
 
   describe('sellerDeleteProductCustomTextToken', () => {
@@ -127,6 +377,40 @@ describe('SellerCustomTemplateService', () => {
       await expect(
         service.sellerDeleteProductCustomTextToken(BigInt(1), BigInt(999)),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('유효한 토큰을 소프트 삭제하고 true를 반환해야 한다', async () => {
+      productRepo.findCustomTextTokenById.mockResolvedValue({
+        id: BigInt(40),
+        token_key: 'NAME',
+        template: {
+          product_id: BigInt(10),
+          product: { store_id: BigInt(100) },
+        },
+      } as never);
+      productRepo.softDeleteCustomTextToken.mockResolvedValue(
+        undefined as never,
+      );
+
+      const result = await service.sellerDeleteProductCustomTextToken(
+        BigInt(1),
+        BigInt(40),
+      );
+
+      expect(result).toBe(true);
+
+      expect(productRepo.softDeleteCustomTextToken).toHaveBeenCalledWith(
+        BigInt(40),
+      );
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.DELETE,
+        beforeJson: { tokenId: '40', tokenKey: 'NAME' },
+      });
     });
   });
 
@@ -147,6 +431,78 @@ describe('SellerCustomTemplateService', () => {
           tokenIds: ['1'],
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('유효한 입력으로 토큰을 정렬하고 결과를 반환해야 한다', async () => {
+      productRepo.findCustomTemplateById.mockResolvedValue({
+        id: BigInt(20),
+        product_id: BigInt(10),
+        product: { store_id: BigInt(100) },
+      } as never);
+      productRepo.listCustomTextTokens.mockResolvedValue([
+        { id: BigInt(40) },
+        { id: BigInt(41) },
+      ] as never);
+
+      const reorderedRows = [
+        {
+          id: BigInt(41),
+          template_id: BigInt(20),
+          token_key: 'MESSAGE',
+          default_text: '메시지를 입력하세요',
+          max_length: 200,
+          sort_order: 0,
+          is_required: false,
+          pos_x: null,
+          pos_y: null,
+          width: null,
+          height: null,
+        },
+        {
+          id: BigInt(40),
+          template_id: BigInt(20),
+          token_key: 'NAME',
+          default_text: '이름을 입력하세요',
+          max_length: 50,
+          sort_order: 1,
+          is_required: true,
+          pos_x: 10,
+          pos_y: 20,
+          width: 100,
+          height: 30,
+        },
+      ];
+      productRepo.reorderCustomTextTokens.mockResolvedValue(
+        reorderedRows as never,
+      );
+
+      const result = await service.sellerReorderProductCustomTextTokens(
+        BigInt(1),
+        {
+          templateId: '20',
+          tokenIds: ['41', '40'],
+        },
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('41');
+      expect(result[0].tokenKey).toBe('MESSAGE');
+      expect(result[1].id).toBe('40');
+      expect(result[1].tokenKey).toBe('NAME');
+
+      expect(productRepo.reorderCustomTextTokens).toHaveBeenCalledWith({
+        templateId: BigInt(20),
+        tokenIds: [BigInt(41), BigInt(40)],
+      });
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.UPDATE,
+        afterJson: { tokenIds: ['41', '40'] },
+      });
     });
   });
 });

--- a/src/features/seller/services/seller-option.service.spec.ts
+++ b/src/features/seller/services/seller-option.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuditActionType, AuditTargetType } from '@prisma/client';
 
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
@@ -76,6 +77,65 @@ describe('SellerOptionService', () => {
         }),
       ).rejects.toThrow(BadRequestException);
     });
+
+    it('유효한 입력으로 옵션 그룹을 생성하고 결과를 반환해야 한다', async () => {
+      productRepo.findProductByIdIncludingInactive.mockResolvedValue({
+        id: BigInt(10),
+      } as never);
+
+      const createdRow = {
+        id: BigInt(50),
+        product_id: BigInt(10),
+        name: '사이즈',
+        is_required: true,
+        min_select: 1,
+        max_select: 1,
+        option_requires_description: false,
+        option_requires_image: false,
+        sort_order: 0,
+        is_active: true,
+        option_items: [],
+      };
+      productRepo.createOptionGroup.mockResolvedValue(createdRow as never);
+
+      const result = await service.sellerCreateOptionGroup(BigInt(1), {
+        productId: '10',
+        name: '사이즈',
+      });
+
+      expect(result).toEqual({
+        id: '50',
+        productId: '10',
+        name: '사이즈',
+        isRequired: true,
+        minSelect: 1,
+        maxSelect: 1,
+        optionRequiresDescription: false,
+        optionRequiresImage: false,
+        sortOrder: 0,
+        isActive: true,
+        optionItems: [],
+      });
+
+      expect(productRepo.createOptionGroup).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        data: expect.objectContaining({
+          name: '사이즈',
+          is_required: true,
+          min_select: 1,
+          max_select: 1,
+        }),
+      });
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.CREATE,
+        afterJson: { optionGroupId: '50' },
+      });
+    });
   });
 
   describe('sellerUpdateOptionGroup', () => {
@@ -105,6 +165,109 @@ describe('SellerOptionService', () => {
         }),
       ).rejects.toThrow(BadRequestException);
     });
+
+    it('유효한 입력으로 옵션 그룹을 수정하고 결과를 반환해야 한다', async () => {
+      productRepo.findOptionGroupById.mockResolvedValue({
+        id: BigInt(5),
+        product_id: BigInt(10),
+        min_select: 1,
+        max_select: 3,
+        product: { store_id: BigInt(100) },
+      } as never);
+
+      const updatedRow = {
+        id: BigInt(5),
+        product_id: BigInt(10),
+        name: '수정된 옵션그룹',
+        is_required: false,
+        min_select: 1,
+        max_select: 3,
+        option_requires_description: true,
+        option_requires_image: false,
+        sort_order: 2,
+        is_active: true,
+        option_items: [],
+      };
+      productRepo.updateOptionGroup.mockResolvedValue(updatedRow as never);
+
+      const result = await service.sellerUpdateOptionGroup(BigInt(1), {
+        optionGroupId: '5',
+        name: '수정된 옵션그룹',
+        isRequired: false,
+        optionRequiresDescription: true,
+        sortOrder: 2,
+      });
+
+      expect(result).toEqual({
+        id: '5',
+        productId: '10',
+        name: '수정된 옵션그룹',
+        isRequired: false,
+        minSelect: 1,
+        maxSelect: 3,
+        optionRequiresDescription: true,
+        optionRequiresImage: false,
+        sortOrder: 2,
+        isActive: true,
+        optionItems: [],
+      });
+
+      expect(productRepo.updateOptionGroup).toHaveBeenCalledWith({
+        optionGroupId: BigInt(5),
+        data: expect.objectContaining({
+          name: '수정된 옵션그룹',
+          is_required: false,
+          option_requires_description: true,
+          sort_order: 2,
+        }),
+      });
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.UPDATE,
+        afterJson: { optionGroupId: '5' },
+      });
+    });
+  });
+
+  describe('sellerDeleteOptionGroup', () => {
+    it('옵션 그룹이 없으면 NotFoundException을 던져야 한다', async () => {
+      productRepo.findOptionGroupById.mockResolvedValue(null as never);
+
+      await expect(
+        service.sellerDeleteOptionGroup(BigInt(1), BigInt(999)),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('유효한 옵션 그룹을 소프트 삭제하고 true를 반환해야 한다', async () => {
+      productRepo.findOptionGroupById.mockResolvedValue({
+        id: BigInt(5),
+        product_id: BigInt(10),
+        product: { store_id: BigInt(100) },
+      } as never);
+      productRepo.softDeleteOptionGroup.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerDeleteOptionGroup(
+        BigInt(1),
+        BigInt(5),
+      );
+
+      expect(result).toBe(true);
+
+      expect(productRepo.softDeleteOptionGroup).toHaveBeenCalledWith(BigInt(5));
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.DELETE,
+        beforeJson: { optionGroupId: '5' },
+      });
+    });
   });
 
   describe('sellerReorderOptionGroups', () => {
@@ -124,6 +287,69 @@ describe('SellerOptionService', () => {
         }),
       ).rejects.toThrow(BadRequestException);
     });
+
+    it('유효한 입력으로 옵션 그룹을 정렬하고 결과를 반환해야 한다', async () => {
+      productRepo.findProductByIdIncludingInactive.mockResolvedValue({
+        id: BigInt(10),
+      } as never);
+      productRepo.listOptionGroupsByProduct.mockResolvedValue([
+        { id: BigInt(1) },
+        { id: BigInt(2) },
+      ] as never);
+
+      const reorderedRows = [
+        {
+          id: BigInt(2),
+          product_id: BigInt(10),
+          name: '그룹B',
+          is_required: true,
+          min_select: 1,
+          max_select: 1,
+          option_requires_description: false,
+          option_requires_image: false,
+          sort_order: 0,
+          is_active: true,
+          option_items: [],
+        },
+        {
+          id: BigInt(1),
+          product_id: BigInt(10),
+          name: '그룹A',
+          is_required: true,
+          min_select: 1,
+          max_select: 1,
+          option_requires_description: false,
+          option_requires_image: false,
+          sort_order: 1,
+          is_active: true,
+          option_items: [],
+        },
+      ];
+      productRepo.reorderOptionGroups.mockResolvedValue(reorderedRows as never);
+
+      const result = await service.sellerReorderOptionGroups(BigInt(1), {
+        productId: '10',
+        optionGroupIds: ['2', '1'],
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('2');
+      expect(result[1].id).toBe('1');
+
+      expect(productRepo.reorderOptionGroups).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        optionGroupIds: [BigInt(2), BigInt(1)],
+      });
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.UPDATE,
+        afterJson: { optionGroupIds: ['2', '1'] },
+      });
+    });
   });
 
   // ── 옵션 아이템 ──
@@ -139,6 +365,62 @@ describe('SellerOptionService', () => {
         }),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('유효한 입력으로 옵션 아이템을 생성하고 결과를 반환해야 한다', async () => {
+      productRepo.findOptionGroupById.mockResolvedValue({
+        id: BigInt(5),
+        product_id: BigInt(10),
+        product: { store_id: BigInt(100) },
+      } as never);
+
+      const createdRow = {
+        id: BigInt(30),
+        option_group_id: BigInt(5),
+        title: '라지',
+        description: '큰 사이즈',
+        image_url: null,
+        price_delta: 1000,
+        sort_order: 0,
+        is_active: true,
+      };
+      productRepo.createOptionItem.mockResolvedValue(createdRow as never);
+
+      const result = await service.sellerCreateOptionItem(BigInt(1), {
+        optionGroupId: '5',
+        title: '라지',
+        description: '큰 사이즈',
+        priceDelta: 1000,
+      });
+
+      expect(result).toEqual({
+        id: '30',
+        optionGroupId: '5',
+        title: '라지',
+        description: '큰 사이즈',
+        imageUrl: null,
+        priceDelta: 1000,
+        sortOrder: 0,
+        isActive: true,
+      });
+
+      expect(productRepo.createOptionItem).toHaveBeenCalledWith({
+        optionGroupId: BigInt(5),
+        data: expect.objectContaining({
+          title: '라지',
+          description: '큰 사이즈',
+          price_delta: 1000,
+        }),
+      });
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.CREATE,
+        afterJson: { optionItemId: '30' },
+      });
+    });
   });
 
   describe('sellerUpdateOptionItem', () => {
@@ -151,6 +433,109 @@ describe('SellerOptionService', () => {
           title: '수정',
         }),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('유효한 입력으로 옵션 아이템을 수정하고 결과를 반환해야 한다', async () => {
+      productRepo.findOptionItemById.mockResolvedValue({
+        id: BigInt(30),
+        option_group_id: BigInt(5),
+        option_group: {
+          product_id: BigInt(10),
+          product: { store_id: BigInt(100) },
+        },
+      } as never);
+
+      const updatedRow = {
+        id: BigInt(30),
+        option_group_id: BigInt(5),
+        title: '미디엄',
+        description: '중간 사이즈',
+        image_url: 'https://example.com/img.png',
+        price_delta: 500,
+        sort_order: 1,
+        is_active: true,
+      };
+      productRepo.updateOptionItem.mockResolvedValue(updatedRow as never);
+
+      const result = await service.sellerUpdateOptionItem(BigInt(1), {
+        optionItemId: '30',
+        title: '미디엄',
+        description: '중간 사이즈',
+        imageUrl: 'https://example.com/img.png',
+        priceDelta: 500,
+        sortOrder: 1,
+      });
+
+      expect(result).toEqual({
+        id: '30',
+        optionGroupId: '5',
+        title: '미디엄',
+        description: '중간 사이즈',
+        imageUrl: 'https://example.com/img.png',
+        priceDelta: 500,
+        sortOrder: 1,
+        isActive: true,
+      });
+
+      expect(productRepo.updateOptionItem).toHaveBeenCalledWith({
+        optionItemId: BigInt(30),
+        data: expect.objectContaining({
+          title: '미디엄',
+          description: '중간 사이즈',
+          image_url: 'https://example.com/img.png',
+          price_delta: 500,
+          sort_order: 1,
+        }),
+      });
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.UPDATE,
+        afterJson: { optionItemId: '30' },
+      });
+    });
+  });
+
+  describe('sellerDeleteOptionItem', () => {
+    it('옵션 아이템이 없으면 NotFoundException을 던져야 한다', async () => {
+      productRepo.findOptionItemById.mockResolvedValue(null as never);
+
+      await expect(
+        service.sellerDeleteOptionItem(BigInt(1), BigInt(999)),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('유효한 옵션 아이템을 소프트 삭제하고 true를 반환해야 한다', async () => {
+      productRepo.findOptionItemById.mockResolvedValue({
+        id: BigInt(30),
+        option_group_id: BigInt(5),
+        option_group: {
+          product_id: BigInt(10),
+          product: { store_id: BigInt(100) },
+        },
+      } as never);
+      productRepo.softDeleteOptionItem.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerDeleteOptionItem(
+        BigInt(1),
+        BigInt(30),
+      );
+
+      expect(result).toBe(true);
+
+      expect(productRepo.softDeleteOptionItem).toHaveBeenCalledWith(BigInt(30));
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.DELETE,
+        beforeJson: { optionItemId: '30' },
+      });
     });
   });
 
@@ -171,6 +556,65 @@ describe('SellerOptionService', () => {
           optionItemIds: ['1'],
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('유효한 입력으로 옵션 아이템을 정렬하고 결과를 반환해야 한다', async () => {
+      productRepo.findOptionGroupById.mockResolvedValue({
+        id: BigInt(5),
+        product_id: BigInt(10),
+        product: { store_id: BigInt(100) },
+      } as never);
+      productRepo.listOptionItemsByGroup.mockResolvedValue([
+        { id: BigInt(30) },
+        { id: BigInt(31) },
+      ] as never);
+
+      const reorderedRows = [
+        {
+          id: BigInt(31),
+          option_group_id: BigInt(5),
+          title: '아이템B',
+          description: null,
+          image_url: null,
+          price_delta: 0,
+          sort_order: 0,
+          is_active: true,
+        },
+        {
+          id: BigInt(30),
+          option_group_id: BigInt(5),
+          title: '아이템A',
+          description: null,
+          image_url: null,
+          price_delta: 0,
+          sort_order: 1,
+          is_active: true,
+        },
+      ];
+      productRepo.reorderOptionItems.mockResolvedValue(reorderedRows as never);
+
+      const result = await service.sellerReorderOptionItems(BigInt(1), {
+        optionGroupId: '5',
+        optionItemIds: ['31', '30'],
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('31');
+      expect(result[1].id).toBe('30');
+
+      expect(productRepo.reorderOptionItems).toHaveBeenCalledWith({
+        optionGroupId: BigInt(5),
+        optionItemIds: [BigInt(31), BigInt(30)],
+      });
+
+      expect(repo.createAuditLog).toHaveBeenCalledWith({
+        actorAccountId: BigInt(1),
+        storeId: BigInt(100),
+        targetType: AuditTargetType.PRODUCT,
+        targetId: BigInt(10),
+        action: AuditActionType.UPDATE,
+        afterJson: { optionItemIds: ['31', '30'] },
+      });
     });
   });
 });

--- a/src/features/seller/services/seller-order.service.spec.ts
+++ b/src/features/seller/services/seller-order.service.spec.ts
@@ -19,11 +19,21 @@ describe('SellerOrderService', () => {
   let repo: jest.Mocked<SellerRepository>;
   let orderRepo: jest.Mocked<OrderRepository>;
 
+  const SELLER_CONTEXT = {
+    id: BigInt(1),
+    account_type: 'SELLER',
+    status: 'ACTIVE',
+    store: { id: BigInt(100) },
+  };
+
+  const NOW = new Date('2026-03-30T00:00:00.000Z');
+
   beforeEach(async () => {
     repo = {
       findSellerAccountContext: jest.fn(),
     } as unknown as jest.Mocked<SellerRepository>;
     orderRepo = {
+      listOrdersByStore: jest.fn(),
       findOrderDetailByStore: jest.fn(),
       updateOrderStatusBySeller: jest.fn(),
     } as unknown as jest.Mocked<OrderRepository>;
@@ -46,6 +56,8 @@ describe('SellerOrderService', () => {
 
     service = module.get<SellerOrderService>(SellerOrderService);
   });
+
+  // ─── 기존 예외 테스트 ────────────────────────────────────────
 
   it('판매자 계정이 아니면 ForbiddenException을 던져야 한다', async () => {
     repo.findSellerAccountContext.mockResolvedValue({
@@ -112,5 +124,374 @@ describe('SellerOrderService', () => {
     await expect(service.sellerOrder(BigInt(1), BigInt(9999))).rejects.toThrow(
       NotFoundException,
     );
+  });
+
+  // ─── 성공 경로 테스트 ────────────────────────────────────────
+
+  describe('sellerOrderList', () => {
+    it('주문 목록을 커서 기반 페이지네이션으로 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+
+      const orderRows = [
+        {
+          id: BigInt(10),
+          order_number: 'ORD-001',
+          status: OrderStatus.SUBMITTED,
+          pickup_at: NOW,
+          buyer_name: '홍길동',
+          buyer_phone: '010-1234-5678',
+          total_price: 15000,
+          created_at: NOW,
+        },
+        {
+          id: BigInt(9),
+          order_number: 'ORD-002',
+          status: OrderStatus.CONFIRMED,
+          pickup_at: NOW,
+          buyer_name: '김철수',
+          buyer_phone: '010-9876-5432',
+          total_price: 25000,
+          created_at: NOW,
+        },
+      ];
+      orderRepo.listOrdersByStore.mockResolvedValue(orderRows as never);
+
+      const result = await service.sellerOrderList(BigInt(1));
+
+      expect(orderRepo.listOrdersByStore).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        limit: 20,
+      });
+      expect(result).toEqual({
+        items: [
+          {
+            id: '10',
+            orderNumber: 'ORD-001',
+            status: OrderStatus.SUBMITTED,
+            pickupAt: NOW,
+            buyerName: '홍길동',
+            buyerPhone: '010-1234-5678',
+            totalPrice: 15000,
+            createdAt: NOW,
+          },
+          {
+            id: '9',
+            orderNumber: 'ORD-002',
+            status: OrderStatus.CONFIRMED,
+            pickupAt: NOW,
+            buyerName: '김철수',
+            buyerPhone: '010-9876-5432',
+            totalPrice: 25000,
+            createdAt: NOW,
+          },
+        ],
+        nextCursor: null,
+      });
+    });
+
+    it('status 필터를 적용하여 주문 목록을 조회해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      orderRepo.listOrdersByStore.mockResolvedValue([] as never);
+
+      await service.sellerOrderList(BigInt(1), {
+        status: 'SUBMITTED',
+      });
+
+      expect(orderRepo.listOrdersByStore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          storeId: BigInt(100),
+          status: OrderStatus.SUBMITTED,
+        }),
+      );
+    });
+  });
+
+  describe('sellerOrder', () => {
+    it('주문 상세 정보를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+
+      const orderDetailRow = {
+        id: BigInt(10),
+        order_number: 'ORD-001',
+        account_id: BigInt(20),
+        status: OrderStatus.CONFIRMED,
+        pickup_at: NOW,
+        buyer_name: '홍길동',
+        buyer_phone: '010-1234-5678',
+        subtotal_price: 15000,
+        discount_price: 1000,
+        total_price: 14000,
+        submitted_at: NOW,
+        confirmed_at: NOW,
+        made_at: null,
+        picked_up_at: null,
+        canceled_at: null,
+        created_at: NOW,
+        updated_at: NOW,
+        status_histories: [
+          {
+            id: BigInt(1),
+            from_status: OrderStatus.SUBMITTED,
+            to_status: OrderStatus.CONFIRMED,
+            changed_at: NOW,
+            note: null,
+          },
+        ],
+        items: [
+          {
+            id: BigInt(50),
+            store_id: BigInt(100),
+            product_id: BigInt(200),
+            product_name_snapshot: '케이크',
+            regular_price_snapshot: 15000,
+            sale_price_snapshot: null,
+            quantity: 1,
+            item_subtotal_price: 15000,
+            option_items: [
+              {
+                id: BigInt(60),
+                group_name_snapshot: '사이즈',
+                option_title_snapshot: '라지',
+                option_price_delta_snapshot: 3000,
+              },
+            ],
+            custom_texts: [
+              {
+                id: BigInt(70),
+                token_key_snapshot: 'message',
+                default_text_snapshot: '축하합니다',
+                value_text: '생일 축하해요!',
+                sort_order: 0,
+              },
+            ],
+            free_edits: [
+              {
+                id: BigInt(80),
+                crop_image_url: 'https://img.example.com/crop.png',
+                description_text: '자유 편집',
+                sort_order: 0,
+                attachments: [
+                  {
+                    id: BigInt(90),
+                    image_url: 'https://img.example.com/attach.png',
+                    sort_order: 0,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      orderRepo.findOrderDetailByStore.mockResolvedValue(
+        orderDetailRow as never,
+      );
+
+      const result = await service.sellerOrder(BigInt(1), BigInt(10));
+
+      expect(orderRepo.findOrderDetailByStore).toHaveBeenCalledWith({
+        orderId: BigInt(10),
+        storeId: BigInt(100),
+      });
+      expect(result).toEqual({
+        id: '10',
+        orderNumber: 'ORD-001',
+        accountId: '20',
+        status: OrderStatus.CONFIRMED,
+        pickupAt: NOW,
+        buyerName: '홍길동',
+        buyerPhone: '010-1234-5678',
+        subtotalPrice: 15000,
+        discountPrice: 1000,
+        totalPrice: 14000,
+        submittedAt: NOW,
+        confirmedAt: NOW,
+        madeAt: null,
+        pickedUpAt: null,
+        canceledAt: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+        statusHistories: [
+          {
+            id: '1',
+            fromStatus: OrderStatus.SUBMITTED,
+            toStatus: OrderStatus.CONFIRMED,
+            changedAt: NOW,
+            note: null,
+          },
+        ],
+        items: [
+          {
+            id: '50',
+            storeId: '100',
+            productId: '200',
+            productNameSnapshot: '케이크',
+            regularPriceSnapshot: 15000,
+            salePriceSnapshot: null,
+            quantity: 1,
+            itemSubtotalPrice: 15000,
+            optionItems: [
+              {
+                id: '60',
+                groupNameSnapshot: '사이즈',
+                optionTitleSnapshot: '라지',
+                optionPriceDeltaSnapshot: 3000,
+              },
+            ],
+            customTexts: [
+              {
+                id: '70',
+                tokenKeySnapshot: 'message',
+                defaultTextSnapshot: '축하합니다',
+                valueText: '생일 축하해요!',
+                sortOrder: 0,
+              },
+            ],
+            freeEdits: [
+              {
+                id: '80',
+                cropImageUrl: 'https://img.example.com/crop.png',
+                descriptionText: '자유 편집',
+                sortOrder: 0,
+                attachments: [
+                  {
+                    id: '90',
+                    imageUrl: 'https://img.example.com/attach.png',
+                    sortOrder: 0,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('sellerUpdateOrderStatus', () => {
+    it('유효한 상태 전이로 주문 상태를 변경해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+
+      const currentOrder = {
+        id: BigInt(10),
+        order_number: 'ORD-001',
+        account_id: BigInt(20),
+        status: OrderStatus.SUBMITTED,
+        pickup_at: NOW,
+        buyer_name: '홍길동',
+        buyer_phone: '010-1234-5678',
+        subtotal_price: 15000,
+        discount_price: 0,
+        total_price: 15000,
+        submitted_at: NOW,
+        confirmed_at: null,
+        made_at: null,
+        picked_up_at: null,
+        canceled_at: null,
+        created_at: NOW,
+        updated_at: NOW,
+        status_histories: [],
+        items: [],
+      };
+      orderRepo.findOrderDetailByStore.mockResolvedValue(currentOrder as never);
+
+      const updatedOrder = {
+        id: BigInt(10),
+        order_number: 'ORD-001',
+        status: OrderStatus.CONFIRMED,
+        pickup_at: NOW,
+        buyer_name: '홍길동',
+        buyer_phone: '010-1234-5678',
+        total_price: 15000,
+        created_at: NOW,
+      };
+      orderRepo.updateOrderStatusBySeller.mockResolvedValue(
+        updatedOrder as never,
+      );
+
+      const result = await service.sellerUpdateOrderStatus(BigInt(1), {
+        orderId: '10',
+        toStatus: 'CONFIRMED',
+      });
+
+      expect(orderRepo.findOrderDetailByStore).toHaveBeenCalledWith({
+        orderId: BigInt(10),
+        storeId: BigInt(100),
+      });
+      expect(orderRepo.updateOrderStatusBySeller).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: BigInt(10),
+          storeId: BigInt(100),
+          actorAccountId: BigInt(1),
+          toStatus: OrderStatus.CONFIRMED,
+          note: null,
+        }),
+      );
+      expect(result).toEqual({
+        id: '10',
+        orderNumber: 'ORD-001',
+        status: OrderStatus.CONFIRMED,
+        pickupAt: NOW,
+        buyerName: '홍길동',
+        buyerPhone: '010-1234-5678',
+        totalPrice: 15000,
+        createdAt: NOW,
+      });
+    });
+
+    it('취소 시 사유 노트와 함께 상태를 변경해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+
+      const currentOrder = {
+        id: BigInt(10),
+        order_number: 'ORD-001',
+        account_id: BigInt(20),
+        status: OrderStatus.SUBMITTED,
+        pickup_at: NOW,
+        buyer_name: '홍길동',
+        buyer_phone: '010-1234-5678',
+        subtotal_price: 15000,
+        discount_price: 0,
+        total_price: 15000,
+        submitted_at: NOW,
+        confirmed_at: null,
+        made_at: null,
+        picked_up_at: null,
+        canceled_at: null,
+        created_at: NOW,
+        updated_at: NOW,
+        status_histories: [],
+        items: [],
+      };
+      orderRepo.findOrderDetailByStore.mockResolvedValue(currentOrder as never);
+
+      const updatedOrder = {
+        id: BigInt(10),
+        order_number: 'ORD-001',
+        status: OrderStatus.CANCELED,
+        pickup_at: NOW,
+        buyer_name: '홍길동',
+        buyer_phone: '010-1234-5678',
+        total_price: 15000,
+        created_at: NOW,
+      };
+      orderRepo.updateOrderStatusBySeller.mockResolvedValue(
+        updatedOrder as never,
+      );
+
+      const result = await service.sellerUpdateOrderStatus(BigInt(1), {
+        orderId: '10',
+        toStatus: 'CANCELED',
+        note: '재고 부족',
+      });
+
+      expect(orderRepo.updateOrderStatusBySeller).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: BigInt(10),
+          toStatus: OrderStatus.CANCELED,
+          note: '재고 부족',
+        }),
+      );
+      expect(result.status).toBe(OrderStatus.CANCELED);
+    });
   });
 });

--- a/src/features/seller/services/seller-product-crud.service.spec.ts
+++ b/src/features/seller/services/seller-product-crud.service.spec.ts
@@ -5,6 +5,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuditActionType, AuditTargetType } from '@prisma/client';
 
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
@@ -23,6 +24,59 @@ const USER_CONTEXT = {
   status: 'ACTIVE',
   store: { id: BigInt(100) },
 };
+
+const NOW = new Date('2026-03-30T00:00:00.000Z');
+
+/** 상품 상세 조회 결과 픽스처 */
+function makeProductDetailRow(overrides?: Record<string, unknown>) {
+  return {
+    id: BigInt(10),
+    store_id: BigInt(100),
+    name: '테스트 케이크',
+    description: '맛있는 케이크',
+    purchase_notice: '주문 후 3시간 소요',
+    regular_price: 30000,
+    sale_price: 25000,
+    currency: 'KRW',
+    base_design_image_url: null,
+    preparation_time_minutes: 180,
+    is_active: true,
+    created_at: NOW,
+    updated_at: NOW,
+    images: [
+      {
+        id: BigInt(1),
+        image_url: 'https://example.com/img1.png',
+        sort_order: 0,
+      },
+    ],
+    product_categories: [{ category: { id: BigInt(50), name: '케이크' } }],
+    product_tags: [{ tag: { id: BigInt(60), name: '생일' } }],
+    option_groups: [],
+    custom_template: null,
+    ...overrides,
+  };
+}
+
+/** 상품 생성 결과 픽스처 (createProduct 반환값) */
+function makeCreatedProductRow(overrides?: Record<string, unknown>) {
+  return {
+    id: BigInt(10),
+    store_id: BigInt(100),
+    name: '테스트 케이크',
+    regular_price: 30000,
+    sale_price: 25000,
+    currency: 'KRW',
+    description: '맛있는 케이크',
+    purchase_notice: null,
+    base_design_image_url: null,
+    preparation_time_minutes: 180,
+    is_active: true,
+    created_at: NOW,
+    updated_at: NOW,
+    ...overrides,
+  };
+}
 
 describe('SellerProductCrudService', () => {
   let service: SellerProductCrudService;
@@ -91,6 +145,33 @@ describe('SellerProductCrudService', () => {
 
   // ── 상품 CRUD ──
 
+  describe('sellerProducts', () => {
+    it('상품 목록을 커서 페이지네이션으로 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+
+      const row1 = makeProductDetailRow({ id: BigInt(10) });
+      const row2 = makeProductDetailRow({ id: BigInt(11), name: '롤케이크' });
+      productRepo.listProductsByStore.mockResolvedValue([row1, row2] as never);
+
+      const result = await service.sellerProducts(BigInt(1), {
+        limit: 20,
+        cursor: null,
+      });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].id).toBe('10');
+      expect(result.items[1].id).toBe('11');
+      expect(result.nextCursor).toBeNull();
+      expect(productRepo.listProductsByStore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          storeId: BigInt(100),
+          limit: 20,
+          isActive: true,
+        }),
+      );
+    });
+  });
+
   describe('sellerProduct', () => {
     it('상품이 없으면 NotFoundException을 던져야 한다', async () => {
       repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
@@ -99,6 +180,30 @@ describe('SellerProductCrudService', () => {
       await expect(
         service.sellerProduct(BigInt(1), BigInt(999)),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('상품 ID로 단건 조회 결과를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const row = makeProductDetailRow();
+      productRepo.findProductById.mockResolvedValue(row as never);
+
+      const result = await service.sellerProduct(BigInt(1), BigInt(10));
+
+      expect(result.id).toBe('10');
+      expect(result.storeId).toBe('100');
+      expect(result.name).toBe('테스트 케이크');
+      expect(result.regularPrice).toBe(30000);
+      expect(result.salePrice).toBe(25000);
+      expect(result.currency).toBe('KRW');
+      expect(result.images).toHaveLength(1);
+      expect(result.categories).toHaveLength(1);
+      expect(result.categories[0].name).toBe('케이크');
+      expect(result.tags).toHaveLength(1);
+      expect(result.tags[0].name).toBe('생일');
+      expect(productRepo.findProductById).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        storeId: BigInt(100),
+      });
     });
   });
 
@@ -127,6 +232,55 @@ describe('SellerProductCrudService', () => {
         }),
       ).rejects.toThrow(BadRequestException);
     });
+
+    it('유효한 입력이면 상품을 생성하고 결과를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const created = makeCreatedProductRow();
+      productRepo.createProduct.mockResolvedValue(created as never);
+      productRepo.addProductImage.mockResolvedValue({
+        id: BigInt(1),
+        image_url: 'https://example.com/img.png',
+        sort_order: 0,
+      } as never);
+      const detail = makeProductDetailRow();
+      productRepo.findProductByIdIncludingInactive.mockResolvedValue(
+        detail as never,
+      );
+
+      const result = await service.sellerCreateProduct(BigInt(1), {
+        name: '테스트 케이크',
+        regularPrice: 30000,
+        salePrice: 25000,
+        initialImageUrl: 'https://example.com/img.png',
+      });
+
+      expect(result.id).toBe('10');
+      expect(result.name).toBe('테스트 케이크');
+      expect(productRepo.createProduct).toHaveBeenCalledWith(
+        expect.objectContaining({
+          storeId: BigInt(100),
+          data: expect.objectContaining({
+            name: '테스트 케이크',
+            regular_price: 30000,
+            sale_price: 25000,
+          }),
+        }),
+      );
+      expect(productRepo.addProductImage).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        imageUrl: 'https://example.com/img.png',
+        sortOrder: 0,
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.CREATE,
+        }),
+      );
+    });
   });
 
   describe('sellerUpdateProduct', () => {
@@ -143,6 +297,44 @@ describe('SellerProductCrudService', () => {
         }),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('유효한 입력이면 상품을 수정하고 결과를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const current = makeProductDetailRow();
+      const updated = makeCreatedProductRow({ name: '수정된 케이크' });
+      const detail = makeProductDetailRow({ name: '수정된 케이크' });
+
+      // 첫 번째 호출: current 조회, 두 번째 호출: 업데이트 후 detail 조회
+      productRepo.findProductByIdIncludingInactive
+        .mockResolvedValueOnce(current as never)
+        .mockResolvedValueOnce(detail as never);
+      productRepo.updateProduct.mockResolvedValue(updated as never);
+
+      const result = await service.sellerUpdateProduct(BigInt(1), {
+        productId: '10',
+        name: '수정된 케이크',
+      });
+
+      expect(result.id).toBe('10');
+      expect(result.name).toBe('수정된 케이크');
+      expect(productRepo.updateProduct).toHaveBeenCalledWith(
+        expect.objectContaining({
+          productId: BigInt(10),
+          data: expect.objectContaining({ name: '수정된 케이크' }),
+        }),
+      );
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.UPDATE,
+          beforeJson: { name: '테스트 케이크' },
+          afterJson: { name: '수정된 케이크' },
+        }),
+      );
+    });
   });
 
   describe('sellerDeleteProduct', () => {
@@ -155,6 +347,66 @@ describe('SellerProductCrudService', () => {
       await expect(
         service.sellerDeleteProduct(BigInt(1), BigInt(999)),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('상품을 소프트 삭제하고 true를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const current = makeProductDetailRow();
+      productRepo.findProductByIdIncludingInactive.mockResolvedValue(
+        current as never,
+      );
+      productRepo.softDeleteProduct.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerDeleteProduct(BigInt(1), BigInt(10));
+
+      expect(result).toBe(true);
+      expect(productRepo.softDeleteProduct).toHaveBeenCalledWith(BigInt(10));
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.DELETE,
+          beforeJson: { name: '테스트 케이크' },
+        }),
+      );
+    });
+  });
+
+  describe('sellerSetProductActive', () => {
+    it('상품 활성 상태를 변경하고 결과를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const current = makeProductDetailRow({ is_active: true });
+      const detail = makeProductDetailRow({ is_active: false });
+
+      productRepo.findProductByIdIncludingInactive
+        .mockResolvedValueOnce(current as never)
+        .mockResolvedValueOnce(detail as never);
+      productRepo.updateProduct.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerSetProductActive(BigInt(1), {
+        productId: '10',
+        isActive: false,
+      });
+
+      expect(result.id).toBe('10');
+      expect(result.isActive).toBe(false);
+      expect(productRepo.updateProduct).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        data: { is_active: false },
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.STATUS_CHANGE,
+          beforeJson: { isActive: true },
+          afterJson: { isActive: false },
+        }),
+      );
     });
   });
 
@@ -174,6 +426,43 @@ describe('SellerProductCrudService', () => {
           imageUrl: 'https://example.com/img.png',
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('이미지를 추가하고 결과를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      productRepo.findProductByIdIncludingInactive.mockResolvedValue({
+        id: BigInt(10),
+      } as never);
+      productRepo.countProductImages.mockResolvedValue(2 as never);
+      productRepo.addProductImage.mockResolvedValue({
+        id: BigInt(3),
+        image_url: 'https://example.com/new.png',
+        sort_order: 2,
+      } as never);
+
+      const result = await service.sellerAddProductImage(BigInt(1), {
+        productId: '10',
+        imageUrl: 'https://example.com/new.png',
+      });
+
+      expect(result.id).toBe('3');
+      expect(result.imageUrl).toBe('https://example.com/new.png');
+      expect(result.sortOrder).toBe(2);
+      expect(productRepo.addProductImage).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        imageUrl: 'https://example.com/new.png',
+        sortOrder: 2,
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.UPDATE,
+          afterJson: { imageId: '3' },
+        }),
+      );
     });
   });
 
@@ -213,6 +502,37 @@ describe('SellerProductCrudService', () => {
         service.sellerDeleteProductImage(BigInt(1), BigInt(1)),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('이미지를 소프트 삭제하고 true를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      productRepo.findProductImageById.mockResolvedValue({
+        id: BigInt(5),
+        product_id: BigInt(10),
+        product: { store_id: BigInt(100) },
+      } as never);
+      productRepo.countProductImages.mockResolvedValue(3 as never);
+      productRepo.softDeleteProductImage.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerDeleteProductImage(
+        BigInt(1),
+        BigInt(5),
+      );
+
+      expect(result).toBe(true);
+      expect(productRepo.softDeleteProductImage).toHaveBeenCalledWith(
+        BigInt(5),
+      );
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.UPDATE,
+          beforeJson: { imageId: '5' },
+        }),
+      );
+    });
   });
 
   describe('sellerReorderProductImages', () => {
@@ -232,6 +552,150 @@ describe('SellerProductCrudService', () => {
           imageIds: ['1'],
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('이미지 순서를 변경하고 결과를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      productRepo.findProductByIdIncludingInactive.mockResolvedValue({
+        id: BigInt(10),
+      } as never);
+      productRepo.listProductImages.mockResolvedValue([
+        { id: BigInt(1) },
+        { id: BigInt(2) },
+      ] as never);
+      productRepo.reorderProductImages.mockResolvedValue([
+        {
+          id: BigInt(2),
+          image_url: 'https://example.com/img2.png',
+          sort_order: 0,
+        },
+        {
+          id: BigInt(1),
+          image_url: 'https://example.com/img1.png',
+          sort_order: 1,
+        },
+      ] as never);
+
+      const result = await service.sellerReorderProductImages(BigInt(1), {
+        productId: '10',
+        imageIds: ['2', '1'],
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('2');
+      expect(result[0].sortOrder).toBe(0);
+      expect(result[1].id).toBe('1');
+      expect(result[1].sortOrder).toBe(1);
+      expect(productRepo.reorderProductImages).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        imageIds: [BigInt(2), BigInt(1)],
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.UPDATE,
+          afterJson: { imageIds: ['2', '1'] },
+        }),
+      );
+    });
+  });
+
+  // ── 카테고리 / 태그 ──
+
+  describe('sellerSetProductCategories', () => {
+    it('상품에 카테고리를 설정하고 결과를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const product = makeProductDetailRow();
+      const detail = makeProductDetailRow({
+        product_categories: [
+          { category: { id: BigInt(50), name: '케이크' } },
+          { category: { id: BigInt(51), name: '마카롱' } },
+        ],
+      });
+
+      productRepo.findProductByIdIncludingInactive
+        .mockResolvedValueOnce(product as never)
+        .mockResolvedValueOnce(detail as never);
+      productRepo.findCategoryIds.mockResolvedValue([
+        { id: BigInt(50) },
+        { id: BigInt(51) },
+      ] as never);
+      productRepo.replaceProductCategories.mockResolvedValue(
+        undefined as never,
+      );
+
+      const result = await service.sellerSetProductCategories(BigInt(1), {
+        productId: '10',
+        categoryIds: ['50', '51'],
+      });
+
+      expect(result.id).toBe('10');
+      expect(result.categories).toHaveLength(2);
+      expect(result.categories[0].name).toBe('케이크');
+      expect(result.categories[1].name).toBe('마카롱');
+      expect(productRepo.replaceProductCategories).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        categoryIds: [BigInt(50), BigInt(51)],
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.UPDATE,
+          afterJson: { categoryIds: ['50', '51'] },
+        }),
+      );
+    });
+  });
+
+  describe('sellerSetProductTags', () => {
+    it('상품에 태그를 설정하고 결과를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const product = makeProductDetailRow();
+      const detail = makeProductDetailRow({
+        product_tags: [
+          { tag: { id: BigInt(60), name: '생일' } },
+          { tag: { id: BigInt(61), name: '기념일' } },
+        ],
+      });
+
+      productRepo.findProductByIdIncludingInactive
+        .mockResolvedValueOnce(product as never)
+        .mockResolvedValueOnce(detail as never);
+      productRepo.findTagIds.mockResolvedValue([
+        { id: BigInt(60) },
+        { id: BigInt(61) },
+      ] as never);
+      productRepo.replaceProductTags.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerSetProductTags(BigInt(1), {
+        productId: '10',
+        tagIds: ['60', '61'],
+      });
+
+      expect(result.id).toBe('10');
+      expect(result.tags).toHaveLength(2);
+      expect(result.tags[0].name).toBe('생일');
+      expect(result.tags[1].name).toBe('기념일');
+      expect(productRepo.replaceProductTags).toHaveBeenCalledWith({
+        productId: BigInt(10),
+        tagIds: [BigInt(60), BigInt(61)],
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.PRODUCT,
+          targetId: BigInt(10),
+          action: AuditActionType.UPDATE,
+          afterJson: { tagIds: ['60', '61'] },
+        }),
+      );
     });
   });
 });

--- a/src/features/seller/services/seller-store.service.spec.ts
+++ b/src/features/seller/services/seller-store.service.spec.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuditActionType, AuditTargetType, Prisma } from '@prisma/client';
 
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerStoreService } from '@/features/seller/services/seller-store.service';
@@ -27,6 +28,30 @@ const NO_STORE_CONTEXT = {
   account_type: 'SELLER',
   status: 'ACTIVE',
   store: null,
+};
+
+const NOW = new Date('2026-03-30T12:00:00Z');
+
+const STORE_ROW = {
+  id: BigInt(100),
+  seller_account_id: BigInt(1),
+  store_name: '카퀵 베이커리',
+  store_phone: '02-1234-5678',
+  address_full: '서울시 강남구 역삼동 123-45',
+  address_city: '서울시',
+  address_district: '강남구',
+  address_neighborhood: '역삼동',
+  latitude: new Prisma.Decimal('37.4979'),
+  longitude: new Prisma.Decimal('127.0276'),
+  map_provider: 'NAVER' as const,
+  website_url: 'https://caquick.kr',
+  business_hours_text: '매일 09:00~18:00',
+  pickup_slot_interval_minutes: 30,
+  min_lead_time_minutes: 60,
+  max_days_ahead: 7,
+  is_active: true,
+  created_at: NOW,
+  updated_at: NOW,
 };
 
 describe('SellerStoreService', () => {
@@ -101,6 +126,224 @@ describe('SellerStoreService', () => {
         NotFoundException,
       );
     });
+
+    it('정상 조회 시 매장 정보를 변환하여 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      repo.findStoreBySellerAccountId.mockResolvedValue(STORE_ROW as never);
+
+      const result = await service.sellerMyStore(BigInt(1));
+
+      expect(result.id).toBe('100');
+      expect(result.sellerAccountId).toBe('1');
+      expect(result.storeName).toBe('카퀵 베이커리');
+      expect(result.storePhone).toBe('02-1234-5678');
+      expect(result.addressFull).toBe('서울시 강남구 역삼동 123-45');
+      expect(result.addressCity).toBe('서울시');
+      expect(result.latitude).toBe('37.4979');
+      expect(result.longitude).toBe('127.0276');
+      expect(result.mapProvider).toBe('NAVER');
+      expect(result.isActive).toBe(true);
+      expect(repo.findStoreBySellerAccountId).toHaveBeenCalledWith(BigInt(1));
+    });
+  });
+
+  // ─── sellerStoreBusinessHours ───
+
+  describe('sellerStoreBusinessHours', () => {
+    it('정상 조회 시 영업시간 목록을 변환하여 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const rows = [
+        {
+          id: BigInt(1),
+          day_of_week: 0,
+          is_closed: true,
+          open_time: null,
+          close_time: null,
+          created_at: NOW,
+          updated_at: NOW,
+        },
+        {
+          id: BigInt(2),
+          day_of_week: 1,
+          is_closed: false,
+          open_time: new Date('1970-01-01T09:00:00Z'),
+          close_time: new Date('1970-01-01T18:00:00Z'),
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ];
+      repo.listStoreBusinessHours.mockResolvedValue(rows as never);
+
+      const result = await service.sellerStoreBusinessHours(BigInt(1));
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('1');
+      expect(result[0].dayOfWeek).toBe(0);
+      expect(result[0].isClosed).toBe(true);
+      expect(result[0].openTime).toBeNull();
+      expect(result[1].id).toBe('2');
+      expect(result[1].dayOfWeek).toBe(1);
+      expect(result[1].isClosed).toBe(false);
+      expect(result[1].openTime).toEqual(new Date('1970-01-01T09:00:00Z'));
+      expect(result[1].closeTime).toEqual(new Date('1970-01-01T18:00:00Z'));
+      expect(repo.listStoreBusinessHours).toHaveBeenCalledWith(BigInt(100));
+    });
+  });
+
+  // ─── sellerStoreSpecialClosures ───
+
+  describe('sellerStoreSpecialClosures', () => {
+    it('정상 조회 시 특별 휴무 목록과 nextCursor를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const rows = [
+        {
+          id: BigInt(10),
+          closure_date: new Date('2026-04-01'),
+          reason: '정기 휴무',
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ];
+      repo.listStoreSpecialClosures.mockResolvedValue(rows as never);
+
+      const result = await service.sellerStoreSpecialClosures(BigInt(1));
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].id).toBe('10');
+      expect(result.items[0].closureDate).toEqual(new Date('2026-04-01'));
+      expect(result.items[0].reason).toBe('정기 휴무');
+      expect(result.nextCursor).toBeNull();
+      expect(repo.listStoreSpecialClosures).toHaveBeenCalledWith(
+        expect.objectContaining({ storeId: BigInt(100) }),
+      );
+    });
+
+    it('cursor와 limit을 전달하면 정규화된 값으로 repository를 호출해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      repo.listStoreSpecialClosures.mockResolvedValue([] as never);
+
+      await service.sellerStoreSpecialClosures(BigInt(1), {
+        limit: 5,
+        cursor: '50',
+      });
+
+      expect(repo.listStoreSpecialClosures).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        limit: 5,
+        cursor: BigInt(50),
+      });
+    });
+  });
+
+  // ─── sellerStoreDailyCapacities ───
+
+  describe('sellerStoreDailyCapacities', () => {
+    it('정상 조회 시 일별 용량 목록과 nextCursor를 반환해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const rows = [
+        {
+          id: BigInt(20),
+          capacity_date: new Date('2026-04-01'),
+          capacity: 100,
+          created_at: NOW,
+          updated_at: NOW,
+        },
+        {
+          id: BigInt(21),
+          capacity_date: new Date('2026-04-02'),
+          capacity: 150,
+          created_at: NOW,
+          updated_at: NOW,
+        },
+      ];
+      repo.listStoreDailyCapacities.mockResolvedValue(rows as never);
+
+      const result = await service.sellerStoreDailyCapacities(BigInt(1));
+
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].id).toBe('20');
+      expect(result.items[0].capacityDate).toEqual(new Date('2026-04-01'));
+      expect(result.items[0].capacity).toBe(100);
+      expect(result.items[1].id).toBe('21');
+      expect(result.items[1].capacity).toBe(150);
+      expect(result.nextCursor).toBeNull();
+      expect(repo.listStoreDailyCapacities).toHaveBeenCalledWith(
+        expect.objectContaining({ storeId: BigInt(100) }),
+      );
+    });
+
+    it('fromDate/toDate 필터를 전달하면 repository에 전달해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      repo.listStoreDailyCapacities.mockResolvedValue([] as never);
+
+      await service.sellerStoreDailyCapacities(BigInt(1), {
+        limit: 10,
+        cursor: '30',
+        fromDate: new Date('2026-04-01'),
+        toDate: new Date('2026-04-30'),
+      });
+
+      expect(repo.listStoreDailyCapacities).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        limit: 10,
+        cursor: BigInt(30),
+        fromDate: new Date('2026-04-01'),
+        toDate: new Date('2026-04-30'),
+      });
+    });
+  });
+
+  // ─── sellerUpdateStoreBasicInfo ───
+
+  describe('sellerUpdateStoreBasicInfo', () => {
+    it('정상 수정 시 업데이트된 매장 정보를 반환하고 감사 로그를 생성해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      repo.findStoreBySellerAccountId.mockResolvedValue(STORE_ROW as never);
+      const updatedRow = {
+        ...STORE_ROW,
+        store_name: '새 매장명',
+        store_phone: '02-9999-8888',
+        updated_at: new Date('2026-03-30T13:00:00Z'),
+      };
+      repo.updateStore.mockResolvedValue(updatedRow as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerUpdateStoreBasicInfo(BigInt(1), {
+        storeName: '새 매장명',
+        storePhone: '02-9999-8888',
+      });
+
+      expect(result.id).toBe('100');
+      expect(result.storeName).toBe('새 매장명');
+      expect(result.storePhone).toBe('02-9999-8888');
+      expect(repo.updateStore).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        data: expect.objectContaining({
+          store_name: '새 매장명',
+          store_phone: '02-9999-8888',
+        }),
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.STORE,
+          targetId: BigInt(100),
+          action: AuditActionType.UPDATE,
+        }),
+      );
+    });
+
+    it('매장 정보가 없으면 NotFoundException을 던져야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      repo.findStoreBySellerAccountId.mockResolvedValue(null as never);
+
+      await expect(
+        service.sellerUpdateStoreBasicInfo(BigInt(1), {
+          storeName: '새 매장명',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
   });
 
   // ─── sellerUpsertStoreBusinessHour ───
@@ -152,6 +395,79 @@ describe('SellerStoreService', () => {
           closeTime: new Date('1970-01-01T09:00:00Z'),
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('정상 영업일 upsert 시 영업시간을 반환하고 감사 로그를 생성해야 한다', async () => {
+      const bhRow = {
+        id: BigInt(5),
+        day_of_week: 1,
+        is_closed: false,
+        open_time: new Date('1970-01-01T09:00:00Z'),
+        close_time: new Date('1970-01-01T18:00:00Z'),
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      repo.upsertStoreBusinessHour.mockResolvedValue(bhRow as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerUpsertStoreBusinessHour(BigInt(1), {
+        dayOfWeek: 1,
+        isClosed: false,
+        openTime: new Date('1970-01-01T09:00:00Z'),
+        closeTime: new Date('1970-01-01T18:00:00Z'),
+      });
+
+      expect(result.id).toBe('5');
+      expect(result.dayOfWeek).toBe(1);
+      expect(result.isClosed).toBe(false);
+      expect(result.openTime).toEqual(new Date('1970-01-01T09:00:00Z'));
+      expect(result.closeTime).toEqual(new Date('1970-01-01T18:00:00Z'));
+      expect(repo.upsertStoreBusinessHour).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        dayOfWeek: 1,
+        isClosed: false,
+        openTime: new Date('1970-01-01T09:00:00Z'),
+        closeTime: new Date('1970-01-01T18:00:00Z'),
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.STORE,
+          action: AuditActionType.UPDATE,
+        }),
+      );
+    });
+
+    it('휴무일 upsert 시 openTime/closeTime을 null로 저장해야 한다', async () => {
+      const bhRow = {
+        id: BigInt(6),
+        day_of_week: 0,
+        is_closed: true,
+        open_time: null,
+        close_time: null,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      repo.upsertStoreBusinessHour.mockResolvedValue(bhRow as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerUpsertStoreBusinessHour(BigInt(1), {
+        dayOfWeek: 0,
+        isClosed: true,
+        openTime: new Date('1970-01-01T09:00:00Z'),
+        closeTime: new Date('1970-01-01T18:00:00Z'),
+      });
+
+      expect(result.isClosed).toBe(true);
+      expect(result.openTime).toBeNull();
+      expect(repo.upsertStoreBusinessHour).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isClosed: true,
+          openTime: null,
+          closeTime: null,
+        }),
+      );
     });
   });
 
@@ -232,6 +548,42 @@ describe('SellerStoreService', () => {
         service.sellerDeleteStoreSpecialClosure(BigInt(1), BigInt(999)),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('정상 삭제 시 true를 반환하고 감사 로그를 생성해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const closureRow = {
+        id: BigInt(10),
+        closure_date: new Date('2026-04-01'),
+        reason: '정기 휴무',
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      repo.findStoreSpecialClosureById.mockResolvedValue(closureRow as never);
+      repo.softDeleteStoreSpecialClosure.mockResolvedValue(undefined as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerDeleteStoreSpecialClosure(
+        BigInt(1),
+        BigInt(10),
+      );
+
+      expect(result).toBe(true);
+      expect(repo.softDeleteStoreSpecialClosure).toHaveBeenCalledWith(
+        BigInt(10),
+      );
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.STORE,
+          targetId: BigInt(100),
+          action: AuditActionType.DELETE,
+          beforeJson: expect.objectContaining({
+            closureDate: new Date('2026-04-01').toISOString(),
+          }),
+        }),
+      );
+    });
   });
 
   // ─── sellerUpdatePickupPolicy ───
@@ -297,6 +649,57 @@ describe('SellerStoreService', () => {
         ).rejects.toThrow(BadRequestException);
       },
     );
+
+    it('정상 수정 시 업데이트된 매장 정보를 반환하고 감사 로그를 생성해야 한다', async () => {
+      repo.findStoreBySellerAccountId.mockResolvedValue(STORE_ROW as never);
+      const updatedRow = {
+        ...STORE_ROW,
+        pickup_slot_interval_minutes: 15,
+        min_lead_time_minutes: 30,
+        max_days_ahead: 14,
+        updated_at: new Date('2026-03-30T13:00:00Z'),
+      };
+      repo.updateStore.mockResolvedValue(updatedRow as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerUpdatePickupPolicy(BigInt(1), {
+        pickupSlotIntervalMinutes: 15,
+        minLeadTimeMinutes: 30,
+        maxDaysAhead: 14,
+      });
+
+      expect(result.id).toBe('100');
+      expect(result.pickupSlotIntervalMinutes).toBe(15);
+      expect(result.minLeadTimeMinutes).toBe(30);
+      expect(result.maxDaysAhead).toBe(14);
+      expect(repo.updateStore).toHaveBeenCalledWith({
+        storeId: BigInt(100),
+        data: {
+          pickup_slot_interval_minutes: 15,
+          min_lead_time_minutes: 30,
+          max_days_ahead: 14,
+        },
+      });
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.STORE,
+          targetId: BigInt(100),
+          action: AuditActionType.UPDATE,
+          beforeJson: expect.objectContaining({
+            pickupSlotIntervalMinutes: 30,
+            minLeadTimeMinutes: 60,
+            maxDaysAhead: 7,
+          }),
+          afterJson: expect.objectContaining({
+            pickupSlotIntervalMinutes: 15,
+            minLeadTimeMinutes: 30,
+            maxDaysAhead: 14,
+          }),
+        }),
+      );
+    });
   });
 
   // ─── sellerUpsertStoreDailyCapacity ───
@@ -387,6 +790,43 @@ describe('SellerStoreService', () => {
       await expect(
         service.sellerDeleteStoreDailyCapacity(BigInt(1), BigInt(999)),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('정상 삭제 시 true를 반환하고 감사 로그를 생성해야 한다', async () => {
+      repo.findSellerAccountContext.mockResolvedValue(SELLER_CONTEXT as never);
+      const capacityRow = {
+        id: BigInt(20),
+        capacity_date: new Date('2026-04-01'),
+        capacity: 100,
+        created_at: NOW,
+        updated_at: NOW,
+      };
+      repo.findStoreDailyCapacityById.mockResolvedValue(capacityRow as never);
+      repo.softDeleteStoreDailyCapacity.mockResolvedValue(undefined as never);
+      repo.createAuditLog.mockResolvedValue(undefined as never);
+
+      const result = await service.sellerDeleteStoreDailyCapacity(
+        BigInt(1),
+        BigInt(20),
+      );
+
+      expect(result).toBe(true);
+      expect(repo.softDeleteStoreDailyCapacity).toHaveBeenCalledWith(
+        BigInt(20),
+      );
+      expect(repo.createAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorAccountId: BigInt(1),
+          storeId: BigInt(100),
+          targetType: AuditTargetType.STORE,
+          targetId: BigInt(100),
+          action: AuditActionType.DELETE,
+          beforeJson: expect.objectContaining({
+            capacityDate: new Date('2026-04-01').toISOString().slice(0, 10),
+            capacity: 100,
+          }),
+        }),
+      );
     });
   });
 });

--- a/src/features/user/resolvers/user.resolver.spec.ts
+++ b/src/features/user/resolvers/user.resolver.spec.ts
@@ -31,7 +31,7 @@ const mockMePayload: MePayload = {
   accountId: '1',
   email: 'test@example.com',
   name: 'Test User',
-  accountType: 'CONSUMER',
+  accountType: 'USER',
   profile: {
     nickname: 'tester',
     birthDate: null,

--- a/src/features/user/resolvers/user.resolver.spec.ts
+++ b/src/features/user/resolvers/user.resolver.spec.ts
@@ -1,21 +1,310 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { UserEngagementMutationResolver } from '@/features/user/resolvers/user-engagement-mutation.resolver';
 import { UserNotificationMutationResolver } from '@/features/user/resolvers/user-notification-mutation.resolver';
+import { UserNotificationQueryResolver } from '@/features/user/resolvers/user-notification-query.resolver';
+import { UserProfileMutationResolver } from '@/features/user/resolvers/user-profile-mutation.resolver';
 import { UserProfileQueryResolver } from '@/features/user/resolvers/user-profile-query.resolver';
+import { UserSearchMutationResolver } from '@/features/user/resolvers/user-search-mutation.resolver';
+import { UserSearchQueryResolver } from '@/features/user/resolvers/user-search-query.resolver';
+import { UserEngagementService } from '@/features/user/services/user-engagement.service';
 import { UserNotificationService } from '@/features/user/services/user-notification.service';
 import { UserProfileService } from '@/features/user/services/user-profile.service';
+import { UserSearchService } from '@/features/user/services/user-search.service';
+import type {
+  CompleteOnboardingInput,
+  UpdateMyProfileImageInput,
+  UpdateMyProfileInput,
+} from '@/features/user/types/user-input.type';
+import type {
+  MePayload,
+  NotificationConnection,
+  SearchHistoryConnection,
+  ViewerCounts,
+} from '@/features/user/types/user-output.type';
 
-describe('UserResolvers', () => {
-  let queryResolver: UserProfileQueryResolver;
-  let mutationResolver: UserNotificationMutationResolver;
+// ---------------------------------------------------------------------------
+// 공통 mock 데이터
+// ---------------------------------------------------------------------------
+
+const mockMePayload: MePayload = {
+  accountId: '1',
+  email: 'test@example.com',
+  name: 'Test User',
+  accountType: 'CONSUMER',
+  profile: {
+    nickname: 'tester',
+    birthDate: null,
+    phoneNumber: null,
+    profileImageUrl: null,
+    onboardingCompletedAt: null,
+  },
+};
+
+const mockViewerCounts: ViewerCounts = {
+  unreadNotificationCount: 3,
+  cartItemCount: 2,
+  wishlistCount: 5,
+};
+
+const mockNotificationConnection: NotificationConnection = {
+  items: [
+    {
+      id: '10',
+      type: 'SYSTEM',
+      title: 'Welcome',
+      body: 'Welcome to CaQuick!',
+      readAt: null,
+      createdAt: new Date('2026-01-01'),
+    },
+  ],
+  totalCount: 1,
+  hasMore: false,
+};
+
+const mockSearchHistoryConnection: SearchHistoryConnection = {
+  items: [
+    {
+      id: '20',
+      keyword: 'coffee',
+      lastUsedAt: new Date('2026-01-01'),
+    },
+  ],
+  totalCount: 1,
+  hasMore: false,
+};
+
+// ---------------------------------------------------------------------------
+// UserProfileQueryResolver
+// ---------------------------------------------------------------------------
+
+describe('UserProfileQueryResolver', () => {
+  let resolver: UserProfileQueryResolver;
   let profileService: jest.Mocked<UserProfileService>;
-  let notificationService: jest.Mocked<UserNotificationService>;
 
   beforeEach(async () => {
     profileService = {
       me: jest.fn(),
     } as unknown as jest.Mocked<UserProfileService>;
 
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserProfileQueryResolver,
+        { provide: UserProfileService, useValue: profileService },
+      ],
+    }).compile();
+
+    resolver = module.get<UserProfileQueryResolver>(UserProfileQueryResolver);
+  });
+
+  it('me는 accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+    profileService.me.mockResolvedValue(mockMePayload);
+
+    const user = { accountId: '1' };
+    const result = await resolver.me(user);
+
+    expect(profileService.me).toHaveBeenCalledWith(BigInt(1));
+    expect(result).toBe(mockMePayload);
+  });
+
+  it('me는 서비스 에러를 그대로 전파해야 한다', async () => {
+    const error = new Error('User not found');
+    profileService.me.mockRejectedValue(error);
+
+    const user = { accountId: '1' };
+    await expect(resolver.me(user)).rejects.toThrow(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UserProfileMutationResolver
+// ---------------------------------------------------------------------------
+
+describe('UserProfileMutationResolver', () => {
+  let resolver: UserProfileMutationResolver;
+  let profileService: jest.Mocked<UserProfileService>;
+
+  beforeEach(async () => {
+    profileService = {
+      completeOnboarding: jest.fn(),
+      updateMyProfile: jest.fn(),
+      updateMyProfileImage: jest.fn(),
+      deleteMyAccount: jest.fn(),
+    } as unknown as jest.Mocked<UserProfileService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserProfileMutationResolver,
+        { provide: UserProfileService, useValue: profileService },
+      ],
+    }).compile();
+
+    resolver = module.get<UserProfileMutationResolver>(
+      UserProfileMutationResolver,
+    );
+  });
+
+  it('completeOnboarding은 accountId를 BigInt로 변환하고 input을 서비스에 전달해야 한다', async () => {
+    profileService.completeOnboarding.mockResolvedValue(mockMePayload);
+
+    const user = { accountId: '1' };
+    const input: CompleteOnboardingInput = {
+      nickname: 'newbie',
+      name: 'New User',
+      birthDate: new Date('1990-01-01'),
+      phoneNumber: '010-1234-5678',
+    };
+
+    const result = await resolver.completeOnboarding(user, input);
+
+    expect(profileService.completeOnboarding).toHaveBeenCalledWith(
+      BigInt(1),
+      input,
+    );
+    expect(result).toBe(mockMePayload);
+  });
+
+  it('updateMyProfile은 accountId를 BigInt로 변환하고 input을 서비스에 전달해야 한다', async () => {
+    profileService.updateMyProfile.mockResolvedValue(mockMePayload);
+
+    const user = { accountId: '2' };
+    const input: UpdateMyProfileInput = { nickname: 'updated' };
+
+    const result = await resolver.updateMyProfile(user, input);
+
+    expect(profileService.updateMyProfile).toHaveBeenCalledWith(
+      BigInt(2),
+      input,
+    );
+    expect(result).toBe(mockMePayload);
+  });
+
+  it('updateMyProfileImage는 accountId를 BigInt로 변환하고 input을 서비스에 전달해야 한다', async () => {
+    profileService.updateMyProfileImage.mockResolvedValue(mockMePayload);
+
+    const user = { accountId: '3' };
+    const input: UpdateMyProfileImageInput = {
+      profileImageUrl: 'https://example.com/img.png',
+    };
+
+    const result = await resolver.updateMyProfileImage(user, input);
+
+    expect(profileService.updateMyProfileImage).toHaveBeenCalledWith(
+      BigInt(3),
+      input,
+    );
+    expect(result).toBe(mockMePayload);
+  });
+
+  it('deleteMyAccount는 accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+    profileService.deleteMyAccount.mockResolvedValue(true);
+
+    const user = { accountId: '4' };
+    const result = await resolver.deleteMyAccount(user);
+
+    expect(profileService.deleteMyAccount).toHaveBeenCalledWith(BigInt(4));
+    expect(result).toBe(true);
+  });
+
+  it('completeOnboarding은 서비스 에러를 그대로 전파해야 한다', async () => {
+    const error = new Error('Nickname already exists.');
+    profileService.completeOnboarding.mockRejectedValue(error);
+
+    const user = { accountId: '1' };
+    const input: CompleteOnboardingInput = { nickname: 'dup' };
+
+    await expect(resolver.completeOnboarding(user, input)).rejects.toThrow(
+      error,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UserNotificationQueryResolver
+// ---------------------------------------------------------------------------
+
+describe('UserNotificationQueryResolver', () => {
+  let resolver: UserNotificationQueryResolver;
+  let notificationService: jest.Mocked<UserNotificationService>;
+
+  beforeEach(async () => {
+    notificationService = {
+      viewerCounts: jest.fn(),
+      myNotifications: jest.fn(),
+    } as unknown as jest.Mocked<UserNotificationService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserNotificationQueryResolver,
+        { provide: UserNotificationService, useValue: notificationService },
+      ],
+    }).compile();
+
+    resolver = module.get<UserNotificationQueryResolver>(
+      UserNotificationQueryResolver,
+    );
+  });
+
+  it('viewerCounts는 accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+    notificationService.viewerCounts.mockResolvedValue(mockViewerCounts);
+
+    const user = { accountId: '1' };
+    const result = await resolver.viewerCounts(user);
+
+    expect(notificationService.viewerCounts).toHaveBeenCalledWith(BigInt(1));
+    expect(result).toBe(mockViewerCounts);
+  });
+
+  it('myNotifications는 accountId를 BigInt로 변환하고 input을 서비스에 전달해야 한다', async () => {
+    notificationService.myNotifications.mockResolvedValue(
+      mockNotificationConnection,
+    );
+
+    const user = { accountId: '2' };
+    const input = { unreadOnly: true, offset: 0, limit: 10 };
+
+    const result = await resolver.myNotifications(user, input);
+
+    expect(notificationService.myNotifications).toHaveBeenCalledWith(
+      BigInt(2),
+      input,
+    );
+    expect(result).toBe(mockNotificationConnection);
+  });
+
+  it('myNotifications는 input 없이 호출할 수 있어야 한다', async () => {
+    notificationService.myNotifications.mockResolvedValue(
+      mockNotificationConnection,
+    );
+
+    const user = { accountId: '1' };
+    const result = await resolver.myNotifications(user, undefined);
+
+    expect(notificationService.myNotifications).toHaveBeenCalledWith(
+      BigInt(1),
+      undefined,
+    );
+    expect(result).toBe(mockNotificationConnection);
+  });
+
+  it('viewerCounts는 서비스 에러를 그대로 전파해야 한다', async () => {
+    const error = new Error('User not found');
+    notificationService.viewerCounts.mockRejectedValue(error);
+
+    const user = { accountId: '1' };
+    await expect(resolver.viewerCounts(user)).rejects.toThrow(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UserNotificationMutationResolver
+// ---------------------------------------------------------------------------
+
+describe('UserNotificationMutationResolver', () => {
+  let resolver: UserNotificationMutationResolver;
+  let notificationService: jest.Mocked<UserNotificationService>;
+
+  beforeEach(async () => {
     notificationService = {
       markNotificationRead: jest.fn(),
       markAllNotificationsRead: jest.fn(),
@@ -23,41 +312,219 @@ describe('UserResolvers', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        UserProfileQueryResolver,
         UserNotificationMutationResolver,
-        { provide: UserProfileService, useValue: profileService },
         { provide: UserNotificationService, useValue: notificationService },
       ],
     }).compile();
 
-    queryResolver = module.get<UserProfileQueryResolver>(
-      UserProfileQueryResolver,
-    );
-    mutationResolver = module.get<UserNotificationMutationResolver>(
+    resolver = module.get<UserNotificationMutationResolver>(
       UserNotificationMutationResolver,
     );
   });
 
-  it('me는 서비스 호출로 연결되어야 한다', async () => {
-    const user = { accountId: '1' };
-    await queryResolver.me(user);
-    expect(profileService.me).toHaveBeenCalledWith(BigInt(1));
-  });
+  it('markNotificationRead는 notificationId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+    notificationService.markNotificationRead.mockResolvedValue(true);
 
-  it('markNotificationRead는 notificationId를 BigInt로 전달해야 한다', async () => {
     const user = { accountId: '1' };
-    await mutationResolver.markNotificationRead(user, '5');
+    const result = await resolver.markNotificationRead(user, '5');
+
     expect(notificationService.markNotificationRead).toHaveBeenCalledWith(
       BigInt(1),
       BigInt(5),
     );
+    expect(result).toBe(true);
   });
 
-  it('markAllNotificationsRead는 accountId를 전달해야 한다', async () => {
+  it('markAllNotificationsRead는 accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+    notificationService.markAllNotificationsRead.mockResolvedValue(true);
+
     const user = { accountId: '1' };
-    await mutationResolver.markAllNotificationsRead(user);
+    const result = await resolver.markAllNotificationsRead(user);
+
     expect(notificationService.markAllNotificationsRead).toHaveBeenCalledWith(
       BigInt(1),
     );
+    expect(result).toBe(true);
+  });
+
+  it('markNotificationRead는 서비스 에러를 그대로 전파해야 한다', async () => {
+    const error = new Error('Notification not found.');
+    notificationService.markNotificationRead.mockRejectedValue(error);
+
+    const user = { accountId: '1' };
+    await expect(resolver.markNotificationRead(user, '99')).rejects.toThrow(
+      error,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UserSearchQueryResolver
+// ---------------------------------------------------------------------------
+
+describe('UserSearchQueryResolver', () => {
+  let resolver: UserSearchQueryResolver;
+  let searchService: jest.Mocked<UserSearchService>;
+
+  beforeEach(async () => {
+    searchService = {
+      mySearchHistories: jest.fn(),
+    } as unknown as jest.Mocked<UserSearchService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserSearchQueryResolver,
+        { provide: UserSearchService, useValue: searchService },
+      ],
+    }).compile();
+
+    resolver = module.get<UserSearchQueryResolver>(UserSearchQueryResolver);
+  });
+
+  it('mySearchHistories는 accountId를 BigInt로 변환하고 input을 서비스에 전달해야 한다', async () => {
+    searchService.mySearchHistories.mockResolvedValue(
+      mockSearchHistoryConnection,
+    );
+
+    const user = { accountId: '1' };
+    const input = { offset: 0, limit: 10 };
+
+    const result = await resolver.mySearchHistories(user, input);
+
+    expect(searchService.mySearchHistories).toHaveBeenCalledWith(
+      BigInt(1),
+      input,
+    );
+    expect(result).toBe(mockSearchHistoryConnection);
+  });
+
+  it('mySearchHistories는 input 없이 호출할 수 있어야 한다', async () => {
+    searchService.mySearchHistories.mockResolvedValue(
+      mockSearchHistoryConnection,
+    );
+
+    const user = { accountId: '1' };
+    const result = await resolver.mySearchHistories(user, undefined);
+
+    expect(searchService.mySearchHistories).toHaveBeenCalledWith(
+      BigInt(1),
+      undefined,
+    );
+    expect(result).toBe(mockSearchHistoryConnection);
+  });
+
+  it('mySearchHistories는 서비스 에러를 그대로 전파해야 한다', async () => {
+    const error = new Error('User not found');
+    searchService.mySearchHistories.mockRejectedValue(error);
+
+    const user = { accountId: '1' };
+    await expect(resolver.mySearchHistories(user)).rejects.toThrow(error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UserSearchMutationResolver
+// ---------------------------------------------------------------------------
+
+describe('UserSearchMutationResolver', () => {
+  let resolver: UserSearchMutationResolver;
+  let searchService: jest.Mocked<UserSearchService>;
+
+  beforeEach(async () => {
+    searchService = {
+      deleteSearchHistory: jest.fn(),
+      clearSearchHistories: jest.fn(),
+    } as unknown as jest.Mocked<UserSearchService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserSearchMutationResolver,
+        { provide: UserSearchService, useValue: searchService },
+      ],
+    }).compile();
+
+    resolver = module.get<UserSearchMutationResolver>(
+      UserSearchMutationResolver,
+    );
+  });
+
+  it('deleteSearchHistory는 id를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+    searchService.deleteSearchHistory.mockResolvedValue(true);
+
+    const user = { accountId: '1' };
+    const result = await resolver.deleteSearchHistory(user, '7');
+
+    expect(searchService.deleteSearchHistory).toHaveBeenCalledWith(
+      BigInt(1),
+      BigInt(7),
+    );
+    expect(result).toBe(true);
+  });
+
+  it('clearSearchHistories는 accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+    searchService.clearSearchHistories.mockResolvedValue(true);
+
+    const user = { accountId: '2' };
+    const result = await resolver.clearSearchHistories(user);
+
+    expect(searchService.clearSearchHistories).toHaveBeenCalledWith(BigInt(2));
+    expect(result).toBe(true);
+  });
+
+  it('deleteSearchHistory는 서비스 에러를 그대로 전파해야 한다', async () => {
+    const error = new Error('Search history not found.');
+    searchService.deleteSearchHistory.mockRejectedValue(error);
+
+    const user = { accountId: '1' };
+    await expect(resolver.deleteSearchHistory(user, '99')).rejects.toThrow(
+      error,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UserEngagementMutationResolver
+// ---------------------------------------------------------------------------
+
+describe('UserEngagementMutationResolver', () => {
+  let resolver: UserEngagementMutationResolver;
+  let engagementService: jest.Mocked<UserEngagementService>;
+
+  beforeEach(async () => {
+    engagementService = {
+      likeReview: jest.fn(),
+    } as unknown as jest.Mocked<UserEngagementService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserEngagementMutationResolver,
+        { provide: UserEngagementService, useValue: engagementService },
+      ],
+    }).compile();
+
+    resolver = module.get<UserEngagementMutationResolver>(
+      UserEngagementMutationResolver,
+    );
+  });
+
+  it('likeReview는 reviewId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
+    engagementService.likeReview.mockResolvedValue(true);
+
+    const user = { accountId: '1' };
+    const result = await resolver.likeReview(user, '42');
+
+    expect(engagementService.likeReview).toHaveBeenCalledWith(
+      BigInt(1),
+      BigInt(42),
+    );
+    expect(result).toBe(true);
+  });
+
+  it('likeReview는 서비스 에러를 그대로 전파해야 한다', async () => {
+    const error = new Error('Review not found.');
+    engagementService.likeReview.mockRejectedValue(error);
+
+    const user = { accountId: '1' };
+    await expect(resolver.likeReview(user, '99')).rejects.toThrow(error);
   });
 });

--- a/src/prisma/soft-delete.middleware.spec.ts
+++ b/src/prisma/soft-delete.middleware.spec.ts
@@ -54,4 +54,143 @@ describe('soft delete extension', () => {
 
     expect(result).toEqual(params.args);
   });
+
+  it('findMany에 deleted_at 필터를 자동으로 추가해야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: 'Account',
+      operation: 'findMany',
+      args: {
+        where: { email: 'test@example.com' },
+      },
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual({
+      where: { email: 'test@example.com', deleted_at: null },
+    });
+  });
+
+  it('count에 deleted_at 필터를 자동으로 추가해야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: 'Account',
+      operation: 'count',
+      args: {
+        where: { email: 'test@example.com' },
+      },
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual({
+      where: { email: 'test@example.com', deleted_at: null },
+    });
+  });
+
+  it('create 작업에는 필터를 추가하지 않아야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: 'Account',
+      operation: 'create',
+      args: {
+        data: { email: 'test@example.com' },
+      },
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual(params.args);
+  });
+
+  it('update 작업에는 필터를 추가하지 않아야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: 'Account',
+      operation: 'update',
+      args: {
+        where: { id: BigInt(1) },
+        data: { email: 'new@example.com' },
+      },
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual(params.args);
+  });
+
+  it('SOFT_DELETE_MODELS에 없는 모델이면 필터를 추가하지 않아야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: 'NonExistentModel' as Prisma.ModelName,
+      operation: 'findFirst',
+      args: {
+        where: { id: BigInt(1) },
+      },
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual(params.args);
+  });
+
+  it('model이 undefined이면 필터를 추가하지 않아야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: undefined,
+      operation: 'findFirst',
+      args: {
+        where: { id: BigInt(1) },
+      },
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual(params.args);
+  });
+
+  it('args가 undefined이면 정상적으로 처리해야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: 'Account',
+      operation: 'findFirst',
+      args: undefined,
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual({
+      where: { deleted_at: null },
+    });
+  });
+
+  it('where에 deleted_at: null이 이미 있으면 덮어쓰지 않아야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: 'Account',
+      operation: 'findFirst',
+      args: {
+        where: { id: BigInt(1), deleted_at: null },
+      },
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual({
+      where: { id: BigInt(1), deleted_at: null },
+    });
+  });
+
+  it('args의 다른 속성(include, select 등)을 보존해야 한다', () => {
+    const params: SoftDeleteInput = {
+      model: 'Account',
+      operation: 'findFirst',
+      args: {
+        where: { email: 'test@example.com' },
+        include: { UserProfile: true },
+        select: { id: true, email: true },
+      },
+    };
+
+    const result = applySoftDeleteArgs(params);
+
+    expect(result).toEqual({
+      where: { email: 'test@example.com', deleted_at: null },
+      include: { UserProfile: true },
+      select: { id: true, email: true },
+    });
+  });
 });

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -119,4 +119,109 @@ describe('AppController (e2e)', () => {
       },
     });
   });
+
+  it('Authorization 헤더가 없으면 GraphQL me 쿼리는 에러를 반환해야 한다', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: `
+          query Me {
+            me {
+              accountId
+              email
+            }
+          }
+        `,
+      })
+      .expect(200);
+
+    const body = response.body as {
+      data?: { me?: unknown } | null;
+      errors?: Array<{
+        message: string;
+        extensions?: { code?: string };
+      }>;
+    };
+
+    expect(body.errors).toBeDefined();
+    expect(body.errors!.length).toBeGreaterThanOrEqual(1);
+    expect(body.data).toBeNull();
+  });
+
+  it('잘못된 형식의 JWT가 전달되면 GraphQL me 쿼리는 에러를 반환해야 한다', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', 'Bearer this-is-not-a-valid-jwt')
+      .send({
+        query: `
+          query Me {
+            me {
+              accountId
+              email
+            }
+          }
+        `,
+      })
+      .expect(200);
+
+    const body = response.body as {
+      data?: { me?: unknown } | null;
+      errors?: Array<{
+        message: string;
+        extensions?: { code?: string };
+      }>;
+    };
+
+    expect(body.errors).toBeDefined();
+    expect(body.errors!.length).toBeGreaterThanOrEqual(1);
+    expect(body.data).toBeNull();
+  });
+
+  it('만료된 JWT가 전달되면 GraphQL me 쿼리는 에러를 반환해야 한다', async () => {
+    const expiredToken = jwt.sign(
+      { sub: '1', typ: 'access' },
+      { expiresIn: '0s' },
+    );
+
+    // sign 직후에도 exp가 이미 과거이므로 검증 시 만료 처리됨
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .set('Authorization', `Bearer ${expiredToken}`)
+      .send({
+        query: `
+          query Me {
+            me {
+              accountId
+              email
+            }
+          }
+        `,
+      })
+      .expect(200);
+
+    const body = response.body as {
+      data?: { me?: unknown } | null;
+      errors?: Array<{
+        message: string;
+        extensions?: { code?: string };
+      }>;
+    };
+
+    expect(body.errors).toBeDefined();
+    expect(body.errors!.length).toBeGreaterThanOrEqual(1);
+    expect(body.data).toBeNull();
+  });
+
+  it('query 필드가 없는 GraphQL 요청은 에러를 반환해야 한다', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .send({});
+
+    // Apollo Server는 query 필드가 없으면 400 Bad Request를 반환한다
+    expect(response.status).toBe(400);
+  });
+
+  it('/health (HEAD) 요청에 200으로 응답해야 한다', async () => {
+    await request(app.getHttpServer()).head('/health').expect(200);
+  });
 });

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -4,6 +4,7 @@
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "moduleNameMapper": {
+    "^@/(.*)$": "<rootDir>/../src/$1",
     "^src/(.*)$": "<rootDir>/../src/$1"
   },
   "transform": {


### PR DESCRIPTION
## Summary
- 전체 테스트 243개 → 386개로 +143 테스트 추가 (59% 증가)
- Seller 서비스 7개 파일에 성공 경로 테스트 추가 (기존 실패 케이스 전용 → 성공+실패)
- Seller 리졸버 전체 메서드 커버리지 확장 (2 → 71 테스트)
- User 리졸버 전체 메서드 + 반환값 검증 + 에러 전파 테스트
- Auth 리포지토리 미테스트 9개 메서드 추가, mock 반환값 현실화
- Auth seller 서비스 1 → 24 테스트 (sellerLogin/changePassword/refresh/logout)
- E2E 미인증/만료/잘못된 토큰/빈 쿼리 시나리오 추가
- 유틸리티 경계값/엣지케이스 보강 (date-parser, text-cleaner, soft-delete)
- `sellerLogin` password 미trim 버그 수정 (테스트 과정에서 발견)
- PR AI description 워크플로우 임시 비활성화

## Test plan
- [x] `yarn test` — 386 tests, 24 suites 전부 통과
- [x] `yarn lint` — 린트 에러 없음
- [ ] `yarn test:e2e` — E2E 테스트 로컬 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 판매자 로그인 시 비밀번호의 앞뒤 공백을 자동 제거하도록 개선했습니다.

* **테스트**
  * 인증·판매자·사용자 등 주요 영역의 단위/통합 테스트 범위를 대폭 확대했습니다.
  * GraphQL 인증 실패 시나리오 등 엔드투엔드(e2e) 테스트를 추가했습니다.

* **설정**
  * 개발용 모듈 경로 매핑을 추가했습니다.

* **기타**
  * 커밋 전 타입 검사(type-check)를 추가하여 코드 품질 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->