### PR TITLE
feat: 최근 본 상품 기록/조회 API 구현 (STAGE 6)

### DIFF
--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -659,6 +659,16 @@ export class ProductRepository {
     });
   }
 
+  async findActiveProduct(productId: bigint): Promise<{ id: bigint } | null> {
+    return this.prisma.product.findFirst({
+      where: {
+        id: productId,
+        is_active: true,
+      },
+      select: { id: true },
+    });
+  }
+
   async findProductOwnership(args: { productId: bigint; storeId: bigint }) {
     return this.prisma.product.findFirst({
       where: {

--- a/src/features/user/repositories/recent-product-view.repository.ts
+++ b/src/features/user/repositories/recent-product-view.repository.ts
@@ -22,6 +22,133 @@ export interface RecentViewedProductRow {
 export class RecentProductViewRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  async findRecentByAccountPaginated(args: {
+    accountId: bigint;
+    offset: number;
+    limit: number;
+  }): Promise<{ items: RecentViewedProductRow[]; totalCount: number }> {
+    const where = {
+      account_id: args.accountId,
+      product: {
+        deleted_at: null,
+        is_active: true,
+        store: { deleted_at: null },
+      },
+    };
+
+    const selectFields = {
+      product_id: true as const,
+      viewed_at: true as const,
+      product: {
+        select: {
+          name: true as const,
+          regular_price: true as const,
+          sale_price: true as const,
+          store: { select: { store_name: true as const } },
+          images: {
+            where: { deleted_at: null },
+            orderBy: { sort_order: 'asc' as const },
+            take: 1,
+            select: { image_url: true as const },
+          },
+        },
+      },
+    };
+
+    const [items, totalCount] = await this.prisma.$transaction([
+      this.prisma.recentProductView.findMany({
+        where,
+        orderBy: { viewed_at: 'desc' },
+        skip: args.offset,
+        take: args.limit,
+        select: selectFields,
+      }),
+      this.prisma.recentProductView.count({ where }),
+    ]);
+
+    return { items, totalCount };
+  }
+
+  async upsertView(args: {
+    accountId: bigint;
+    productId: bigint;
+    now: Date;
+  }): Promise<void> {
+    await this.prisma.recentProductView.upsert({
+      where: {
+        account_id_product_id: {
+          account_id: args.accountId,
+          product_id: args.productId,
+        },
+      },
+      create: {
+        account_id: args.accountId,
+        product_id: args.productId,
+        viewed_at: args.now,
+      },
+      update: {
+        viewed_at: args.now,
+        deleted_at: null,
+      },
+    });
+  }
+
+  async countByAccount(accountId: bigint): Promise<number> {
+    return this.prisma.recentProductView.count({
+      where: { account_id: accountId },
+    });
+  }
+
+  async deleteOldestOverLimit(args: {
+    accountId: bigint;
+    maxCount: number;
+    now: Date;
+  }): Promise<void> {
+    const oldest = await this.prisma.recentProductView.findMany({
+      where: { account_id: args.accountId },
+      orderBy: { viewed_at: 'desc' },
+      skip: args.maxCount,
+      select: { id: true },
+    });
+
+    if (oldest.length > 0) {
+      await this.prisma.recentProductView.updateMany({
+        where: { id: { in: oldest.map((o) => o.id) } },
+        data: { deleted_at: args.now },
+      });
+    }
+  }
+
+  async softDeleteByProduct(args: {
+    accountId: bigint;
+    productId: bigint;
+    now: Date;
+  }): Promise<boolean> {
+    const result = await this.prisma.recentProductView.updateMany({
+      where: {
+        account_id: args.accountId,
+        product_id: args.productId,
+        deleted_at: null,
+      },
+      data: { deleted_at: args.now },
+    });
+    return result.count > 0;
+  }
+
+  async softDeleteAllByAccount(args: {
+    accountId: bigint;
+    now: Date;
+  }): Promise<number> {
+    const result = await this.prisma.recentProductView.updateMany({
+      where: {
+        account_id: args.accountId,
+        deleted_at: null,
+      },
+      data: { deleted_at: args.now },
+    });
+    return result.count;
+  }
+
   async findRecentByAccount(
     accountId: bigint,
     limit: number,

--- a/src/features/user/repositories/recent-product-view.repository.ts
+++ b/src/features/user/repositories/recent-product-view.repository.ts
@@ -29,6 +29,7 @@ export class RecentProductViewRepository {
   }): Promise<{ items: RecentViewedProductRow[]; totalCount: number }> {
     const where = {
       account_id: args.accountId,
+      deleted_at: null,
       product: {
         deleted_at: null,
         is_active: true,
@@ -95,7 +96,7 @@ export class RecentProductViewRepository {
 
   async countByAccount(accountId: bigint): Promise<number> {
     return this.prisma.recentProductView.count({
-      where: { account_id: accountId },
+      where: { account_id: accountId, deleted_at: null },
     });
   }
 
@@ -105,7 +106,7 @@ export class RecentProductViewRepository {
     now: Date;
   }): Promise<void> {
     const oldest = await this.prisma.recentProductView.findMany({
-      where: { account_id: args.accountId },
+      where: { account_id: args.accountId, deleted_at: null },
       orderBy: { viewed_at: 'desc' },
       skip: args.maxCount,
       select: { id: true },

--- a/src/features/user/resolvers/user-recent-view-mutation.resolver.ts
+++ b/src/features/user/resolvers/user-recent-view-mutation.resolver.ts
@@ -1,0 +1,40 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+import { UserRecentViewService } from '@/features/user/services/user-recent-view.service';
+import {
+  CurrentUser,
+  JwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+@Resolver('Mutation')
+@UseGuards(JwtAuthGuard)
+export class UserRecentViewMutationResolver {
+  constructor(private readonly recentViewService: UserRecentViewService) {}
+
+  @Mutation('recordProductView')
+  recordProductView(
+    @CurrentUser() user: JwtUser,
+    @Args('productId') productId: string,
+  ): Promise<boolean> {
+    const accountId = parseAccountId(user);
+    return this.recentViewService.record(accountId, productId);
+  }
+
+  @Mutation('deleteRecentViewedProduct')
+  deleteRecentViewedProduct(
+    @CurrentUser() user: JwtUser,
+    @Args('productId') productId: string,
+  ): Promise<boolean> {
+    const accountId = parseAccountId(user);
+    return this.recentViewService.deleteOne(accountId, productId);
+  }
+
+  @Mutation('clearRecentViewedProducts')
+  clearRecentViewedProducts(@CurrentUser() user: JwtUser): Promise<boolean> {
+    const accountId = parseAccountId(user);
+    return this.recentViewService.clearAll(accountId);
+  }
+}

--- a/src/features/user/resolvers/user-recent-view-query.resolver.ts
+++ b/src/features/user/resolvers/user-recent-view-query.resolver.ts
@@ -1,0 +1,25 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { UserRecentViewService } from '@/features/user/services/user-recent-view.service';
+import {
+  CurrentUser,
+  JwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+@Resolver('Query')
+@UseGuards(JwtAuthGuard)
+export class UserRecentViewQueryResolver {
+  constructor(private readonly recentViewService: UserRecentViewService) {}
+
+  @Query('myRecentViewedProducts')
+  myRecentViewedProducts(
+    @CurrentUser() user: JwtUser,
+    @Args('input') input?: { offset?: number; limit?: number },
+  ) {
+    const accountId = parseAccountId(user);
+    return this.recentViewService.list(accountId, input);
+  }
+}

--- a/src/features/user/services/user-mypage.service.spec.ts
+++ b/src/features/user/services/user-mypage.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CustomDraftStatus, OrderStatus } from '@prisma/client';
+import { OrderStatus } from '@prisma/client';
 
 import { OrderRepository } from '@/features/order/repositories/order.repository';
 import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';

--- a/src/features/user/services/user-recent-view.service.spec.ts
+++ b/src/features/user/services/user-recent-view.service.spec.ts
@@ -1,0 +1,168 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
+import { UserRecentViewService } from '@/features/user/services/user-recent-view.service';
+
+describe('UserRecentViewService', () => {
+  let service: UserRecentViewService;
+  let recentViewRepo: jest.Mocked<RecentProductViewRepository>;
+  let productRepo: jest.Mocked<ProductRepository>;
+
+  const accountId = BigInt(1);
+
+  beforeEach(async () => {
+    recentViewRepo = {
+      findRecentByAccountPaginated: jest.fn(),
+      upsertView: jest.fn(),
+      countByAccount: jest.fn(),
+      deleteOldestOverLimit: jest.fn(),
+      softDeleteByProduct: jest.fn(),
+      softDeleteAllByAccount: jest.fn(),
+    } as unknown as jest.Mocked<RecentProductViewRepository>;
+
+    productRepo = {
+      findActiveProduct: jest.fn(),
+    } as unknown as jest.Mocked<ProductRepository>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserRecentViewService,
+        { provide: RecentProductViewRepository, useValue: recentViewRepo },
+        { provide: ProductRepository, useValue: productRepo },
+      ],
+    }).compile();
+
+    service = module.get<UserRecentViewService>(UserRecentViewService);
+  });
+
+  describe('list', () => {
+    it('최근 본 상품 목록을 반환해야 한다', async () => {
+      recentViewRepo.findRecentByAccountPaginated.mockResolvedValue({
+        items: [
+          {
+            product_id: BigInt(200),
+            viewed_at: new Date('2026-04-12'),
+            product: {
+              name: '레터링 케이크',
+              regular_price: 45000,
+              sale_price: 40000,
+              store: { store_name: '스웨이드 베이커리' },
+              images: [{ image_url: 'https://s3.example.com/cake.jpg' }],
+            },
+          },
+        ],
+        totalCount: 1,
+      });
+
+      const result = await service.list(accountId);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        productId: '200',
+        productName: '레터링 케이크',
+        storeName: '스웨이드 베이커리',
+      });
+      expect(result.totalCount).toBe(1);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('offset + limit < totalCount이면 hasMore가 true여야 한다', async () => {
+      recentViewRepo.findRecentByAccountPaginated.mockResolvedValue({
+        items: [],
+        totalCount: 25,
+      });
+
+      const result = await service.list(accountId, { offset: 0, limit: 20 });
+
+      expect(result.hasMore).toBe(true);
+    });
+
+    it('limit이 0이면 에러를 던져야 한다', async () => {
+      await expect(service.list(accountId, { limit: 0 })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('offset이 음수이면 에러를 던져야 한다', async () => {
+      await expect(service.list(accountId, { offset: -1 })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('record', () => {
+    it('상품이 존재하면 upsert 후 초과분을 정리해야 한다', async () => {
+      productRepo.findActiveProduct.mockResolvedValue({ id: BigInt(200) });
+      recentViewRepo.upsertView.mockResolvedValue(undefined);
+      recentViewRepo.deleteOldestOverLimit.mockResolvedValue(undefined);
+
+      const result = await service.record(accountId, '200');
+
+      expect(result).toBe(true);
+      expect(recentViewRepo.upsertView).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId,
+          productId: BigInt(200),
+        }),
+      );
+      expect(recentViewRepo.deleteOldestOverLimit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId,
+          maxCount: 50,
+        }),
+      );
+    });
+
+    it('상품이 존재하지 않으면 NotFoundException을 던져야 한다', async () => {
+      productRepo.findActiveProduct.mockResolvedValue(null);
+
+      await expect(service.record(accountId, '999')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('유효하지 않은 productId이면 BadRequestException을 던져야 한다', async () => {
+      await expect(service.record(accountId, 'abc')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('deleteOne', () => {
+    it('삭제 성공 시 true를 반환해야 한다', async () => {
+      recentViewRepo.softDeleteByProduct.mockResolvedValue(true);
+
+      const result = await service.deleteOne(accountId, '200');
+
+      expect(result).toBe(true);
+    });
+
+    it('존재하지 않는 항목이면 false를 반환해야 한다', async () => {
+      recentViewRepo.softDeleteByProduct.mockResolvedValue(false);
+
+      const result = await service.deleteOne(accountId, '999');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('clearAll', () => {
+    it('전체 삭제 후 true를 반환해야 한다', async () => {
+      recentViewRepo.softDeleteAllByAccount.mockResolvedValue(5);
+
+      const result = await service.clearAll(accountId);
+
+      expect(result).toBe(true);
+    });
+
+    it('삭제할 항목이 없어도 true를 반환해야 한다', async () => {
+      recentViewRepo.softDeleteAllByAccount.mockResolvedValue(0);
+
+      const result = await service.clearAll(accountId);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/features/user/services/user-recent-view.service.ts
+++ b/src/features/user/services/user-recent-view.service.ts
@@ -1,0 +1,102 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { parseId } from '@/common/utils/id-parser';
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
+import type { RecentViewedProductConnection } from '@/features/user/types/user-mypage-output.type';
+
+/** 계정당 최대 보관 개수 */
+const MAX_RECENT_VIEWS = 50;
+
+const RECENT_VIEW_ERRORS = {
+  INVALID_LIMIT: '조회 개수는 1~50 사이여야 합니다.',
+  INVALID_OFFSET: '오프셋은 0 이상이어야 합니다.',
+  PRODUCT_NOT_FOUND: '상품을 찾을 수 없습니다.',
+} as const;
+
+@Injectable()
+export class UserRecentViewService {
+  constructor(
+    private readonly recentViewRepo: RecentProductViewRepository,
+    private readonly productRepo: ProductRepository,
+  ) {}
+
+  async list(
+    accountId: bigint,
+    input?: { offset?: number; limit?: number },
+  ): Promise<RecentViewedProductConnection> {
+    const offset = input?.offset ?? 0;
+    const limit = input?.limit ?? 20;
+
+    if (offset < 0) {
+      throw new BadRequestException(RECENT_VIEW_ERRORS.INVALID_OFFSET);
+    }
+    if (limit < 1 || limit > 50) {
+      throw new BadRequestException(RECENT_VIEW_ERRORS.INVALID_LIMIT);
+    }
+
+    const { items, totalCount } =
+      await this.recentViewRepo.findRecentByAccountPaginated({
+        accountId,
+        offset,
+        limit,
+      });
+
+    return {
+      items: items.map((view) => ({
+        productId: view.product_id.toString(),
+        productName: view.product.name,
+        representativeImageUrl: view.product.images[0]?.image_url ?? null,
+        salePrice: view.product.sale_price,
+        regularPrice: view.product.regular_price,
+        storeName: view.product.store.store_name,
+        viewedAt: view.viewed_at,
+      })),
+      totalCount,
+      hasMore: offset + limit < totalCount,
+    };
+  }
+
+  async record(accountId: bigint, productIdStr: string): Promise<boolean> {
+    const productId = parseId(productIdStr);
+    const now = new Date();
+
+    // 상품 존재 확인 (active + 삭제되지 않은 것)
+    const product = await this.productRepo.findActiveProduct(productId);
+    if (!product) {
+      throw new NotFoundException(RECENT_VIEW_ERRORS.PRODUCT_NOT_FOUND);
+    }
+
+    await this.recentViewRepo.upsertView({ accountId, productId, now });
+
+    // 초과분 정리
+    await this.recentViewRepo.deleteOldestOverLimit({
+      accountId,
+      maxCount: MAX_RECENT_VIEWS,
+      now,
+    });
+
+    return true;
+  }
+
+  async deleteOne(accountId: bigint, productIdStr: string): Promise<boolean> {
+    const productId = parseId(productIdStr);
+    return this.recentViewRepo.softDeleteByProduct({
+      accountId,
+      productId,
+      now: new Date(),
+    });
+  }
+
+  async clearAll(accountId: bigint): Promise<boolean> {
+    const count = await this.recentViewRepo.softDeleteAllByAccount({
+      accountId,
+      now: new Date(),
+    });
+    return count >= 0;
+  }
+}

--- a/src/features/user/types/user-mypage-output.type.ts
+++ b/src/features/user/types/user-mypage-output.type.ts
@@ -28,6 +28,12 @@ export interface RecentViewedProductSummary {
   viewedAt: Date;
 }
 
+export interface RecentViewedProductConnection {
+  items: RecentViewedProductSummary[];
+  totalCount: number;
+  hasMore: boolean;
+}
+
 export interface MyPageOverview {
   counts: MyPageCounts;
   ongoingOrders: OngoingOrderSummary[];

--- a/src/features/user/user-recent-view.graphql
+++ b/src/features/user/user-recent-view.graphql
@@ -1,0 +1,24 @@
+extend type Query {
+  """최근 본 상품 목록 조회"""
+  myRecentViewedProducts(input: MyRecentViewedProductsInput): RecentViewedProductConnection!
+}
+
+extend type Mutation {
+  """상품 상세 진입 시 호출하여 최근 본 상품에 기록"""
+  recordProductView(productId: ID!): Boolean!
+  """최근 본 상품 단건 삭제"""
+  deleteRecentViewedProduct(productId: ID!): Boolean!
+  """최근 본 상품 전체 삭제"""
+  clearRecentViewedProducts: Boolean!
+}
+
+input MyRecentViewedProductsInput {
+  offset: Int = 0
+  limit: Int = 20
+}
+
+type RecentViewedProductConnection {
+  items: [RecentViewedProductSummary!]!
+  totalCount: Int!
+  hasMore: Boolean!
+}

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { OrderModule } from '@/features/order/order.module';
+import { ProductModule } from '@/features/product/product.module';
 import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserEngagementMutationResolver } from '@/features/user/resolvers/user-engagement-mutation.resolver';
@@ -10,6 +11,8 @@ import { UserNotificationQueryResolver } from '@/features/user/resolvers/user-no
 import { UserOrderQueryResolver } from '@/features/user/resolvers/user-order-query.resolver';
 import { UserProfileMutationResolver } from '@/features/user/resolvers/user-profile-mutation.resolver';
 import { UserProfileQueryResolver } from '@/features/user/resolvers/user-profile-query.resolver';
+import { UserRecentViewMutationResolver } from '@/features/user/resolvers/user-recent-view-mutation.resolver';
+import { UserRecentViewQueryResolver } from '@/features/user/resolvers/user-recent-view-query.resolver';
 import { UserSearchMutationResolver } from '@/features/user/resolvers/user-search-mutation.resolver';
 import { UserSearchQueryResolver } from '@/features/user/resolvers/user-search-query.resolver';
 import { UserEngagementService } from '@/features/user/services/user-engagement.service';
@@ -17,13 +20,14 @@ import { UserMypageService } from '@/features/user/services/user-mypage.service'
 import { UserNotificationService } from '@/features/user/services/user-notification.service';
 import { UserOrderService } from '@/features/user/services/user-order.service';
 import { UserProfileService } from '@/features/user/services/user-profile.service';
+import { UserRecentViewService } from '@/features/user/services/user-recent-view.service';
 import { UserSearchService } from '@/features/user/services/user-search.service';
 
 /**
  * User 도메인 모듈
  */
 @Module({
-  imports: [OrderModule],
+  imports: [OrderModule, ProductModule],
   providers: [
     UserProfileService,
     UserNotificationService,
@@ -31,6 +35,7 @@ import { UserSearchService } from '@/features/user/services/user-search.service'
     UserEngagementService,
     UserMypageService,
     UserOrderService,
+    UserRecentViewService,
     UserRepository,
     RecentProductViewRepository,
     UserProfileQueryResolver,
@@ -38,6 +43,8 @@ import { UserSearchService } from '@/features/user/services/user-search.service'
     UserSearchQueryResolver,
     UserMypageQueryResolver,
     UserOrderQueryResolver,
+    UserRecentViewQueryResolver,
+    UserRecentViewMutationResolver,
     UserProfileMutationResolver,
     UserNotificationMutationResolver,
     UserSearchMutationResolver,

--- a/src/global/storage/s3.service.spec.ts
+++ b/src/global/storage/s3.service.spec.ts
@@ -1,7 +1,4 @@
-import {
-  BadRequestException,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 

--- a/src/global/storage/s3.service.ts
+++ b/src/global/storage/s3.service.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { extname } from 'node:path';
 
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';


### PR DESCRIPTION
## Summary
- **`myRecentViewedProducts` 쿼리**: offset 기반 페이지네이션으로 최근 본 상품 목록 조회
- **`recordProductView` mutation**: upsert (존재하면 viewed_at 갱신) + 50개 초과 시 오래된 항목 soft-delete
- **`deleteRecentViewedProduct` mutation**: 단건 soft-delete
- **`clearRecentViewedProducts` mutation**: 전체 soft-delete
- `RecentProductViewRepository` 확장: upsert, countByAccount, deleteOldestOverLimit, soft-delete 메서드
- `ProductRepository.findActiveProduct` 추가 (상품 존재 확인)
- `RecentViewedProductConnection` 타입을 공유 output DTO로 이동

## Test plan
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `yarn test` 전체 449 테스트 통과 (기존 438 + 신규 11)
- [ ] PR 리뷰 후 develop 머지