### PR TITLE
feat: S3 Presigned URL 업로드 모듈 구축 (STAGE 2)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,7 @@ import { AuthGlobalModule } from '@/global/auth/auth-global.module';
 import { GraphqlGlobalModule } from '@/global/graphql/graphql.module';
 import { LoggerModule } from '@/global/logger/logger.module';
 import { DocsAccessMiddleware } from '@/global/middlewares/docs-access.middleware';
+import { StorageModule } from '@/global/storage/storage.module';
 import { PrismaModule } from '@/prisma';
 
 @Module({
@@ -44,6 +45,7 @@ import { PrismaModule } from '@/prisma';
     LoggerModule,
     AuthGlobalModule,
     GraphqlGlobalModule,
+    StorageModule,
     GraphQLModule.forRootAsync<ApolloDriverConfig>({
       driver: ApolloDriver,
       inject: [ConfigService],

--- a/src/global/storage/constants/storage.constants.ts
+++ b/src/global/storage/constants/storage.constants.ts
@@ -1,0 +1,35 @@
+import type {
+  UploadPolicy,
+  UploadPurpose,
+} from '@/global/storage/types/storage.types';
+
+/**
+ * 업로드 목적별 정책
+ */
+export const UPLOAD_POLICIES: Record<UploadPurpose, UploadPolicy> = {
+  PROFILE_IMAGE: {
+    keyPrefix: 'profile-images',
+    maxSizeBytes: 5 * 1024 * 1024, // 5MB
+    allowedContentTypes: ['image/jpeg', 'image/png', 'image/webp'],
+  },
+  REVIEW_IMAGE: {
+    keyPrefix: 'review-media/images',
+    maxSizeBytes: 10 * 1024 * 1024, // 10MB
+    allowedContentTypes: ['image/jpeg', 'image/png', 'image/webp'],
+  },
+  REVIEW_VIDEO: {
+    keyPrefix: 'review-media/videos',
+    maxSizeBytes: 50 * 1024 * 1024, // 50MB
+    allowedContentTypes: ['video/mp4', 'video/quicktime'],
+  },
+} as const;
+
+/**
+ * 스토리지 에러 메시지
+ */
+export const STORAGE_ERRORS = {
+  INVALID_CONTENT_TYPE: '허용되지 않은 파일 형식입니다.',
+  FILE_TOO_LARGE: '파일 용량이 허용 한도를 초과했습니다.',
+  S3_PRESIGN_FAILED: '업로드 URL 생성에 실패했습니다.',
+  INVALID_CONTENT_LENGTH: '파일 용량은 0보다 커야 합니다.',
+} as const;

--- a/src/global/storage/s3.service.spec.ts
+++ b/src/global/storage/s3.service.spec.ts
@@ -1,4 +1,7 @@
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -230,7 +233,7 @@ describe('S3Service', () => {
     });
 
     describe('S3 presign 실패', () => {
-      it('getSignedUrl 실패 시 BadRequestException을 던져야 한다', async () => {
+      it('getSignedUrl 실패 시 InternalServerErrorException을 던져야 한다', async () => {
         const { getSignedUrl: mockGetSignedUrl } = jest.requireMock<
           typeof import('@aws-sdk/s3-request-presigner')
         >('@aws-sdk/s3-request-presigner');

--- a/src/global/storage/s3.service.spec.ts
+++ b/src/global/storage/s3.service.spec.ts
@@ -1,0 +1,268 @@
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { STORAGE_ERRORS } from '@/global/storage/constants/storage.constants';
+import { S3Service } from '@/global/storage/s3.service';
+
+// getSignedUrl을 모킹
+jest.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: jest.fn().mockResolvedValue('https://mock-presigned-url.com'),
+}));
+
+// S3Client를 모킹
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({})),
+  PutObjectCommand: jest.fn().mockImplementation((input) => input),
+}));
+
+describe('S3Service', () => {
+  let service: S3Service;
+
+  const mockConfig = {
+    region: 'ap-northeast-2',
+    bucket: 'caquick-media-test',
+    accessKeyId: 'test-key',
+    secretAccessKey: 'test-secret',
+    presignExpiresSeconds: 600,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        S3Service,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(mockConfig) },
+        },
+      ],
+    }).compile();
+
+    service = module.get<S3Service>(S3Service);
+  });
+
+  describe('createUploadUrl', () => {
+    const baseInput = {
+      accountId: BigInt(1),
+      purpose: 'PROFILE_IMAGE' as const,
+      contentType: 'image/jpeg',
+      contentLength: 1024 * 1024, // 1MB
+    };
+
+    it('유효한 입력이면 Presigned URL을 반환해야 한다', async () => {
+      const result = await service.createUploadUrl(baseInput);
+
+      expect(result.uploadUrl).toBe('https://mock-presigned-url.com');
+      expect(result.publicUrl).toContain('caquick-media-test');
+      expect(result.publicUrl).toContain('profile-images/1/');
+      expect(result.publicUrl).toEndWith('.jpg');
+      expect(result.key).toContain('profile-images/1/');
+      expect(result.expiresInSeconds).toBe(600);
+    });
+
+    it('key 형식이 {prefix}/{accountId}/{date}/{uuid}.{ext}여야 한다', async () => {
+      const result = await service.createUploadUrl(baseInput);
+      const keyPattern =
+        /^profile-images\/1\/\d{4}-\d{2}-\d{2}\/[a-f0-9-]+\.jpg$/;
+      expect(result.key).toMatch(keyPattern);
+    });
+
+    it('publicUrl이 올바른 S3 URL 형식이어야 한다', async () => {
+      const result = await service.createUploadUrl(baseInput);
+      expect(result.publicUrl).toBe(
+        `https://caquick-media-test.s3.ap-northeast-2.amazonaws.com/${result.key}`,
+      );
+    });
+
+    describe('PROFILE_IMAGE purpose', () => {
+      it('image/jpeg을 허용해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({ ...baseInput, contentType: 'image/jpeg' }),
+        ).resolves.toBeDefined();
+      });
+
+      it('image/png을 허용해야 한다', async () => {
+        const result = await service.createUploadUrl({
+          ...baseInput,
+          contentType: 'image/png',
+        });
+        expect(result.key).toEndWith('.png');
+      });
+
+      it('image/webp을 허용해야 한다', async () => {
+        const result = await service.createUploadUrl({
+          ...baseInput,
+          contentType: 'image/webp',
+        });
+        expect(result.key).toEndWith('.webp');
+      });
+
+      it('허용되지 않은 contentType이면 거부해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({ ...baseInput, contentType: 'image/gif' }),
+        ).rejects.toThrow(BadRequestException);
+      });
+
+      it('5MB 초과하면 거부해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({
+            ...baseInput,
+            contentLength: 6 * 1024 * 1024,
+          }),
+        ).rejects.toThrow(BadRequestException);
+      });
+
+      it('5MB 이하이면 허용해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({
+            ...baseInput,
+            contentLength: 5 * 1024 * 1024,
+          }),
+        ).resolves.toBeDefined();
+      });
+    });
+
+    describe('REVIEW_IMAGE purpose', () => {
+      const reviewImageInput = {
+        ...baseInput,
+        purpose: 'REVIEW_IMAGE' as const,
+      };
+
+      it('10MB 이하이면 허용해야 한다', async () => {
+        const result = await service.createUploadUrl({
+          ...reviewImageInput,
+          contentLength: 10 * 1024 * 1024,
+        });
+        expect(result.key).toContain('review-media/images/');
+      });
+
+      it('10MB 초과하면 거부해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({
+            ...reviewImageInput,
+            contentLength: 11 * 1024 * 1024,
+          }),
+        ).rejects.toThrow(BadRequestException);
+      });
+    });
+
+    describe('REVIEW_VIDEO purpose', () => {
+      const reviewVideoInput = {
+        ...baseInput,
+        purpose: 'REVIEW_VIDEO' as const,
+        contentType: 'video/mp4',
+      };
+
+      it('video/mp4을 허용해야 한다', async () => {
+        const result = await service.createUploadUrl(reviewVideoInput);
+        expect(result.key).toContain('review-media/videos/');
+        expect(result.key).toEndWith('.mp4');
+      });
+
+      it('video/quicktime을 허용해야 한다', async () => {
+        const result = await service.createUploadUrl({
+          ...reviewVideoInput,
+          contentType: 'video/quicktime',
+        });
+        expect(result.key).toEndWith('.mov');
+      });
+
+      it('50MB 이하이면 허용해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({
+            ...reviewVideoInput,
+            contentLength: 50 * 1024 * 1024,
+          }),
+        ).resolves.toBeDefined();
+      });
+
+      it('50MB 초과하면 거부해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({
+            ...reviewVideoInput,
+            contentLength: 51 * 1024 * 1024,
+          }),
+        ).rejects.toThrow(BadRequestException);
+      });
+
+      it('이미지 contentType이면 거부해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({
+            ...reviewVideoInput,
+            contentType: 'image/jpeg',
+          }),
+        ).rejects.toThrow(BadRequestException);
+      });
+    });
+
+    describe('contentLength 검증', () => {
+      it('0이면 거부해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({ ...baseInput, contentLength: 0 }),
+        ).rejects.toThrow(STORAGE_ERRORS.INVALID_CONTENT_LENGTH);
+      });
+
+      it('음수이면 거부해야 한다', async () => {
+        await expect(
+          service.createUploadUrl({ ...baseInput, contentLength: -1 }),
+        ).rejects.toThrow(STORAGE_ERRORS.INVALID_CONTENT_LENGTH);
+      });
+    });
+
+    describe('에러 메시지 검증', () => {
+      it('허용되지 않은 contentType 에러에 허용 목록이 포함되어야 한다', async () => {
+        await expect(
+          service.createUploadUrl({
+            ...baseInput,
+            contentType: 'application/pdf',
+          }),
+        ).rejects.toThrow('허용되지 않은 파일 형식입니다.');
+      });
+
+      it('용량 초과 에러에 최대 크기가 포함되어야 한다', async () => {
+        await expect(
+          service.createUploadUrl({
+            ...baseInput,
+            contentLength: 100 * 1024 * 1024,
+          }),
+        ).rejects.toThrow('최대 5MB');
+      });
+    });
+
+    describe('S3 presign 실패', () => {
+      it('getSignedUrl 실패 시 BadRequestException을 던져야 한다', async () => {
+        const { getSignedUrl: mockGetSignedUrl } = jest.requireMock<
+          typeof import('@aws-sdk/s3-request-presigner')
+        >('@aws-sdk/s3-request-presigner');
+        (mockGetSignedUrl as jest.Mock).mockRejectedValueOnce(
+          new Error('S3 error'),
+        );
+
+        await expect(service.createUploadUrl(baseInput)).rejects.toThrow(
+          STORAGE_ERRORS.S3_PRESIGN_FAILED,
+        );
+      });
+    });
+  });
+});
+
+// Jest 커스텀 매처
+expect.extend({
+  toEndWith(received: string, suffix: string) {
+    const pass = received.endsWith(suffix);
+    return {
+      pass,
+      message: () =>
+        `expected "${received}" ${pass ? 'not ' : ''}to end with "${suffix}"`,
+    };
+  },
+});
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      toEndWith(suffix: string): R;
+    }
+  }
+}

--- a/src/global/storage/s3.service.ts
+++ b/src/global/storage/s3.service.ts
@@ -3,7 +3,11 @@ import { extname } from 'node:path';
 
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 import type { S3Config } from '@/config/s3.config';
@@ -94,7 +98,7 @@ export class S3Service {
         expiresInSeconds: this.presignExpiresSeconds,
       };
     } catch {
-      throw new BadRequestException(STORAGE_ERRORS.S3_PRESIGN_FAILED);
+      throw new InternalServerErrorException(STORAGE_ERRORS.S3_PRESIGN_FAILED);
     }
   }
 

--- a/src/global/storage/s3.service.ts
+++ b/src/global/storage/s3.service.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from 'node:crypto';
+import { extname } from 'node:path';
+
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import type { S3Config } from '@/config/s3.config';
+import {
+  STORAGE_ERRORS,
+  UPLOAD_POLICIES,
+} from '@/global/storage/constants/storage.constants';
+import type {
+  CreateUploadUrlInput,
+  CreateUploadUrlOutput,
+} from '@/global/storage/types/storage.types';
+
+/**
+ * Content-Type에서 확장자를 추출하는 맵
+ */
+const CONTENT_TYPE_TO_EXT: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'video/mp4': '.mp4',
+  'video/quicktime': '.mov',
+};
+
+@Injectable()
+export class S3Service {
+  private readonly client: S3Client;
+  private readonly bucket: string;
+  private readonly region: string;
+  private readonly presignExpiresSeconds: number;
+
+  constructor(private readonly configService: ConfigService) {
+    const config = this.configService.get<S3Config>('s3')!;
+
+    this.bucket = config.bucket;
+    this.region = config.region;
+    this.presignExpiresSeconds = config.presignExpiresSeconds;
+
+    this.client = new S3Client({
+      region: config.region,
+      ...(config.accessKeyId && config.secretAccessKey
+        ? {
+            credentials: {
+              accessKeyId: config.accessKeyId,
+              secretAccessKey: config.secretAccessKey,
+            },
+          }
+        : {}),
+    });
+  }
+
+  /**
+   * Presigned PUT URL을 발급한다.
+   *
+   * 1. purpose별 정책(크기/타입) 검증
+   * 2. S3 key 생성
+   * 3. Presigned URL 발급
+   */
+  async createUploadUrl(
+    input: CreateUploadUrlInput,
+  ): Promise<CreateUploadUrlOutput> {
+    const policy = UPLOAD_POLICIES[input.purpose];
+
+    this.validateContentType(input.contentType, policy.allowedContentTypes);
+    this.validateContentLength(input.contentLength, policy.maxSizeBytes);
+
+    const key = this.buildKey(
+      policy.keyPrefix,
+      input.accountId,
+      input.contentType,
+    );
+
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+      ContentType: input.contentType,
+      ContentLength: input.contentLength,
+    });
+
+    try {
+      const uploadUrl = await getSignedUrl(this.client, command, {
+        expiresIn: this.presignExpiresSeconds,
+      });
+
+      return {
+        uploadUrl,
+        publicUrl: this.buildPublicUrl(key),
+        key,
+        expiresInSeconds: this.presignExpiresSeconds,
+      };
+    } catch {
+      throw new BadRequestException(STORAGE_ERRORS.S3_PRESIGN_FAILED);
+    }
+  }
+
+  private validateContentType(
+    contentType: string,
+    allowedTypes: readonly string[],
+  ): void {
+    if (!allowedTypes.includes(contentType)) {
+      throw new BadRequestException(
+        `${STORAGE_ERRORS.INVALID_CONTENT_TYPE} (허용: ${allowedTypes.join(', ')})`,
+      );
+    }
+  }
+
+  private validateContentLength(
+    contentLength: number,
+    maxSizeBytes: number,
+  ): void {
+    if (contentLength <= 0) {
+      throw new BadRequestException(STORAGE_ERRORS.INVALID_CONTENT_LENGTH);
+    }
+    if (contentLength > maxSizeBytes) {
+      const maxMB = Math.round(maxSizeBytes / (1024 * 1024));
+      throw new BadRequestException(
+        `${STORAGE_ERRORS.FILE_TOO_LARGE} (최대 ${maxMB}MB)`,
+      );
+    }
+  }
+
+  /**
+   * S3 key 생성 규칙: {prefix}/{accountId}/{yyyy-mm-dd}/{uuid}.{ext}
+   */
+  private buildKey(
+    prefix: string,
+    accountId: bigint,
+    contentType: string,
+  ): string {
+    const date = new Date().toISOString().slice(0, 10); // yyyy-mm-dd
+    const uuid = randomUUID();
+    const ext = CONTENT_TYPE_TO_EXT[contentType] ?? '.bin';
+    return `${prefix}/${accountId.toString()}/${date}/${uuid}${ext}`;
+  }
+
+  private buildPublicUrl(key: string): string {
+    return `https://${this.bucket}.s3.${this.region}.amazonaws.com/${key}`;
+  }
+}

--- a/src/global/storage/storage.module.ts
+++ b/src/global/storage/storage.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+
+import { S3Service } from '@/global/storage/s3.service';
+
+@Global()
+@Module({
+  providers: [S3Service],
+  exports: [S3Service],
+})
+export class StorageModule {}

--- a/src/global/storage/types/storage.types.ts
+++ b/src/global/storage/types/storage.types.ts
@@ -1,0 +1,37 @@
+/**
+ * 업로드 목적 (purpose별 정책이 달라짐)
+ */
+export type UploadPurpose = 'PROFILE_IMAGE' | 'REVIEW_IMAGE' | 'REVIEW_VIDEO';
+
+/**
+ * Presigned URL 발급 요청 입력
+ */
+export interface CreateUploadUrlInput {
+  accountId: bigint;
+  purpose: UploadPurpose;
+  contentType: string;
+  contentLength: number;
+}
+
+/**
+ * Presigned URL 발급 결과
+ */
+export interface CreateUploadUrlOutput {
+  /** Presigned PUT URL (클라이언트가 이 URL로 직접 업로드) */
+  uploadUrl: string;
+  /** 업로드 완료 후 접근 가능한 공개 URL */
+  publicUrl: string;
+  /** S3 object key */
+  key: string;
+  /** URL 만료 시간(초) */
+  expiresInSeconds: number;
+}
+
+/**
+ * 업로드 정책 정의
+ */
+export interface UploadPolicy {
+  keyPrefix: string;
+  maxSizeBytes: number;
+  allowedContentTypes: readonly string[];
+}


### PR DESCRIPTION
## Summary
- **S3Service** 신규: purpose별 정책(크기/타입) 검증 + Presigned PUT URL 발급
- **StorageModule**: `@Global()`로 등록하여 모든 feature에서 DI 가능
- 업로드 정책 상수화:
  - `PROFILE_IMAGE`: 5MB, jpeg/png/webp
  - `REVIEW_IMAGE`: 10MB, jpeg/png/webp
  - `REVIEW_VIDEO`: 50MB, mp4/quicktime
- S3 key 규칙: `{prefix}/{accountId}/{yyyy-mm-dd}/{uuid}.{ext}`
- `ConfigService`로 S3 설정 주입 (STAGE 0에서 추가한 `s3.config.ts` 활용)

## 신규 파일
- `src/global/storage/storage.module.ts`
- `src/global/storage/s3.service.ts`
- `src/global/storage/s3.service.spec.ts`
- `src/global/storage/constants/storage.constants.ts`
- `src/global/storage/types/storage.types.ts`

## 수정 파일
- `src/app.module.ts` — `StorageModule` import 추가

## Test plan
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `yarn test` 전체 408 테스트 통과 (기존 387 + S3 신규 21)
- [x] PR 리뷰 후 develop 머지