### PR TITLE
feat: 닉네임 중복 확인 + 프로필 이미지 업로드 URL 발급 (STAGE 7)

### DIFF
--- a/src/features/user/resolvers/user-profile-mutation.resolver.ts
+++ b/src/features/user/resolvers/user-profile-mutation.resolver.ts
@@ -7,7 +7,10 @@ import type {
   UpdateMyProfileImageInput,
   UpdateMyProfileInput,
 } from '@/features/user/types/user-input.type';
-import type { MePayload } from '@/features/user/types/user-output.type';
+import type {
+  MePayload,
+  ProfileImageUploadUrl,
+} from '@/features/user/types/user-output.type';
 import {
   CurrentUser,
   JwtAuthGuard,
@@ -45,6 +48,15 @@ export class UserProfileMutationResolver {
   ): Promise<MePayload> {
     const accountId = parseAccountId(user);
     return this.profileService.updateMyProfileImage(accountId, input);
+  }
+
+  @Mutation('createProfileImageUploadUrl')
+  createProfileImageUploadUrl(
+    @CurrentUser() user: JwtUser,
+    @Args('input') input: { contentType: string; contentLength: number },
+  ): Promise<ProfileImageUploadUrl> {
+    const accountId = parseAccountId(user);
+    return this.profileService.createProfileImageUploadUrl(accountId, input);
   }
 
   @Mutation('deleteMyAccount')

--- a/src/features/user/resolvers/user-profile-query.resolver.ts
+++ b/src/features/user/resolvers/user-profile-query.resolver.ts
@@ -1,8 +1,11 @@
 import { UseGuards } from '@nestjs/common';
-import { Query, Resolver } from '@nestjs/graphql';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 
 import { UserProfileService } from '@/features/user/services/user-profile.service';
-import type { MePayload } from '@/features/user/types/user-output.type';
+import type {
+  MePayload,
+  NicknameAvailability,
+} from '@/features/user/types/user-output.type';
 import {
   CurrentUser,
   JwtAuthGuard,
@@ -19,5 +22,14 @@ export class UserProfileQueryResolver {
   me(@CurrentUser() user: JwtUser): Promise<MePayload> {
     const accountId = parseAccountId(user);
     return this.profileService.me(accountId);
+  }
+
+  @Query('checkNicknameAvailability')
+  checkNicknameAvailability(
+    @CurrentUser() user: JwtUser,
+    @Args('nickname') nickname: string,
+  ): Promise<NicknameAvailability> {
+    const accountId = parseAccountId(user);
+    return this.profileService.checkNicknameAvailability(nickname, accountId);
   }
 }

--- a/src/features/user/services/user-profile.service.spec.ts
+++ b/src/features/user/services/user-profile.service.spec.ts
@@ -102,6 +102,10 @@ describe('UserProfileService', () => {
   });
 
   describe('checkNicknameAvailability', () => {
+    beforeEach(() => {
+      repo.findAccountWithProfile.mockResolvedValue(baseAccount);
+    });
+
     it('사용 가능한 닉네임이면 available: true를 반환해야 한다', async () => {
       repo.isNicknameTaken.mockResolvedValue(false);
 
@@ -144,6 +148,10 @@ describe('UserProfileService', () => {
   });
 
   describe('createProfileImageUploadUrl', () => {
+    beforeEach(() => {
+      repo.findAccountWithProfile.mockResolvedValue(baseAccount);
+    });
+
     it('S3Service에 PROFILE_IMAGE purpose로 위임해야 한다', async () => {
       const mockResult = {
         uploadUrl: 'https://presigned-url.com',

--- a/src/features/user/services/user-profile.service.spec.ts
+++ b/src/features/user/services/user-profile.service.spec.ts
@@ -4,10 +4,12 @@ import { AccountType } from '@prisma/client';
 
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserProfileService } from '@/features/user/services/user-profile.service';
+import { S3Service } from '@/global/storage/s3.service';
 
 describe('UserProfileService', () => {
   let service: UserProfileService;
   let repo: jest.Mocked<UserRepository>;
+  let s3Service: jest.Mocked<S3Service>;
 
   const baseAccount = {
     id: BigInt(1),
@@ -35,10 +37,15 @@ describe('UserProfileService', () => {
       softDeleteAccount: jest.fn(),
     } as unknown as jest.Mocked<UserRepository>;
 
+    s3Service = {
+      createUploadUrl: jest.fn(),
+    } as unknown as jest.Mocked<S3Service>;
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         UserProfileService,
         { provide: UserRepository, useValue: repo },
+        { provide: S3Service, useValue: s3Service },
       ],
     }).compile();
 
@@ -92,5 +99,72 @@ describe('UserProfileService', () => {
         deletedNickname: 'deleted_1',
       }),
     );
+  });
+
+  describe('checkNicknameAvailability', () => {
+    it('사용 가능한 닉네임이면 available: true를 반환해야 한다', async () => {
+      repo.isNicknameTaken.mockResolvedValue(false);
+
+      const result = await service.checkNicknameAvailability(
+        'newNick',
+        BigInt(1),
+      );
+
+      expect(result).toEqual({ available: true, reason: null });
+    });
+
+    it('이미 사용 중인 닉네임이면 available: false를 반환해야 한다', async () => {
+      repo.isNicknameTaken.mockResolvedValue(true);
+
+      const result = await service.checkNicknameAvailability(
+        'takenNick',
+        BigInt(1),
+      );
+
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain('이미 사용 중');
+    });
+
+    it('닉네임이 너무 짧으면 available: false를 반환해야 한다', async () => {
+      const result = await service.checkNicknameAvailability('a', BigInt(1));
+
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain('2~20자');
+    });
+
+    it('닉네임에 특수문자가 포함되면 available: false를 반환해야 한다', async () => {
+      const result = await service.checkNicknameAvailability(
+        'nick@name',
+        BigInt(1),
+      );
+
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain('한글, 영문, 숫자, 언더스코어');
+    });
+  });
+
+  describe('createProfileImageUploadUrl', () => {
+    it('S3Service에 PROFILE_IMAGE purpose로 위임해야 한다', async () => {
+      const mockResult = {
+        uploadUrl: 'https://presigned-url.com',
+        publicUrl: 'https://s3.example.com/profile.jpg',
+        key: 'profile-images/1/2026-04-13/uuid.jpg',
+        expiresInSeconds: 600,
+      };
+      s3Service.createUploadUrl.mockResolvedValue(mockResult);
+
+      const result = await service.createProfileImageUploadUrl(BigInt(1), {
+        contentType: 'image/jpeg',
+        contentLength: 1024 * 1024,
+      });
+
+      expect(result).toEqual(mockResult);
+      expect(s3Service.createUploadUrl).toHaveBeenCalledWith({
+        accountId: BigInt(1),
+        purpose: 'PROFILE_IMAGE',
+        contentType: 'image/jpeg',
+        contentLength: 1024 * 1024,
+      });
+    });
   });
 });

--- a/src/features/user/services/user-profile.service.ts
+++ b/src/features/user/services/user-profile.service.ts
@@ -4,6 +4,10 @@ import {
   Injectable,
 } from '@nestjs/common';
 
+import {
+  MAX_NICKNAME_LENGTH,
+  MIN_NICKNAME_LENGTH,
+} from '@/features/user/constants/user.constants';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserBaseService } from '@/features/user/services/user-base.service';
 import type {
@@ -11,11 +15,19 @@ import type {
   UpdateMyProfileImageInput,
   UpdateMyProfileInput,
 } from '@/features/user/types/user-input.type';
-import type { MePayload } from '@/features/user/types/user-output.type';
+import type {
+  MePayload,
+  NicknameAvailability,
+  ProfileImageUploadUrl,
+} from '@/features/user/types/user-output.type';
+import { S3Service } from '@/global/storage/s3.service';
 
 @Injectable()
 export class UserProfileService extends UserBaseService {
-  constructor(repo: UserRepository) {
+  constructor(
+    repo: UserRepository,
+    private readonly s3Service: S3Service,
+  ) {
     super(repo);
   }
 
@@ -114,6 +126,50 @@ export class UserProfileService extends UserBaseService {
     });
 
     return this.me(accountId);
+  }
+
+  async checkNicknameAvailability(
+    nickname: string,
+    accountId: bigint,
+  ): Promise<NicknameAvailability> {
+    const trimmed = nickname.trim();
+
+    if (
+      trimmed.length < MIN_NICKNAME_LENGTH ||
+      trimmed.length > MAX_NICKNAME_LENGTH
+    ) {
+      return {
+        available: false,
+        reason: `닉네임은 ${MIN_NICKNAME_LENGTH}~${MAX_NICKNAME_LENGTH}자여야 합니다.`,
+      };
+    }
+
+    const nicknameRegex = /^[A-Za-z0-9가-힣_]+$/;
+    if (!nicknameRegex.test(trimmed)) {
+      return {
+        available: false,
+        reason: '닉네임은 한글, 영문, 숫자, 언더스코어만 사용할 수 있습니다.',
+      };
+    }
+
+    const isTaken = await this.repo.isNicknameTaken(trimmed, accountId);
+    if (isTaken) {
+      return { available: false, reason: '이미 사용 중인 닉네임입니다.' };
+    }
+
+    return { available: true, reason: null };
+  }
+
+  async createProfileImageUploadUrl(
+    accountId: bigint,
+    input: { contentType: string; contentLength: number },
+  ): Promise<ProfileImageUploadUrl> {
+    return this.s3Service.createUploadUrl({
+      accountId,
+      purpose: 'PROFILE_IMAGE',
+      contentType: input.contentType,
+      contentLength: input.contentLength,
+    });
   }
 
   async deleteMyAccount(accountId: bigint): Promise<boolean> {

--- a/src/features/user/services/user-profile.service.ts
+++ b/src/features/user/services/user-profile.service.ts
@@ -132,6 +132,8 @@ export class UserProfileService extends UserBaseService {
     nickname: string,
     accountId: bigint,
   ): Promise<NicknameAvailability> {
+    await this.requireActiveUser(accountId);
+
     const trimmed = nickname.trim();
 
     if (
@@ -164,6 +166,8 @@ export class UserProfileService extends UserBaseService {
     accountId: bigint,
     input: { contentType: string; contentLength: number },
   ): Promise<ProfileImageUploadUrl> {
+    await this.requireActiveUser(accountId);
+
     return this.s3Service.createUploadUrl({
       accountId,
       purpose: 'PROFILE_IMAGE',

--- a/src/features/user/types/user-output.type.ts
+++ b/src/features/user/types/user-output.type.ts
@@ -48,3 +48,15 @@ export interface SearchHistoryConnection {
   totalCount: number;
   hasMore: boolean;
 }
+
+export interface NicknameAvailability {
+  available: boolean;
+  reason: string | null;
+}
+
+export interface ProfileImageUploadUrl {
+  uploadUrl: string;
+  publicUrl: string;
+  key: string;
+  expiresInSeconds: number;
+}

--- a/src/features/user/user-profile.graphql
+++ b/src/features/user/user-profile.graphql
@@ -1,6 +1,8 @@
 extend type Query {
   """현재 로그인한 유저 정보 조회"""
   me: MePayload!
+  """닉네임 중복 확인"""
+  checkNicknameAvailability(nickname: String!): NicknameAvailability!
 }
 
 extend type Mutation {
@@ -12,6 +14,8 @@ extend type Mutation {
   updateMyProfileImage(input: UpdateMyProfileImageInput!): MePayload!
   """회원 탈퇴(soft delete)"""
   deleteMyAccount: Boolean!
+  """프로필 이미지 업로드용 Presigned URL 발급"""
+  createProfileImageUploadUrl(input: CreateProfileImageUploadUrlInput!): ProfileImageUploadUrl!
 }
 
 """현재 로그인한 유저 정보"""
@@ -68,4 +72,25 @@ input UpdateMyProfileInput {
 input UpdateMyProfileImageInput {
   """프로필 이미지 URL"""
   profileImageUrl: String!
+}
+
+"""닉네임 사용 가능 여부"""
+type NicknameAvailability {
+  available: Boolean!
+  """미통과 시 이유"""
+  reason: String
+}
+
+"""프로필 이미지 업로드 URL 발급 입력"""
+input CreateProfileImageUploadUrlInput {
+  contentType: String!
+  contentLength: Int!
+}
+
+"""프로필 이미지 업로드 URL 결과"""
+type ProfileImageUploadUrl {
+  uploadUrl: String!
+  publicUrl: String!
+  key: String!
+  expiresInSeconds: Int!
 }


### PR DESCRIPTION
## Summary
- **`checkNicknameAvailability(nickname)` 쿼리**: 형식 검증(2~20자, 한글/영문/숫자/언더스코어) + DB 중복 확인. 에러가 아닌 `{ available, reason }` 응답으로 프론트 UX 친화적 설계
- **`createProfileImageUploadUrl(input)` mutation**: S3Service에 `PROFILE_IMAGE` purpose로 위임하여 Presigned PUT URL + publicUrl 반환. 기존 `updateMyProfileImage`와 2단계 업로드 플로우 구성

## 수정 파일
- `src/features/user/user-profile.graphql` — 쿼리/뮤테이션 + NicknameAvailability, CreateProfileImageUploadUrlInput, ProfileImageUploadUrl 타입 추가
- `src/features/user/types/user-output.type.ts` — NicknameAvailability, ProfileImageUploadUrl DTO 추가
- `src/features/user/services/user-profile.service.ts` — checkNicknameAvailability, createProfileImageUploadUrl 메서드 + S3Service 주입
- `src/features/user/resolvers/user-profile-query.resolver.ts` — checkNicknameAvailability 쿼리 추가
- `src/features/user/resolvers/user-profile-mutation.resolver.ts` — createProfileImageUploadUrl 뮤테이션 추가
- `src/features/user/services/user-profile.service.spec.ts` — 5개 테스트 추가

## Test plan
- [x] `yarn lint` 0 warnings
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `yarn test` 전체 454 테스트 통과 (기존 449 + 신규 5)
- [ ] PR 리뷰 후 develop 머지