### PR TITLE
feat: 유저 주문 상세 조회 API 구현 (STAGE 5)

### DIFF
--- a/src/common/utils/business-hours-formatter.spec.ts
+++ b/src/common/utils/business-hours-formatter.spec.ts
@@ -1,0 +1,78 @@
+import { formatBusinessHours } from '@/common/utils/business-hours-formatter';
+
+function makeTime(h: number, m: number): Date {
+  return new Date(Date.UTC(2000, 0, 1, h, m, 0));
+}
+
+function makeHour(
+  day: number,
+  open: [number, number],
+  close: [number, number],
+  closed = false,
+) {
+  return {
+    day_of_week: day,
+    is_closed: closed,
+    open_time: closed ? null : makeTime(open[0], open[1]),
+    close_time: closed ? null : makeTime(close[0], close[1]),
+  };
+}
+
+describe('formatBusinessHours', () => {
+  it('모든 요일이 같은 시간이면 "매일 HH:mm ~ HH:mm"을 반환해야 한다', () => {
+    const hours = Array.from({ length: 7 }, (_, i) =>
+      makeHour(i, [9, 0], [18, 0]),
+    );
+    expect(formatBusinessHours(hours)).toBe('매일 09:00 ~ 18:00');
+  });
+
+  it('일부 요일이 휴무이면 영업시간 + 휴무 정보를 반환해야 한다', () => {
+    const hours = [
+      makeHour(0, [0, 0], [0, 0], true), // 일 휴무
+      makeHour(1, [9, 0], [18, 0]),
+      makeHour(2, [9, 0], [18, 0], true), // 화 휴무
+      makeHour(3, [9, 0], [18, 0]),
+      makeHour(4, [9, 0], [18, 0]),
+      makeHour(5, [9, 0], [18, 0]),
+      makeHour(6, [9, 0], [18, 0]),
+    ];
+    const result = formatBusinessHours(hours);
+    expect(result).toContain('09:00 ~ 18:00');
+    expect(result).toContain('일요일');
+    expect(result).toContain('화요일');
+    expect(result).toContain('정기 휴무');
+  });
+
+  it('요일별로 다른 시간이면 그룹별로 표시해야 한다', () => {
+    const hours = [
+      makeHour(1, [9, 0], [18, 0]),
+      makeHour(2, [9, 0], [18, 0]),
+      makeHour(3, [9, 0], [18, 0]),
+      makeHour(4, [9, 0], [18, 0]),
+      makeHour(5, [9, 0], [18, 0]),
+      makeHour(6, [10, 0], [17, 0]),
+      makeHour(0, [10, 0], [17, 0]),
+    ];
+    const result = formatBusinessHours(hours);
+    expect(result).toContain('월~금 09:00 ~ 18:00');
+    expect(result).toContain('10:00 ~ 17:00');
+  });
+
+  it('빈 배열이면 fallback을 반환해야 한다', () => {
+    expect(formatBusinessHours([], '매일 09:00 ~ 18:00')).toBe(
+      '매일 09:00 ~ 18:00',
+    );
+  });
+
+  it('빈 배열에 fallback이 없으면 null을 반환해야 한다', () => {
+    expect(formatBusinessHours([])).toBeNull();
+  });
+
+  it('모든 요일이 휴무이면 휴무만 표시해야 한다', () => {
+    const hours = Array.from({ length: 7 }, (_, i) =>
+      makeHour(i, [0, 0], [0, 0], true),
+    );
+    const result = formatBusinessHours(hours);
+    expect(result).toContain('정기 휴무');
+  });
+});

--- a/src/common/utils/business-hours-formatter.ts
+++ b/src/common/utils/business-hours-formatter.ts
@@ -1,0 +1,106 @@
+const DAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+interface BusinessHourRow {
+  day_of_week: number; // 0=일 ~ 6=토
+  is_closed: boolean;
+  open_time: Date | null;
+  close_time: Date | null;
+}
+
+/**
+ * Date 객체에서 HH:mm 문자열을 추출한다.
+ * Prisma의 Time 타입은 Date 객체로 반환되며 시/분만 의미가 있다.
+ */
+function formatTime(date: Date): string {
+  const h = date.getUTCHours().toString().padStart(2, '0');
+  const m = date.getUTCMinutes().toString().padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+/**
+ * 구조화된 StoreBusinessHour 데이터에서 사람이 읽을 수 있는
+ * 영업시간 텍스트를 생성한다.
+ *
+ * 예: "매일 09:00 ~ 18:00 / 화요일 정기 휴무"
+ * 예: "월~금 09:00 ~ 18:00, 토 10:00 ~ 17:00 / 일요일 정기 휴무"
+ *
+ * @param hours 요일별 영업시간 (0~6)
+ * @param fallback 구조화 데이터가 없을 때 반환할 문자열
+ */
+export function formatBusinessHours(
+  hours: BusinessHourRow[],
+  fallback?: string | null,
+): string | null {
+  if (hours.length === 0) {
+    return fallback ?? null;
+  }
+
+  // 요일 순서로 정렬 (0=일 ~ 6=토)
+  const sorted = [...hours].sort((a, b) => a.day_of_week - b.day_of_week);
+
+  const closedDays: string[] = [];
+  const openSlots: { dayOfWeek: number; timeRange: string }[] = [];
+
+  for (const h of sorted) {
+    if (h.is_closed) {
+      closedDays.push(`${DAY_LABELS[h.day_of_week]}요일`);
+    } else if (h.open_time && h.close_time) {
+      openSlots.push({
+        dayOfWeek: h.day_of_week,
+        timeRange: `${formatTime(h.open_time)} ~ ${formatTime(h.close_time)}`,
+      });
+    }
+  }
+
+  // 영업 시간대별로 그룹핑
+  const groups = groupByTimeRange(openSlots);
+  const parts: string[] = [];
+
+  for (const group of groups) {
+    const dayLabel = formatDayRange(group.days);
+    parts.push(`${dayLabel} ${group.timeRange}`);
+  }
+
+  if (closedDays.length > 0) {
+    parts.push(`${closedDays.join(', ')} 정기 휴무`);
+  }
+
+  return parts.length > 0 ? parts.join(' / ') : (fallback ?? null);
+}
+
+function groupByTimeRange(
+  slots: { dayOfWeek: number; timeRange: string }[],
+): { days: number[]; timeRange: string }[] {
+  const groups: { days: number[]; timeRange: string }[] = [];
+
+  for (const slot of slots) {
+    const existing = groups.find((g) => g.timeRange === slot.timeRange);
+    if (existing) {
+      existing.days.push(slot.dayOfWeek);
+    } else {
+      groups.push({ days: [slot.dayOfWeek], timeRange: slot.timeRange });
+    }
+  }
+
+  return groups;
+}
+
+function formatDayRange(days: number[]): string {
+  if (days.length === 7) return '매일';
+  if (days.length === 0) return '';
+
+  // 연속 범위 감지
+  const sorted = [...days].sort((a, b) => a - b);
+  if (isConsecutive(sorted) && sorted.length > 2) {
+    return `${DAY_LABELS[sorted[0]]}~${DAY_LABELS[sorted[sorted.length - 1]]}`;
+  }
+
+  return sorted.map((d) => DAY_LABELS[d]).join(', ');
+}
+
+function isConsecutive(sortedDays: number[]): boolean {
+  for (let i = 1; i < sortedDays.length; i++) {
+    if (sortedDays[i] !== sortedDays[i - 1] + 1) return false;
+  }
+  return true;
+}

--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -142,6 +142,77 @@ export class OrderRepository {
     });
   }
 
+  async findOrderDetailByAccount(args: { orderId: bigint; accountId: bigint }) {
+    return this.prisma.order.findFirst({
+      where: {
+        id: args.orderId,
+        account_id: args.accountId,
+      },
+      include: {
+        status_histories: {
+          where: { deleted_at: null },
+          orderBy: { changed_at: 'asc' },
+        },
+        items: {
+          where: { deleted_at: null },
+          orderBy: { id: 'asc' },
+          include: {
+            store: {
+              select: {
+                id: true,
+                store_name: true,
+                store_phone: true,
+                address_full: true,
+                address_city: true,
+                address_district: true,
+                address_neighborhood: true,
+                latitude: true,
+                longitude: true,
+                business_hours_text: true,
+                website_url: true,
+                business_hours: {
+                  where: { deleted_at: null },
+                  orderBy: { day_of_week: 'asc' },
+                },
+              },
+            },
+            product: {
+              select: {
+                images: {
+                  where: { deleted_at: null },
+                  orderBy: { sort_order: 'asc' },
+                  take: 1,
+                  select: { image_url: true },
+                },
+              },
+            },
+            option_items: {
+              where: { deleted_at: null },
+              orderBy: { id: 'asc' },
+            },
+            custom_texts: {
+              where: { deleted_at: null },
+              orderBy: { sort_order: 'asc' },
+            },
+            free_edits: {
+              where: { deleted_at: null },
+              orderBy: { sort_order: 'asc' },
+              include: {
+                attachments: {
+                  where: { deleted_at: null },
+                  orderBy: { sort_order: 'asc' },
+                },
+              },
+            },
+            review: {
+              select: { id: true },
+            },
+          },
+        },
+      },
+    });
+  }
+
   async listOrdersByStore(args: {
     storeId: bigint;
     limit: number;

--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -205,7 +205,7 @@ export class OrderRepository {
               },
             },
             review: {
-              select: { id: true },
+              select: { id: true, deleted_at: true },
             },
           },
         },

--- a/src/features/user/constants/user-order-error-messages.ts
+++ b/src/features/user/constants/user-order-error-messages.ts
@@ -1,4 +1,5 @@
 export const USER_ORDER_ERRORS = {
   INVALID_LIMIT: '조회 개수는 1~50 사이여야 합니다.',
   INVALID_OFFSET: '오프셋은 0 이상이어야 합니다.',
+  ORDER_NOT_FOUND: '주문을 찾을 수 없습니다.',
 } as const;

--- a/src/features/user/resolvers/user-order-query.resolver.ts
+++ b/src/features/user/resolvers/user-order-query.resolver.ts
@@ -1,9 +1,13 @@
 import { UseGuards } from '@nestjs/common';
 import { Args, Query, Resolver } from '@nestjs/graphql';
 
+import { parseId } from '@/common/utils/id-parser';
 import { UserOrderService } from '@/features/user/services/user-order.service';
 import type { MyOrdersInput } from '@/features/user/types/user-order-input.type';
-import type { MyOrderConnection } from '@/features/user/types/user-order-output.type';
+import type {
+  MyOrderConnection,
+  MyOrderDetail,
+} from '@/features/user/types/user-order-output.type';
 import {
   CurrentUser,
   JwtAuthGuard,
@@ -23,5 +27,14 @@ export class UserOrderQueryResolver {
   ): Promise<MyOrderConnection> {
     const accountId = parseAccountId(user);
     return this.orderService.listMyOrders(accountId, input);
+  }
+
+  @Query('myOrder')
+  myOrder(
+    @CurrentUser() user: JwtUser,
+    @Args('orderId') orderId: string,
+  ): Promise<MyOrderDetail> {
+    const accountId = parseAccountId(user);
+    return this.orderService.getMyOrder(accountId, parseId(orderId));
   }
 }

--- a/src/features/user/services/user-order.service.spec.ts
+++ b/src/features/user/services/user-order.service.spec.ts
@@ -183,6 +183,7 @@ describe('UserOrderService', () => {
     const makeDetailOrder = (overrides?: {
       status?: OrderStatus;
       hasReview?: boolean;
+      reviewDeleted?: boolean;
     }) => ({
       id: BigInt(100),
       order_number: 'CQ-20260413-00001',
@@ -243,7 +244,14 @@ describe('UserOrderService', () => {
           ],
           custom_texts: [],
           free_edits: [],
-          review: overrides?.hasReview ? { id: BigInt(1) } : null,
+          review: overrides?.hasReview
+            ? {
+                id: BigInt(1),
+                deleted_at: overrides?.reviewDeleted
+                  ? new Date('2026-04-12')
+                  : null,
+              }
+            : null,
         },
       ],
     });
@@ -299,6 +307,21 @@ describe('UserOrderService', () => {
 
       expect(result.items[0].canWriteReview).toBe(false);
       expect(result.items[0].hasMyReview).toBe(true);
+    });
+
+    it('soft-delete된 리뷰가 있으면 canWriteReview가 true여야 한다', async () => {
+      orderRepo.findOrderDetailByAccount.mockResolvedValue(
+        makeDetailOrder({
+          status: OrderStatus.PICKED_UP,
+          hasReview: true,
+          reviewDeleted: true,
+        }) as never,
+      );
+
+      const result = await service.getMyOrder(accountId, BigInt(100));
+
+      expect(result.items[0].canWriteReview).toBe(true);
+      expect(result.items[0].hasMyReview).toBe(false);
     });
 
     it('PICKED_UP이 아닌 상태면 canWriteReview가 false여야 한다', async () => {

--- a/src/features/user/services/user-order.service.spec.ts
+++ b/src/features/user/services/user-order.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { OrderStatus } from '@prisma/client';
 
@@ -50,6 +50,7 @@ describe('UserOrderService', () => {
     orderRepo = {
       findOrdersByAccount: jest.fn(),
       countOrdersByAccount: jest.fn(),
+      findOrderDetailByAccount: jest.fn(),
     } as unknown as jest.Mocked<OrderRepository>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -176,5 +177,149 @@ describe('UserOrderService', () => {
     await expect(
       service.listMyOrders(accountId, { offset: -1 }),
     ).rejects.toThrow(USER_ORDER_ERRORS.INVALID_OFFSET);
+  });
+
+  describe('getMyOrder', () => {
+    const makeDetailOrder = (overrides?: {
+      status?: OrderStatus;
+      hasReview?: boolean;
+    }) => ({
+      id: BigInt(100),
+      order_number: 'CQ-20260413-00001',
+      account_id: accountId,
+      status: overrides?.status ?? OrderStatus.PICKED_UP,
+      created_at: new Date('2026-04-10'),
+      pickup_at: new Date('2026-04-15'),
+      buyer_name: '홍길동',
+      buyer_phone: '010-1234-5678',
+      subtotal_price: 35000,
+      discount_price: 0,
+      total_price: 35000,
+      submitted_at: new Date('2026-04-10'),
+      confirmed_at: new Date('2026-04-11'),
+      made_at: new Date('2026-04-14'),
+      picked_up_at: new Date('2026-04-15'),
+      canceled_at: null,
+      status_histories: [
+        {
+          from_status: null,
+          to_status: OrderStatus.SUBMITTED,
+          changed_at: new Date('2026-04-10'),
+          note: null,
+        },
+      ],
+      items: [
+        {
+          id: BigInt(200),
+          product_id: BigInt(300),
+          product_name_snapshot: '딸기 케이크',
+          regular_price_snapshot: 35000,
+          sale_price_snapshot: null,
+          quantity: 1,
+          item_subtotal_price: 35000,
+          store: {
+            id: BigInt(10),
+            store_name: '스웨이드 베이커리',
+            store_phone: '0507-1449-4422',
+            address_full: '서울 강남구 도산대로62길 26 1층',
+            address_city: '서울',
+            address_district: '강남구',
+            address_neighborhood: '신사동',
+            latitude: { toNumber: () => 37.5228 } as unknown,
+            longitude: { toNumber: () => 127.0236 } as unknown,
+            business_hours_text: '매일 09:00 ~ 18:00',
+            website_url: 'https://suede.co.kr',
+            business_hours: [],
+          },
+          product: {
+            images: [{ image_url: 'https://s3.example.com/cake.jpg' }],
+          },
+          option_items: [
+            {
+              group_name_snapshot: '사이즈',
+              option_title_snapshot: '2호',
+              option_price_delta_snapshot: 5000,
+            },
+          ],
+          custom_texts: [],
+          free_edits: [],
+          review: overrides?.hasReview ? { id: BigInt(1) } : null,
+        },
+      ],
+    });
+
+    it('주문 상세를 반환해야 한다', async () => {
+      orderRepo.findOrderDetailByAccount.mockResolvedValue(
+        makeDetailOrder() as never,
+      );
+
+      const result = await service.getMyOrder(accountId, BigInt(100));
+
+      expect(result.orderId).toBe('100');
+      expect(result.orderNumber).toBe('CQ-20260413-00001');
+      expect(result.buyerName).toBe('홍길동');
+      expect(result.store.storeName).toBe('스웨이드 베이커리');
+      expect(result.store.addressFull).toBe('서울 강남구 도산대로62길 26 1층');
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].selectedOptions).toHaveLength(1);
+      expect(result.items[0].selectedOptions[0].groupName).toBe('사이즈');
+    });
+
+    it('주문이 없으면 NotFoundException을 던져야 한다', async () => {
+      orderRepo.findOrderDetailByAccount.mockResolvedValue(null);
+
+      await expect(service.getMyOrder(accountId, BigInt(999))).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('PICKED_UP 상태이고 리뷰가 없으면 canWriteReview가 true여야 한다', async () => {
+      orderRepo.findOrderDetailByAccount.mockResolvedValue(
+        makeDetailOrder({
+          status: OrderStatus.PICKED_UP,
+          hasReview: false,
+        }) as never,
+      );
+
+      const result = await service.getMyOrder(accountId, BigInt(100));
+
+      expect(result.items[0].canWriteReview).toBe(true);
+      expect(result.items[0].hasMyReview).toBe(false);
+    });
+
+    it('리뷰가 이미 있으면 canWriteReview가 false여야 한다', async () => {
+      orderRepo.findOrderDetailByAccount.mockResolvedValue(
+        makeDetailOrder({
+          status: OrderStatus.PICKED_UP,
+          hasReview: true,
+        }) as never,
+      );
+
+      const result = await service.getMyOrder(accountId, BigInt(100));
+
+      expect(result.items[0].canWriteReview).toBe(false);
+      expect(result.items[0].hasMyReview).toBe(true);
+    });
+
+    it('PICKED_UP이 아닌 상태면 canWriteReview가 false여야 한다', async () => {
+      orderRepo.findOrderDetailByAccount.mockResolvedValue(
+        makeDetailOrder({ status: OrderStatus.CONFIRMED }) as never,
+      );
+
+      const result = await service.getMyOrder(accountId, BigInt(100));
+
+      expect(result.items[0].canWriteReview).toBe(false);
+    });
+
+    it('상태 히스토리를 올바르게 매핑해야 한다', async () => {
+      orderRepo.findOrderDetailByAccount.mockResolvedValue(
+        makeDetailOrder() as never,
+      );
+
+      const result = await service.getMyOrder(accountId, BigInt(100));
+
+      expect(result.statusHistories).toHaveLength(1);
+      expect(result.statusHistories[0].toStatus).toBe(OrderStatus.SUBMITTED);
+    });
   });
 });

--- a/src/features/user/services/user-order.service.ts
+++ b/src/features/user/services/user-order.service.ts
@@ -1,9 +1,18 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { OrderStatus } from '@prisma/client';
 
+import { formatBusinessHours } from '@/common/utils/business-hours-formatter';
 import { OrderRepository } from '@/features/order/repositories/order.repository';
 import { USER_ORDER_ERRORS } from '@/features/user/constants/user-order-error-messages';
 import type { MyOrdersInput } from '@/features/user/types/user-order-input.type';
-import type { MyOrderConnection } from '@/features/user/types/user-order-output.type';
+import type {
+  MyOrderConnection,
+  MyOrderDetail,
+} from '@/features/user/types/user-order-output.type';
 
 const MAX_LIMIT = 50;
 
@@ -64,6 +73,104 @@ export class UserOrderService {
       }),
       totalCount,
       hasMore,
+    };
+  }
+
+  async getMyOrder(accountId: bigint, orderId: bigint): Promise<MyOrderDetail> {
+    const order = await this.orderRepository.findOrderDetailByAccount({
+      orderId,
+      accountId,
+    });
+
+    if (!order) {
+      throw new NotFoundException(USER_ORDER_ERRORS.ORDER_NOT_FOUND);
+    }
+
+    const firstItem = order.items[0];
+    const store = firstItem?.store;
+    const isPickedUp = order.status === OrderStatus.PICKED_UP;
+
+    return {
+      orderId: order.id.toString(),
+      orderNumber: order.order_number,
+      status: order.status,
+      createdAt: order.created_at,
+      pickupAt: order.pickup_at,
+      buyerName: order.buyer_name,
+      buyerPhone: order.buyer_phone,
+      subtotalPrice: order.subtotal_price,
+      discountPrice: order.discount_price,
+      totalPrice: order.total_price,
+      submittedAt: order.submitted_at,
+      confirmedAt: order.confirmed_at,
+      madeAt: order.made_at,
+      pickedUpAt: order.picked_up_at,
+      canceledAt: order.canceled_at,
+      statusHistories: order.status_histories.map((h) => ({
+        fromStatus: h.from_status,
+        toStatus: h.to_status,
+        changedAt: h.changed_at,
+        note: h.note,
+      })),
+      items: order.items.map((item) => ({
+        orderItemId: item.id.toString(),
+        productId: item.product_id.toString(),
+        productName: item.product_name_snapshot,
+        representativeImageUrl: item.product?.images?.[0]?.image_url ?? null,
+        quantity: item.quantity,
+        regularPrice: item.regular_price_snapshot,
+        salePrice: item.sale_price_snapshot,
+        itemSubtotalPrice: item.item_subtotal_price,
+        selectedOptions: item.option_items.map((oi) => ({
+          groupName: oi.group_name_snapshot,
+          optionTitle: oi.option_title_snapshot,
+          priceDelta: oi.option_price_delta_snapshot,
+        })),
+        customTexts: item.custom_texts.map((ct) => ({
+          tokenKey: ct.token_key_snapshot,
+          defaultText: ct.default_text_snapshot,
+          valueText: ct.value_text,
+          sortOrder: ct.sort_order,
+        })),
+        customFreeEdits: item.free_edits.map((fe) => ({
+          cropImageUrl: fe.crop_image_url,
+          descriptionText: fe.description_text,
+          sortOrder: fe.sort_order,
+          attachmentImageUrls: fe.attachments.map((a) => a.image_url),
+        })),
+        hasMyReview: Boolean(item.review),
+        canWriteReview: isPickedUp && !item.review,
+      })),
+      store: store
+        ? {
+            storeId: store.id.toString(),
+            storeName: store.store_name,
+            storePhone: store.store_phone,
+            addressFull: store.address_full,
+            addressCity: store.address_city,
+            addressDistrict: store.address_district,
+            addressNeighborhood: store.address_neighborhood,
+            latitude: store.latitude ? Number(store.latitude) : null,
+            longitude: store.longitude ? Number(store.longitude) : null,
+            businessHoursText: formatBusinessHours(
+              store.business_hours,
+              store.business_hours_text,
+            ),
+            websiteUrl: store.website_url,
+          }
+        : {
+            storeId: '0',
+            storeName: '매장 정보 없음',
+            storePhone: '',
+            addressFull: '',
+            addressCity: null,
+            addressDistrict: null,
+            addressNeighborhood: null,
+            latitude: null,
+            longitude: null,
+            businessHoursText: null,
+            websiteUrl: null,
+          },
     };
   }
 }

--- a/src/features/user/services/user-order.service.ts
+++ b/src/features/user/services/user-order.service.ts
@@ -138,8 +138,9 @@ export class UserOrderService {
           sortOrder: fe.sort_order,
           attachmentImageUrls: fe.attachments.map((a) => a.image_url),
         })),
-        hasMyReview: Boolean(item.review),
-        canWriteReview: isPickedUp && !item.review,
+        hasMyReview: Boolean(item.review && !item.review.deleted_at),
+        canWriteReview:
+          isPickedUp && (!item.review || Boolean(item.review.deleted_at)),
       })),
       store: store
         ? {

--- a/src/features/user/types/user-order-output.type.ts
+++ b/src/features/user/types/user-order-output.type.ts
@@ -18,3 +18,81 @@ export interface MyOrderConnection {
   totalCount: number;
   hasMore: boolean;
 }
+
+export interface MyOrderStatusHistory {
+  fromStatus: OrderStatus | null;
+  toStatus: OrderStatus;
+  changedAt: Date;
+  note: string | null;
+}
+
+export interface MyOrderItemSelectedOption {
+  groupName: string;
+  optionTitle: string;
+  priceDelta: number;
+}
+
+export interface MyOrderItemCustomText {
+  tokenKey: string;
+  defaultText: string;
+  valueText: string;
+  sortOrder: number;
+}
+
+export interface MyOrderItemCustomFreeEdit {
+  cropImageUrl: string;
+  descriptionText: string;
+  sortOrder: number;
+  attachmentImageUrls: string[];
+}
+
+export interface MyOrderItemDetail {
+  orderItemId: string;
+  productId: string;
+  productName: string;
+  representativeImageUrl: string | null;
+  quantity: number;
+  regularPrice: number;
+  salePrice: number | null;
+  itemSubtotalPrice: number;
+  selectedOptions: MyOrderItemSelectedOption[];
+  customTexts: MyOrderItemCustomText[];
+  customFreeEdits: MyOrderItemCustomFreeEdit[];
+  hasMyReview: boolean;
+  canWriteReview: boolean;
+}
+
+export interface MyOrderStoreInfo {
+  storeId: string;
+  storeName: string;
+  storePhone: string;
+  addressFull: string;
+  addressCity: string | null;
+  addressDistrict: string | null;
+  addressNeighborhood: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  businessHoursText: string | null;
+  websiteUrl: string | null;
+}
+
+export interface MyOrderDetail {
+  orderId: string;
+  orderNumber: string;
+  status: OrderStatus;
+  createdAt: Date;
+  pickupAt: Date;
+  buyerName: string;
+  buyerPhone: string;
+  subtotalPrice: number;
+  discountPrice: number;
+  totalPrice: number;
+  submittedAt: Date | null;
+  confirmedAt: Date | null;
+  madeAt: Date | null;
+  pickedUpAt: Date | null;
+  canceledAt: Date | null;
+  statusHistories: MyOrderStatusHistory[];
+  items: MyOrderItemDetail[];
+  store: MyOrderStoreInfo;
+}

--- a/src/features/user/user-order.graphql
+++ b/src/features/user/user-order.graphql
@@ -1,6 +1,8 @@
 extend type Query {
   """내 주문 목록 조회"""
   myOrders(input: MyOrdersInput): MyOrderConnection!
+  """내 주문 상세 조회"""
+  myOrder(orderId: ID!): MyOrderDetail!
 }
 
 """내 주문 조회 입력"""
@@ -35,4 +37,97 @@ type MyOrderSummary {
   totalPrice: Int!
   """매장명"""
   storeName: String!
+}
+
+"""주문 상세"""
+type MyOrderDetail {
+  orderId: ID!
+  orderNumber: String!
+  status: OrderStatusType!
+  createdAt: DateTime!
+  pickupAt: DateTime!
+
+  buyerName: String!
+  buyerPhone: String!
+
+  subtotalPrice: Int!
+  discountPrice: Int!
+  totalPrice: Int!
+
+  """상태 스테퍼용 타임스탬프"""
+  submittedAt: DateTime
+  confirmedAt: DateTime
+  madeAt: DateTime
+  pickedUpAt: DateTime
+  canceledAt: DateTime
+
+  """상태 변경 히스토리"""
+  statusHistories: [MyOrderStatusHistory!]!
+  """주문 아이템 목록"""
+  items: [MyOrderItemDetail!]!
+  """판매자 정보 (단일 매장 전제)"""
+  store: MyOrderStoreInfo!
+}
+
+type MyOrderStatusHistory {
+  fromStatus: OrderStatusType
+  toStatus: OrderStatusType!
+  changedAt: DateTime!
+  note: String
+}
+
+type MyOrderItemDetail {
+  orderItemId: ID!
+  productId: ID!
+  productName: String!
+  representativeImageUrl: String
+  quantity: Int!
+  regularPrice: Int!
+  salePrice: Int
+  itemSubtotalPrice: Int!
+  """선택한 옵션 목록"""
+  selectedOptions: [MyOrderItemSelectedOption!]!
+  """커스텀 텍스트(스냅샷)"""
+  customTexts: [MyOrderItemCustomText!]!
+  """자유 커스텀(스냅샷)"""
+  customFreeEdits: [MyOrderItemCustomFreeEdit!]!
+  """내 리뷰 작성 여부"""
+  hasMyReview: Boolean!
+  """리뷰 작성 가능 여부"""
+  canWriteReview: Boolean!
+}
+
+type MyOrderItemSelectedOption {
+  groupName: String!
+  optionTitle: String!
+  priceDelta: Int!
+}
+
+type MyOrderItemCustomText {
+  tokenKey: String!
+  defaultText: String!
+  valueText: String!
+  sortOrder: Int!
+}
+
+type MyOrderItemCustomFreeEdit {
+  cropImageUrl: String!
+  descriptionText: String!
+  sortOrder: Int!
+  attachmentImageUrls: [String!]!
+}
+
+type MyOrderStoreInfo {
+  storeId: ID!
+  storeName: String!
+  storePhone: String!
+  addressFull: String!
+  addressCity: String
+  addressDistrict: String
+  addressNeighborhood: String
+  latitude: Float
+  longitude: Float
+  """영업시간 평문"""
+  businessHoursText: String
+  websiteUrl: String
 }


### PR DESCRIPTION
## Summary
- **`myOrder(orderId)` 쿼리 신규**: 마이페이지 주문현황 상세 조회
  - 상태 스테퍼용 타임스탬프 (submittedAt ~ canceledAt)
  - 상태 변경 히스토리 (처리일시 + 상태 테이블)
  - 주문 아이템 목록 (선택 옵션, 커스텀 텍스트/자유 편집 포함)
  - 판매자 정보 (매장명, 주소, 영업시간, 전화, 웹사이트)
  - `canWriteReview` / `hasMyReview` 판정
- **영업시간 포매터**: `formatBusinessHours` 유틸 (구조화 → "매일 09:00 ~ 18:00 / 화요일 정기 휴무")
- soft-delete 필터 전면 적용

## 신규 파일
- `src/common/utils/business-hours-formatter.ts` + `.spec.ts` — 6개 테스트
- SDL/DTO 타입 확장 (MyOrderDetail, MyOrderStoreInfo 등 8개 타입)

## 수정 파일
- `src/features/order/repositories/order.repository.ts` — `findOrderDetailByAccount` 추가
- `src/features/user/services/user-order.service.ts` — `getMyOrder` 추가
- `src/features/user/resolvers/user-order-query.resolver.ts` — `myOrder` 쿼리 추가
- `src/features/user/user-order.graphql` — 상세 타입 추가
- `src/features/user/types/user-order-output.type.ts` — 상세 DTO 추가

## Test plan
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `yarn test` 전체 437 테스트 통과 (기존 425 + 신규 12)
- [ ] PR 리뷰 후 develop 머지