### PR TITLE
feat: 유저 주문 목록 조회 API 구현 (STAGE 4)

### DIFF
--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -9,6 +9,23 @@ import {
 
 import { PrismaService } from '@/prisma';
 
+export interface MyOrderRow {
+  id: bigint;
+  order_number: string;
+  status: OrderStatus;
+  created_at: Date;
+  pickup_at: Date;
+  total_price: number;
+  items: {
+    product_name_snapshot: string;
+    store: { store_name: string };
+    product: {
+      images: { image_url: string }[];
+    };
+  }[];
+  _count: { items: number };
+}
+
 export interface OngoingOrderRow {
   id: bigint;
   order_number: string;
@@ -61,6 +78,66 @@ export class OrderRepository {
             },
           },
         },
+      },
+    });
+  }
+
+  async findOrdersByAccount(args: {
+    accountId: bigint;
+    statuses?: OrderStatus[];
+    offset: number;
+    limit: number;
+  }): Promise<MyOrderRow[]> {
+    const where = {
+      account_id: args.accountId,
+      ...(args.statuses && args.statuses.length > 0
+        ? { status: { in: args.statuses } }
+        : {}),
+    };
+
+    return this.prisma.order.findMany({
+      where,
+      orderBy: { created_at: 'desc' },
+      skip: args.offset,
+      take: args.limit,
+      include: {
+        items: {
+          where: { deleted_at: null },
+          orderBy: { id: 'asc' },
+          take: 1,
+          include: {
+            store: {
+              select: { store_name: true },
+            },
+            product: {
+              select: {
+                images: {
+                  where: { deleted_at: null },
+                  orderBy: { sort_order: 'asc' },
+                  take: 1,
+                  select: { image_url: true },
+                },
+              },
+            },
+          },
+        },
+        _count: {
+          select: { items: { where: { deleted_at: null } } },
+        },
+      },
+    });
+  }
+
+  async countOrdersByAccount(args: {
+    accountId: bigint;
+    statuses?: OrderStatus[];
+  }): Promise<number> {
+    return this.prisma.order.count({
+      where: {
+        account_id: args.accountId,
+        ...(args.statuses && args.statuses.length > 0
+          ? { status: { in: args.statuses } }
+          : {}),
       },
     });
   }

--- a/src/features/user/constants/user-order-error-messages.ts
+++ b/src/features/user/constants/user-order-error-messages.ts
@@ -1,0 +1,4 @@
+export const USER_ORDER_ERRORS = {
+  INVALID_LIMIT: '조회 개수는 1~50 사이여야 합니다.',
+  INVALID_OFFSET: '오프셋은 0 이상이어야 합니다.',
+} as const;

--- a/src/features/user/resolvers/user-order-query.resolver.ts
+++ b/src/features/user/resolvers/user-order-query.resolver.ts
@@ -1,0 +1,27 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { UserOrderService } from '@/features/user/services/user-order.service';
+import type { MyOrdersInput } from '@/features/user/types/user-order-input.type';
+import type { MyOrderConnection } from '@/features/user/types/user-order-output.type';
+import {
+  CurrentUser,
+  JwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+@Resolver('Query')
+@UseGuards(JwtAuthGuard)
+export class UserOrderQueryResolver {
+  constructor(private readonly orderService: UserOrderService) {}
+
+  @Query('myOrders')
+  myOrders(
+    @CurrentUser() user: JwtUser,
+    @Args('input') input?: MyOrdersInput,
+  ): Promise<MyOrderConnection> {
+    const accountId = parseAccountId(user);
+    return this.orderService.listMyOrders(accountId, input);
+  }
+}

--- a/src/features/user/services/user-order.service.spec.ts
+++ b/src/features/user/services/user-order.service.spec.ts
@@ -1,0 +1,180 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrderStatus } from '@prisma/client';
+
+import { OrderRepository } from '@/features/order/repositories/order.repository';
+import { USER_ORDER_ERRORS } from '@/features/user/constants/user-order-error-messages';
+import { UserOrderService } from '@/features/user/services/user-order.service';
+
+describe('UserOrderService', () => {
+  let service: UserOrderService;
+  let orderRepo: jest.Mocked<OrderRepository>;
+
+  const accountId = BigInt(1);
+
+  const makeMockOrder = (overrides: {
+    id?: bigint;
+    status?: OrderStatus;
+    storeName?: string;
+    productName?: string;
+    imageUrl?: string | null;
+    itemCount?: number;
+  }) => ({
+    id: overrides.id ?? BigInt(100),
+    order_number: 'CQ-20260413-00001',
+    status: overrides.status ?? OrderStatus.SUBMITTED,
+    created_at: new Date('2026-04-10'),
+    pickup_at: new Date('2026-04-15'),
+    total_price: 35000,
+    items: [
+      {
+        product_name_snapshot: overrides.productName ?? '딸기 케이크',
+        store: { store_name: overrides.storeName ?? '스웨이드 베이커리' },
+        product: {
+          images:
+            overrides.imageUrl !== null
+              ? [
+                  {
+                    image_url:
+                      overrides.imageUrl ?? 'https://s3.example.com/cake.jpg',
+                  },
+                ]
+              : [],
+        },
+      },
+    ],
+    _count: { items: overrides.itemCount ?? 1 },
+  });
+
+  beforeEach(async () => {
+    orderRepo = {
+      findOrdersByAccount: jest.fn(),
+      countOrdersByAccount: jest.fn(),
+    } as unknown as jest.Mocked<OrderRepository>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserOrderService,
+        { provide: OrderRepository, useValue: orderRepo },
+      ],
+    }).compile();
+
+    service = module.get<UserOrderService>(UserOrderService);
+  });
+
+  it('기본 입력으로 주문 목록을 반환해야 한다', async () => {
+    const mockOrder = makeMockOrder({});
+    orderRepo.findOrdersByAccount.mockResolvedValue([mockOrder]);
+    orderRepo.countOrdersByAccount.mockResolvedValue(1);
+
+    const result = await service.listMyOrders(accountId);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.totalCount).toBe(1);
+    expect(result.hasMore).toBe(false);
+    expect(result.items[0]).toMatchObject({
+      orderId: '100',
+      orderNumber: 'CQ-20260413-00001',
+      status: OrderStatus.SUBMITTED,
+      representativeProductName: '딸기 케이크',
+      representativeProductImageUrl: 'https://s3.example.com/cake.jpg',
+      storeName: '스웨이드 베이커리',
+      totalPrice: 35000,
+      additionalItemCount: 0,
+    });
+  });
+
+  it('상태 필터가 전달되면 repository에 전달해야 한다', async () => {
+    orderRepo.findOrdersByAccount.mockResolvedValue([]);
+    orderRepo.countOrdersByAccount.mockResolvedValue(0);
+
+    await service.listMyOrders(accountId, {
+      statuses: [OrderStatus.SUBMITTED, OrderStatus.CONFIRMED],
+      offset: 0,
+      limit: 20,
+    });
+
+    expect(orderRepo.findOrdersByAccount).toHaveBeenCalledWith({
+      accountId,
+      statuses: [OrderStatus.SUBMITTED, OrderStatus.CONFIRMED],
+      offset: 0,
+      limit: 21,
+    });
+    expect(orderRepo.countOrdersByAccount).toHaveBeenCalledWith({
+      accountId,
+      statuses: [OrderStatus.SUBMITTED, OrderStatus.CONFIRMED],
+    });
+  });
+
+  it('limit+1개가 반환되면 hasMore가 true여야 한다', async () => {
+    const orders = Array.from({ length: 21 }, (_, i) =>
+      makeMockOrder({ id: BigInt(i + 1) }),
+    );
+    orderRepo.findOrdersByAccount.mockResolvedValue(orders);
+    orderRepo.countOrdersByAccount.mockResolvedValue(25);
+
+    const result = await service.listMyOrders(accountId, { limit: 20 });
+
+    expect(result.items).toHaveLength(20);
+    expect(result.hasMore).toBe(true);
+    expect(result.totalCount).toBe(25);
+  });
+
+  it('limit 미만이면 hasMore가 false여야 한다', async () => {
+    orderRepo.findOrdersByAccount.mockResolvedValue([makeMockOrder({})]);
+    orderRepo.countOrdersByAccount.mockResolvedValue(1);
+
+    const result = await service.listMyOrders(accountId, { limit: 20 });
+
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('additionalItemCount는 전체 아이템 수 - 1이어야 한다', async () => {
+    const mockOrder = makeMockOrder({ itemCount: 3 });
+    orderRepo.findOrdersByAccount.mockResolvedValue([mockOrder]);
+    orderRepo.countOrdersByAccount.mockResolvedValue(1);
+
+    const result = await service.listMyOrders(accountId);
+
+    expect(result.items[0].additionalItemCount).toBe(2);
+  });
+
+  it('이미지가 없으면 representativeProductImageUrl이 null이어야 한다', async () => {
+    const mockOrder = makeMockOrder({ imageUrl: null });
+    orderRepo.findOrdersByAccount.mockResolvedValue([mockOrder]);
+    orderRepo.countOrdersByAccount.mockResolvedValue(1);
+
+    const result = await service.listMyOrders(accountId);
+
+    expect(result.items[0].representativeProductImageUrl).toBeNull();
+  });
+
+  it('빈 목록도 정상 반환해야 한다', async () => {
+    orderRepo.findOrdersByAccount.mockResolvedValue([]);
+    orderRepo.countOrdersByAccount.mockResolvedValue(0);
+
+    const result = await service.listMyOrders(accountId);
+
+    expect(result.items).toHaveLength(0);
+    expect(result.totalCount).toBe(0);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('limit이 50 초과이면 에러를 던져야 한다', async () => {
+    await expect(
+      service.listMyOrders(accountId, { limit: 51 }),
+    ).rejects.toThrow(USER_ORDER_ERRORS.INVALID_LIMIT);
+  });
+
+  it('limit이 0이면 에러를 던져야 한다', async () => {
+    await expect(service.listMyOrders(accountId, { limit: 0 })).rejects.toThrow(
+      USER_ORDER_ERRORS.INVALID_LIMIT,
+    );
+  });
+
+  it('offset이 음수이면 에러를 던져야 한다', async () => {
+    await expect(
+      service.listMyOrders(accountId, { offset: -1 }),
+    ).rejects.toThrow(USER_ORDER_ERRORS.INVALID_OFFSET);
+  });
+});

--- a/src/features/user/services/user-order.service.ts
+++ b/src/features/user/services/user-order.service.ts
@@ -1,0 +1,69 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+import { OrderRepository } from '@/features/order/repositories/order.repository';
+import { USER_ORDER_ERRORS } from '@/features/user/constants/user-order-error-messages';
+import type { MyOrdersInput } from '@/features/user/types/user-order-input.type';
+import type { MyOrderConnection } from '@/features/user/types/user-order-output.type';
+
+const MAX_LIMIT = 50;
+
+@Injectable()
+export class UserOrderService {
+  constructor(private readonly orderRepository: OrderRepository) {}
+
+  async listMyOrders(
+    accountId: bigint,
+    input?: MyOrdersInput,
+  ): Promise<MyOrderConnection> {
+    const offset = input?.offset ?? 0;
+    const limit = input?.limit ?? 20;
+    const statuses = input?.statuses;
+
+    if (offset < 0) {
+      throw new BadRequestException(USER_ORDER_ERRORS.INVALID_OFFSET);
+    }
+    if (limit < 1 || limit > MAX_LIMIT) {
+      throw new BadRequestException(USER_ORDER_ERRORS.INVALID_LIMIT);
+    }
+
+    const [orders, totalCount] = await Promise.all([
+      this.orderRepository.findOrdersByAccount({
+        accountId,
+        statuses,
+        offset,
+        limit: limit + 1,
+      }),
+      this.orderRepository.countOrdersByAccount({
+        accountId,
+        statuses,
+      }),
+    ]);
+
+    const hasMore = orders.length > limit;
+    const sliced = hasMore ? orders.slice(0, limit) : orders;
+
+    return {
+      items: sliced.map((order) => {
+        const firstItem = order.items[0];
+        const firstImage = firstItem?.product?.images?.[0];
+        const itemCount = order._count.items;
+
+        return {
+          orderId: order.id.toString(),
+          orderNumber: order.order_number,
+          status: order.status,
+          createdAt: order.created_at,
+          pickupAt: order.pickup_at,
+          representativeProductName:
+            firstItem?.product_name_snapshot ?? '상품 정보 없음',
+          representativeProductImageUrl: firstImage?.image_url ?? null,
+          additionalItemCount: Math.max(0, itemCount - 1),
+          totalPrice: order.total_price,
+          storeName: firstItem?.store?.store_name ?? '매장 정보 없음',
+        };
+      }),
+      totalCount,
+      hasMore,
+    };
+  }
+}

--- a/src/features/user/types/user-order-input.type.ts
+++ b/src/features/user/types/user-order-input.type.ts
@@ -1,0 +1,7 @@
+import type { OrderStatus } from '@prisma/client';
+
+export interface MyOrdersInput {
+  statuses?: OrderStatus[];
+  offset?: number;
+  limit?: number;
+}

--- a/src/features/user/types/user-order-output.type.ts
+++ b/src/features/user/types/user-order-output.type.ts
@@ -1,0 +1,20 @@
+import type { OrderStatus } from '@prisma/client';
+
+export interface MyOrderSummary {
+  orderId: string;
+  orderNumber: string;
+  status: OrderStatus;
+  createdAt: Date;
+  pickupAt: Date;
+  representativeProductName: string;
+  representativeProductImageUrl: string | null;
+  additionalItemCount: number;
+  totalPrice: number;
+  storeName: string;
+}
+
+export interface MyOrderConnection {
+  items: MyOrderSummary[];
+  totalCount: number;
+  hasMore: boolean;
+}

--- a/src/features/user/user-order.graphql
+++ b/src/features/user/user-order.graphql
@@ -1,4 +1,38 @@
-"""유저 주문 도메인 확장을 위한 placeholder 타입"""
-type UserOrderPlaceholder {
-  id: ID
+extend type Query {
+  """내 주문 목록 조회"""
+  myOrders(input: MyOrdersInput): MyOrderConnection!
+}
+
+"""내 주문 조회 입력"""
+input MyOrdersInput {
+  """상태 필터 (복수 선택 가능). 미지정 시 전체"""
+  statuses: [OrderStatusType!]
+  offset: Int = 0
+  limit: Int = 20
+}
+
+"""주문 목록 응답"""
+type MyOrderConnection {
+  items: [MyOrderSummary!]!
+  totalCount: Int!
+  hasMore: Boolean!
+}
+
+"""유저 주문 목록 카드"""
+type MyOrderSummary {
+  orderId: ID!
+  orderNumber: String!
+  status: OrderStatusType!
+  createdAt: DateTime!
+  pickupAt: DateTime!
+  """대표 상품명 (첫 OrderItem 기준)"""
+  representativeProductName: String!
+  """대표 상품 이미지 URL"""
+  representativeProductImageUrl: String
+  """주문에 포함된 추가 상품 종류 수 (첫 아이템 제외)"""
+  additionalItemCount: Int!
+  """총 가격"""
+  totalPrice: Int!
+  """매장명"""
+  storeName: String!
 }

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -7,6 +7,7 @@ import { UserEngagementMutationResolver } from '@/features/user/resolvers/user-e
 import { UserMypageQueryResolver } from '@/features/user/resolvers/user-mypage-query.resolver';
 import { UserNotificationMutationResolver } from '@/features/user/resolvers/user-notification-mutation.resolver';
 import { UserNotificationQueryResolver } from '@/features/user/resolvers/user-notification-query.resolver';
+import { UserOrderQueryResolver } from '@/features/user/resolvers/user-order-query.resolver';
 import { UserProfileMutationResolver } from '@/features/user/resolvers/user-profile-mutation.resolver';
 import { UserProfileQueryResolver } from '@/features/user/resolvers/user-profile-query.resolver';
 import { UserSearchMutationResolver } from '@/features/user/resolvers/user-search-mutation.resolver';
@@ -14,6 +15,7 @@ import { UserSearchQueryResolver } from '@/features/user/resolvers/user-search-q
 import { UserEngagementService } from '@/features/user/services/user-engagement.service';
 import { UserMypageService } from '@/features/user/services/user-mypage.service';
 import { UserNotificationService } from '@/features/user/services/user-notification.service';
+import { UserOrderService } from '@/features/user/services/user-order.service';
 import { UserProfileService } from '@/features/user/services/user-profile.service';
 import { UserSearchService } from '@/features/user/services/user-search.service';
 
@@ -28,12 +30,14 @@ import { UserSearchService } from '@/features/user/services/user-search.service'
     UserSearchService,
     UserEngagementService,
     UserMypageService,
+    UserOrderService,
     UserRepository,
     RecentProductViewRepository,
     UserProfileQueryResolver,
     UserNotificationQueryResolver,
     UserSearchQueryResolver,
     UserMypageQueryResolver,
+    UserOrderQueryResolver,
     UserProfileMutationResolver,
     UserNotificationMutationResolver,
     UserSearchMutationResolver,


### PR DESCRIPTION
## Summary
- **`myOrders` 쿼리 신규**: 마이페이지 주문현황 리스트에 필요한 주문 목록 조회
  - 상태 필터: `statuses: [OrderStatusType!]` (복수 선택 가능, 미지정 시 전체)
  - offset 기반 페이지네이션 (기존 `myNotifications`와 일관)
  - 주문 카드: 주문번호, 상태, 대표 상품명/이미지, 매장명, 총 가격, 추가 상품 수
  - soft-delete된 items/images 필터링 적용

## 신규 파일
- `src/features/user/user-order.graphql` — placeholder → 실제 SDL 교체
- `src/features/user/types/user-order-input.type.ts`
- `src/features/user/types/user-order-output.type.ts`
- `src/features/user/constants/user-order-error-messages.ts`
- `src/features/user/services/user-order.service.ts`
- `src/features/user/services/user-order.service.spec.ts` — 10개 테스트
- `src/features/user/resolvers/user-order-query.resolver.ts`

## 수정 파일
- `src/features/order/repositories/order.repository.ts` — findOrdersByAccount, countOrdersByAccount 추가
- `src/features/user/user.module.ts` — UserOrderService, UserOrderQueryResolver 등록

## Test plan
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `yarn test` 전체 425 테스트 통과 (기존 415 + 신규 10)
- [ ] PR 리뷰 후 develop 머지