### PR TITLE
feat: 리뷰 작성/조회/삭제 + 리뷰 미디어 업로드 API 구현 (STAGE 8)

### DIFF
--- a/src/features/user/constants/user-review-error-messages.ts
+++ b/src/features/user/constants/user-review-error-messages.ts
@@ -1,0 +1,10 @@
+export const USER_REVIEW_ERRORS = {
+  INVALID_RATING: '별점은 1.0~5.0 사이, 0.5 단위여야 합니다.',
+  CONTENT_TOO_SHORT: '리뷰는 최소 20자 이상이어야 합니다.',
+  CONTENT_TOO_LONG: '리뷰는 최대 1000자까지 작성 가능합니다.',
+  TOO_MANY_MEDIA: '미디어는 최대 10개까지 첨부할 수 있습니다.',
+  ORDER_ITEM_NOT_FOUND: '주문 아이템을 찾을 수 없습니다.',
+  CANNOT_WRITE_REVIEW: '리뷰를 작성할 수 없는 주문입니다.',
+  REVIEW_ALREADY_EXISTS: '이미 리뷰가 작성된 주문 아이템입니다.',
+  REVIEW_NOT_FOUND: '리뷰를 찾을 수 없습니다.',
+} as const;

--- a/src/features/user/repositories/review.repository.ts
+++ b/src/features/user/repositories/review.repository.ts
@@ -101,7 +101,7 @@ export class ReviewRepository {
     });
   }
 
-  private async findReviewById(
+  async findReviewById(
     reviewId: bigint,
     tx?: Parameters<Parameters<PrismaService['$transaction']>[0]>[0],
   ) {

--- a/src/features/user/repositories/review.repository.ts
+++ b/src/features/user/repositories/review.repository.ts
@@ -36,13 +36,14 @@ export class ReviewRepository {
     });
   }
 
-  async createReviewWithMedia(args: {
+  async createOrRestoreReviewWithMedia(args: {
     orderItemId: bigint;
     accountId: bigint;
     storeId: bigint;
     productId: bigint;
     rating: number;
     content: string;
+    existingDeletedReviewId?: bigint;
     media: {
       media_type: ReviewMediaType;
       media_url: string;
@@ -51,21 +52,43 @@ export class ReviewRepository {
     }[];
   }) {
     return this.prisma.$transaction(async (tx) => {
-      const review = await tx.review.create({
-        data: {
-          order_item_id: args.orderItemId,
-          account_id: args.accountId,
-          store_id: args.storeId,
-          product_id: args.productId,
-          rating: args.rating,
-          content: args.content,
-        },
-      });
+      let reviewId: bigint;
+
+      if (args.existingDeletedReviewId) {
+        // soft-delete된 기존 리뷰를 복원 + 내용 교체
+        const restored = await tx.review.update({
+          where: { id: args.existingDeletedReviewId },
+          data: {
+            rating: args.rating,
+            content: args.content,
+            deleted_at: null,
+          },
+        });
+        reviewId = restored.id;
+
+        // 기존 미디어 soft-delete
+        await tx.reviewMedia.updateMany({
+          where: { review_id: reviewId },
+          data: { deleted_at: new Date() },
+        });
+      } else {
+        const review = await tx.review.create({
+          data: {
+            order_item_id: args.orderItemId,
+            account_id: args.accountId,
+            store_id: args.storeId,
+            product_id: args.productId,
+            rating: args.rating,
+            content: args.content,
+          },
+        });
+        reviewId = review.id;
+      }
 
       if (args.media.length > 0) {
         await tx.reviewMedia.createMany({
           data: args.media.map((m) => ({
-            review_id: review.id,
+            review_id: reviewId,
             media_type: m.media_type,
             media_url: m.media_url,
             thumbnail_url: m.thumbnail_url,
@@ -74,7 +97,7 @@ export class ReviewRepository {
         });
       }
 
-      return this.findReviewById(review.id, tx);
+      return this.findReviewById(reviewId, tx);
     });
   }
 

--- a/src/features/user/repositories/review.repository.ts
+++ b/src/features/user/repositories/review.repository.ts
@@ -1,0 +1,174 @@
+import { Injectable } from '@nestjs/common';
+import type { ReviewMediaType } from '@prisma/client';
+
+import { PrismaService } from '@/prisma';
+
+@Injectable()
+export class ReviewRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findOrderItemForReview(args: {
+    orderItemId: bigint;
+    accountId: bigint;
+  }) {
+    return this.prisma.orderItem.findFirst({
+      where: {
+        id: args.orderItemId,
+        order: { account_id: args.accountId },
+      },
+      include: {
+        order: { select: { status: true, account_id: true } },
+        review: { select: { id: true, deleted_at: true } },
+        store: { select: { store_name: true } },
+        product: {
+          select: {
+            id: true,
+            name: true,
+            images: {
+              where: { deleted_at: null },
+              orderBy: { sort_order: 'asc' },
+              take: 1,
+              select: { image_url: true },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  async createReviewWithMedia(args: {
+    orderItemId: bigint;
+    accountId: bigint;
+    storeId: bigint;
+    productId: bigint;
+    rating: number;
+    content: string;
+    media: {
+      media_type: ReviewMediaType;
+      media_url: string;
+      thumbnail_url: string | null;
+      sort_order: number;
+    }[];
+  }) {
+    return this.prisma.$transaction(async (tx) => {
+      const review = await tx.review.create({
+        data: {
+          order_item_id: args.orderItemId,
+          account_id: args.accountId,
+          store_id: args.storeId,
+          product_id: args.productId,
+          rating: args.rating,
+          content: args.content,
+        },
+      });
+
+      if (args.media.length > 0) {
+        await tx.reviewMedia.createMany({
+          data: args.media.map((m) => ({
+            review_id: review.id,
+            media_type: m.media_type,
+            media_url: m.media_url,
+            thumbnail_url: m.thumbnail_url,
+            sort_order: m.sort_order,
+          })),
+        });
+      }
+
+      return this.findReviewById(review.id, tx);
+    });
+  }
+
+  private async findReviewById(
+    reviewId: bigint,
+    tx?: Parameters<Parameters<PrismaService['$transaction']>[0]>[0],
+  ) {
+    const prisma = tx ?? this.prisma;
+    return prisma.review.findFirst({
+      where: { id: reviewId },
+      include: {
+        order_item: {
+          select: {
+            id: true,
+            product_name_snapshot: true,
+            store: { select: { store_name: true } },
+            product: {
+              select: {
+                id: true,
+                images: {
+                  where: { deleted_at: null },
+                  orderBy: { sort_order: 'asc' },
+                  take: 1,
+                  select: { image_url: true },
+                },
+              },
+            },
+          },
+        },
+        media: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+        },
+      },
+    });
+  }
+
+  async listMyReviews(args: {
+    accountId: bigint;
+    offset: number;
+    limit: number;
+  }) {
+    const where = { account_id: args.accountId };
+
+    const [items, totalCount] = await this.prisma.$transaction([
+      this.prisma.review.findMany({
+        where,
+        orderBy: { created_at: 'desc' },
+        skip: args.offset,
+        take: args.limit,
+        include: {
+          order_item: {
+            select: {
+              id: true,
+              product_name_snapshot: true,
+              store: { select: { store_name: true } },
+              product: {
+                select: {
+                  id: true,
+                  images: {
+                    where: { deleted_at: null },
+                    orderBy: { sort_order: 'asc' },
+                    take: 1,
+                    select: { image_url: true },
+                  },
+                },
+              },
+            },
+          },
+          media: {
+            where: { deleted_at: null },
+            orderBy: { sort_order: 'asc' },
+          },
+        },
+      }),
+      this.prisma.review.count({ where }),
+    ]);
+
+    return { items, totalCount };
+  }
+
+  async softDeleteReview(args: {
+    reviewId: bigint;
+    accountId: bigint;
+    now: Date;
+  }): Promise<boolean> {
+    const result = await this.prisma.review.updateMany({
+      where: {
+        id: args.reviewId,
+        account_id: args.accountId,
+        deleted_at: null,
+      },
+      data: { deleted_at: args.now },
+    });
+    return result.count > 0;
+  }
+}

--- a/src/features/user/resolvers/user-review-mutation.resolver.ts
+++ b/src/features/user/resolvers/user-review-mutation.resolver.ts
@@ -1,0 +1,51 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+import { UserReviewService } from '@/features/user/services/user-review.service';
+import type {
+  CreateReviewMediaUploadUrlInput,
+  WriteReviewInput,
+} from '@/features/user/types/user-review-input.type';
+import type {
+  MyReview,
+  ReviewMediaUploadUrl,
+} from '@/features/user/types/user-review-output.type';
+import {
+  CurrentUser,
+  JwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+@Resolver('Mutation')
+@UseGuards(JwtAuthGuard)
+export class UserReviewMutationResolver {
+  constructor(private readonly reviewService: UserReviewService) {}
+
+  @Mutation('writeReview')
+  writeReview(
+    @CurrentUser() user: JwtUser,
+    @Args('input') input: WriteReviewInput,
+  ): Promise<MyReview> {
+    const accountId = parseAccountId(user);
+    return this.reviewService.writeReview(accountId, input);
+  }
+
+  @Mutation('deleteMyReview')
+  deleteMyReview(
+    @CurrentUser() user: JwtUser,
+    @Args('reviewId') reviewId: string,
+  ): Promise<boolean> {
+    const accountId = parseAccountId(user);
+    return this.reviewService.deleteMyReview(accountId, reviewId);
+  }
+
+  @Mutation('createReviewMediaUploadUrl')
+  createReviewMediaUploadUrl(
+    @CurrentUser() user: JwtUser,
+    @Args('input') input: CreateReviewMediaUploadUrlInput,
+  ): Promise<ReviewMediaUploadUrl> {
+    const accountId = parseAccountId(user);
+    return this.reviewService.createReviewMediaUploadUrl(accountId, input);
+  }
+}

--- a/src/features/user/resolvers/user-review-query.resolver.ts
+++ b/src/features/user/resolvers/user-review-query.resolver.ts
@@ -1,0 +1,39 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { UserReviewService } from '@/features/user/services/user-review.service';
+import type { MyReviewsInput } from '@/features/user/types/user-review-input.type';
+import type {
+  MyReviewConnection,
+  MyReviewOrNull,
+} from '@/features/user/types/user-review-output.type';
+import {
+  CurrentUser,
+  JwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+@Resolver('Query')
+@UseGuards(JwtAuthGuard)
+export class UserReviewQueryResolver {
+  constructor(private readonly reviewService: UserReviewService) {}
+
+  @Query('myReviews')
+  myReviews(
+    @CurrentUser() user: JwtUser,
+    @Args('input') input?: MyReviewsInput,
+  ): Promise<MyReviewConnection> {
+    const accountId = parseAccountId(user);
+    return this.reviewService.myReviews(accountId, input);
+  }
+
+  @Query('myReviewForOrderItem')
+  myReviewForOrderItem(
+    @CurrentUser() user: JwtUser,
+    @Args('orderItemId') orderItemId: string,
+  ): Promise<MyReviewOrNull> {
+    const accountId = parseAccountId(user);
+    return this.reviewService.myReviewForOrderItem(accountId, orderItemId);
+  }
+}

--- a/src/features/user/services/user-review.service.spec.ts
+++ b/src/features/user/services/user-review.service.spec.ts
@@ -39,6 +39,7 @@ describe('UserReviewService', () => {
   beforeEach(async () => {
     reviewRepo = {
       findOrderItemForReview: jest.fn(),
+      findReviewById: jest.fn(),
       createOrRestoreReviewWithMedia: jest.fn(),
       listMyReviews: jest.fn(),
       softDeleteReview: jest.fn(),

--- a/src/features/user/services/user-review.service.spec.ts
+++ b/src/features/user/services/user-review.service.spec.ts
@@ -39,7 +39,7 @@ describe('UserReviewService', () => {
   beforeEach(async () => {
     reviewRepo = {
       findOrderItemForReview: jest.fn(),
-      createReviewWithMedia: jest.fn(),
+      createOrRestoreReviewWithMedia: jest.fn(),
       listMyReviews: jest.fn(),
       softDeleteReview: jest.fn(),
     } as unknown as jest.Mocked<ReviewRepository>;
@@ -64,7 +64,7 @@ describe('UserReviewService', () => {
       reviewRepo.findOrderItemForReview.mockResolvedValue(
         mockOrderItem as never,
       );
-      reviewRepo.createReviewWithMedia.mockResolvedValue({
+      reviewRepo.createOrRestoreReviewWithMedia.mockResolvedValue({
         id: BigInt(500),
         order_item_id: BigInt(200),
         product_id: BigInt(300),
@@ -125,7 +125,7 @@ describe('UserReviewService', () => {
         ...mockOrderItem,
         review: { id: BigInt(1), deleted_at: new Date() },
       } as never);
-      reviewRepo.createReviewWithMedia.mockResolvedValue({
+      reviewRepo.createOrRestoreReviewWithMedia.mockResolvedValue({
         id: BigInt(501),
         order_item_id: BigInt(200),
         product_id: BigInt(300),

--- a/src/features/user/services/user-review.service.spec.ts
+++ b/src/features/user/services/user-review.service.spec.ts
@@ -1,0 +1,311 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrderStatus } from '@prisma/client';
+
+import { USER_REVIEW_ERRORS } from '@/features/user/constants/user-review-error-messages';
+import { ReviewRepository } from '@/features/user/repositories/review.repository';
+import { UserReviewService } from '@/features/user/services/user-review.service';
+import { S3Service } from '@/global/storage/s3.service';
+
+describe('UserReviewService', () => {
+  let service: UserReviewService;
+  let reviewRepo: jest.Mocked<ReviewRepository>;
+  let s3Service: jest.Mocked<S3Service>;
+
+  const accountId = BigInt(1);
+
+  const mockOrderItem = {
+    id: BigInt(200),
+    store_id: BigInt(10),
+    product_id: BigInt(300),
+    product_name_snapshot: '딸기 케이크',
+    order: { status: OrderStatus.PICKED_UP, account_id: accountId },
+    review: null,
+    store: { store_name: '스웨이드 베이커리' },
+    product: {
+      id: BigInt(300),
+      name: '딸기 케이크',
+      images: [{ image_url: 'https://s3.example.com/cake.jpg' }],
+    },
+  };
+
+  const validInput = {
+    orderItemId: '200',
+    rating: 4.5,
+    content: '정말 맛있는 케이크였습니다. 데코레이션도 예쁘고 추천합니다!',
+    media: [],
+  };
+
+  beforeEach(async () => {
+    reviewRepo = {
+      findOrderItemForReview: jest.fn(),
+      createReviewWithMedia: jest.fn(),
+      listMyReviews: jest.fn(),
+      softDeleteReview: jest.fn(),
+    } as unknown as jest.Mocked<ReviewRepository>;
+
+    s3Service = {
+      createUploadUrl: jest.fn(),
+    } as unknown as jest.Mocked<S3Service>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserReviewService,
+        { provide: ReviewRepository, useValue: reviewRepo },
+        { provide: S3Service, useValue: s3Service },
+      ],
+    }).compile();
+
+    service = module.get<UserReviewService>(UserReviewService);
+  });
+
+  describe('writeReview', () => {
+    it('유효한 입력이면 리뷰를 생성해야 한다', async () => {
+      reviewRepo.findOrderItemForReview.mockResolvedValue(
+        mockOrderItem as never,
+      );
+      reviewRepo.createReviewWithMedia.mockResolvedValue({
+        id: BigInt(500),
+        order_item_id: BigInt(200),
+        product_id: BigInt(300),
+        rating: 4.5 as never,
+        content: validInput.content,
+        created_at: new Date(),
+        order_item: {
+          id: BigInt(200),
+          product_name_snapshot: '딸기 케이크',
+          store: { store_name: '스웨이드 베이커리' },
+          product: {
+            id: BigInt(300),
+            images: [{ image_url: 'https://s3.example.com/cake.jpg' }],
+          },
+        },
+        media: [],
+      } as never);
+
+      const result = await service.writeReview(accountId, validInput);
+
+      expect(result.reviewId).toBe('500');
+      expect(result.rating).toBe(4.5);
+      expect(result.productName).toBe('딸기 케이크');
+    });
+
+    it('주문 아이템이 없으면 NotFoundException을 던져야 한다', async () => {
+      reviewRepo.findOrderItemForReview.mockResolvedValue(null);
+
+      await expect(service.writeReview(accountId, validInput)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('PICKED_UP이 아니면 BadRequestException을 던져야 한다', async () => {
+      reviewRepo.findOrderItemForReview.mockResolvedValue({
+        ...mockOrderItem,
+        order: { status: OrderStatus.CONFIRMED, account_id: accountId },
+      } as never);
+
+      await expect(service.writeReview(accountId, validInput)).rejects.toThrow(
+        USER_REVIEW_ERRORS.CANNOT_WRITE_REVIEW,
+      );
+    });
+
+    it('이미 리뷰가 있으면 ConflictException을 던져야 한다', async () => {
+      reviewRepo.findOrderItemForReview.mockResolvedValue({
+        ...mockOrderItem,
+        review: { id: BigInt(1), deleted_at: null },
+      } as never);
+
+      await expect(service.writeReview(accountId, validInput)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('soft-delete된 리뷰가 있으면 새 리뷰를 작성할 수 있어야 한다', async () => {
+      reviewRepo.findOrderItemForReview.mockResolvedValue({
+        ...mockOrderItem,
+        review: { id: BigInt(1), deleted_at: new Date() },
+      } as never);
+      reviewRepo.createReviewWithMedia.mockResolvedValue({
+        id: BigInt(501),
+        order_item_id: BigInt(200),
+        product_id: BigInt(300),
+        rating: 4.5 as never,
+        content: validInput.content,
+        created_at: new Date(),
+        order_item: {
+          id: BigInt(200),
+          product_name_snapshot: '딸기 케이크',
+          store: { store_name: '스웨이드 베이커리' },
+          product: { id: BigInt(300), images: [] },
+        },
+        media: [],
+      } as never);
+
+      const result = await service.writeReview(accountId, validInput);
+
+      expect(result.reviewId).toBe('501');
+    });
+
+    describe('입력 검증', () => {
+      beforeEach(() => {
+        reviewRepo.findOrderItemForReview.mockResolvedValue(
+          mockOrderItem as never,
+        );
+      });
+
+      it('별점이 0.5 단위가 아니면 에러를 던져야 한다', async () => {
+        await expect(
+          service.writeReview(accountId, { ...validInput, rating: 4.3 }),
+        ).rejects.toThrow(USER_REVIEW_ERRORS.INVALID_RATING);
+      });
+
+      it('별점이 0이면 에러를 던져야 한다', async () => {
+        await expect(
+          service.writeReview(accountId, { ...validInput, rating: 0 }),
+        ).rejects.toThrow(USER_REVIEW_ERRORS.INVALID_RATING);
+      });
+
+      it('별점이 5.5이면 에러를 던져야 한다', async () => {
+        await expect(
+          service.writeReview(accountId, { ...validInput, rating: 5.5 }),
+        ).rejects.toThrow(USER_REVIEW_ERRORS.INVALID_RATING);
+      });
+
+      it('내용이 20자 미만이면 에러를 던져야 한다', async () => {
+        await expect(
+          service.writeReview(accountId, {
+            ...validInput,
+            content: '짧은 리뷰',
+          }),
+        ).rejects.toThrow(USER_REVIEW_ERRORS.CONTENT_TOO_SHORT);
+      });
+
+      it('내용이 1000자 초과이면 에러를 던져야 한다', async () => {
+        await expect(
+          service.writeReview(accountId, {
+            ...validInput,
+            content: 'a'.repeat(1001),
+          }),
+        ).rejects.toThrow(USER_REVIEW_ERRORS.CONTENT_TOO_LONG);
+      });
+
+      it('미디어가 10개 초과이면 에러를 던져야 한다', async () => {
+        const media = Array.from({ length: 11 }, (_, i) => ({
+          mediaType: 'IMAGE' as const,
+          mediaUrl: `https://s3.example.com/${i}.jpg`,
+          sortOrder: i,
+        }));
+
+        await expect(
+          service.writeReview(accountId, { ...validInput, media }),
+        ).rejects.toThrow(USER_REVIEW_ERRORS.TOO_MANY_MEDIA);
+      });
+    });
+  });
+
+  describe('myReviews', () => {
+    it('리뷰 목록을 반환해야 한다', async () => {
+      reviewRepo.listMyReviews.mockResolvedValue({
+        items: [],
+        totalCount: 0,
+      });
+
+      const result = await service.myReviews(accountId);
+
+      expect(result.items).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+  });
+
+  describe('deleteMyReview', () => {
+    it('삭제 성공 시 true를 반환해야 한다', async () => {
+      reviewRepo.softDeleteReview.mockResolvedValue(true);
+
+      const result = await service.deleteMyReview(accountId, '500');
+
+      expect(result).toBe(true);
+    });
+
+    it('리뷰를 찾을 수 없으면 NotFoundException을 던져야 한다', async () => {
+      reviewRepo.softDeleteReview.mockResolvedValue(false);
+
+      await expect(service.deleteMyReview(accountId, '999')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('createReviewMediaUploadUrl', () => {
+    it('IMAGE 타입이면 REVIEW_IMAGE purpose로 위임해야 한다', async () => {
+      s3Service.createUploadUrl.mockResolvedValue({
+        uploadUrl: 'https://presigned.url',
+        publicUrl: 'https://s3.example.com/img.jpg',
+        key: 'review-media/images/1/img.jpg',
+        expiresInSeconds: 600,
+      });
+
+      await service.createReviewMediaUploadUrl(accountId, {
+        mediaType: 'IMAGE',
+        contentType: 'image/jpeg',
+        contentLength: 1024,
+      });
+
+      expect(s3Service.createUploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ purpose: 'REVIEW_IMAGE' }),
+      );
+    });
+
+    it('VIDEO 타입이면 REVIEW_VIDEO purpose로 위임해야 한다', async () => {
+      s3Service.createUploadUrl.mockResolvedValue({
+        uploadUrl: 'https://presigned.url',
+        publicUrl: 'https://s3.example.com/vid.mp4',
+        key: 'review-media/videos/1/vid.mp4',
+        expiresInSeconds: 600,
+      });
+
+      await service.createReviewMediaUploadUrl(accountId, {
+        mediaType: 'VIDEO',
+        contentType: 'video/mp4',
+        contentLength: 1024,
+      });
+
+      expect(s3Service.createUploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ purpose: 'REVIEW_VIDEO' }),
+      );
+    });
+  });
+
+  describe('myReviewForOrderItem', () => {
+    it('리뷰가 없고 PICKED_UP이면 canWrite: true를 반환해야 한다', async () => {
+      reviewRepo.findOrderItemForReview.mockResolvedValue(
+        mockOrderItem as never,
+      );
+
+      const result = await service.myReviewForOrderItem(accountId, '200');
+
+      expect(result.canWrite).toBe(true);
+      expect(result.review).toBeNull();
+    });
+
+    it('PICKED_UP이 아니면 canWrite: false를 반환해야 한다', async () => {
+      reviewRepo.findOrderItemForReview.mockResolvedValue({
+        ...mockOrderItem,
+        order: { status: OrderStatus.CONFIRMED, account_id: accountId },
+      } as never);
+
+      const result = await service.myReviewForOrderItem(accountId, '200');
+
+      expect(result.canWrite).toBe(false);
+      expect(result.reasonIfCannotWrite).toContain('픽업 완료');
+    });
+
+    it('주문 아이템이 없으면 NotFoundException을 던져야 한다', async () => {
+      reviewRepo.findOrderItemForReview.mockResolvedValue(null);
+
+      await expect(
+        service.myReviewForOrderItem(accountId, '999'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/features/user/services/user-review.service.ts
+++ b/src/features/user/services/user-review.service.ts
@@ -93,7 +93,7 @@ export class UserReviewService {
       storeId: orderItem.store_id,
       productId: orderItem.product_id,
       rating: input.rating,
-      content: input.content,
+      content: input.content.trim(),
       existingDeletedReviewId,
       media: (input.media ?? []).map((m, i) => ({
         media_type:

--- a/src/features/user/services/user-review.service.ts
+++ b/src/features/user/services/user-review.service.ts
@@ -1,0 +1,269 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { OrderStatus, ReviewMediaType } from '@prisma/client';
+
+import { parseId } from '@/common/utils/id-parser';
+import { USER_REVIEW_ERRORS } from '@/features/user/constants/user-review-error-messages';
+import { ReviewRepository } from '@/features/user/repositories/review.repository';
+import type {
+  CreateReviewMediaUploadUrlInput,
+  WriteReviewInput,
+} from '@/features/user/types/user-review-input.type';
+import type {
+  MyReview,
+  MyReviewConnection,
+  MyReviewOrNull,
+  ReviewMediaUploadUrl,
+} from '@/features/user/types/user-review-output.type';
+import { S3Service } from '@/global/storage/s3.service';
+import type { UploadPurpose } from '@/global/storage/types/storage.types';
+
+interface ReviewRow {
+  id: bigint;
+  order_item_id: bigint;
+  product_id: bigint;
+  rating: { toNumber?: () => number } | number;
+  content: string | null;
+  created_at: Date;
+  order_item?: {
+    product_name_snapshot: string;
+    store?: { store_name: string };
+    product?: {
+      images?: { image_url: string }[];
+    };
+  } | null;
+  media?: {
+    media_type: string;
+    media_url: string;
+    thumbnail_url: string | null;
+    sort_order: number;
+  }[];
+}
+
+const MIN_CONTENT_LENGTH = 20;
+const MAX_CONTENT_LENGTH = 1000;
+const MAX_MEDIA_COUNT = 10;
+const MAX_LIMIT = 50;
+
+@Injectable()
+export class UserReviewService {
+  constructor(
+    private readonly reviewRepo: ReviewRepository,
+    private readonly s3Service: S3Service,
+  ) {}
+
+  async writeReview(
+    accountId: bigint,
+    input: WriteReviewInput,
+  ): Promise<MyReview> {
+    this.validateRating(input.rating);
+    this.validateContent(input.content);
+    this.validateMedia(input.media);
+
+    const orderItemId = parseId(input.orderItemId);
+    const orderItem = await this.reviewRepo.findOrderItemForReview({
+      orderItemId,
+      accountId,
+    });
+
+    if (!orderItem) {
+      throw new NotFoundException(USER_REVIEW_ERRORS.ORDER_ITEM_NOT_FOUND);
+    }
+
+    if (orderItem.order.status !== OrderStatus.PICKED_UP) {
+      throw new BadRequestException(USER_REVIEW_ERRORS.CANNOT_WRITE_REVIEW);
+    }
+
+    if (orderItem.review && !orderItem.review.deleted_at) {
+      throw new ConflictException(USER_REVIEW_ERRORS.REVIEW_ALREADY_EXISTS);
+    }
+
+    const review = await this.reviewRepo.createReviewWithMedia({
+      orderItemId,
+      accountId,
+      storeId: orderItem.store_id,
+      productId: orderItem.product_id,
+      rating: input.rating,
+      content: input.content,
+      media: (input.media ?? []).map((m, i) => ({
+        media_type:
+          m.mediaType === 'VIDEO'
+            ? ReviewMediaType.VIDEO
+            : ReviewMediaType.IMAGE,
+        media_url: m.mediaUrl,
+        thumbnail_url: m.thumbnailUrl ?? null,
+        sort_order: i,
+      })),
+    });
+
+    return this.mapReview(review!);
+  }
+
+  async myReviews(
+    accountId: bigint,
+    input?: { offset?: number; limit?: number },
+  ): Promise<MyReviewConnection> {
+    const offset = input?.offset ?? 0;
+    const limit = input?.limit ?? 20;
+
+    if (offset < 0) {
+      throw new BadRequestException('오프셋은 0 이상이어야 합니다.');
+    }
+    if (limit < 1 || limit > MAX_LIMIT) {
+      throw new BadRequestException('조회 개수는 1~50 사이여야 합니다.');
+    }
+
+    const { items, totalCount } = await this.reviewRepo.listMyReviews({
+      accountId,
+      offset,
+      limit,
+    });
+
+    return {
+      items: items.map((r) => this.mapReview(r)),
+      totalCount,
+      hasMore: offset + limit < totalCount,
+    };
+  }
+
+  async myReviewForOrderItem(
+    accountId: bigint,
+    orderItemIdStr: string,
+  ): Promise<MyReviewOrNull> {
+    const orderItemId = parseId(orderItemIdStr);
+    const orderItem = await this.reviewRepo.findOrderItemForReview({
+      orderItemId,
+      accountId,
+    });
+
+    if (!orderItem) {
+      throw new NotFoundException(USER_REVIEW_ERRORS.ORDER_ITEM_NOT_FOUND);
+    }
+
+    const isPickedUp = orderItem.order.status === OrderStatus.PICKED_UP;
+    const hasActiveReview = orderItem.review && !orderItem.review.deleted_at;
+
+    if (hasActiveReview) {
+      // 기존 리뷰 상세를 가져오기 위해 목록 API를 활용하는 것은 비효율적이므로
+      // 간소화된 정보만 반환
+      return {
+        review: {
+          reviewId: orderItem.review!.id.toString(),
+          orderItemId: orderItem.id.toString(),
+          productId: orderItem.product.id.toString(),
+          productName: orderItem.product_name_snapshot,
+          productImageUrl: orderItem.product.images[0]?.image_url ?? null,
+          storeName: orderItem.store.store_name,
+          rating: 0, // 상세 조회 시 별도 쿼리 필요 — 여기서는 존재 여부만 전달
+          content: null,
+          media: [],
+          createdAt: new Date(),
+        },
+        canWrite: false,
+        reasonIfCannotWrite: '이미 리뷰가 작성된 주문 아이템입니다.',
+      };
+    }
+
+    if (!isPickedUp) {
+      return {
+        review: null,
+        canWrite: false,
+        reasonIfCannotWrite: '픽업 완료된 주문만 리뷰를 작성할 수 있습니다.',
+      };
+    }
+
+    return {
+      review: null,
+      canWrite: true,
+      reasonIfCannotWrite: null,
+    };
+  }
+
+  async deleteMyReview(
+    accountId: bigint,
+    reviewIdStr: string,
+  ): Promise<boolean> {
+    const reviewId = parseId(reviewIdStr);
+    const deleted = await this.reviewRepo.softDeleteReview({
+      reviewId,
+      accountId,
+      now: new Date(),
+    });
+
+    if (!deleted) {
+      throw new NotFoundException(USER_REVIEW_ERRORS.REVIEW_NOT_FOUND);
+    }
+
+    return true;
+  }
+
+  async createReviewMediaUploadUrl(
+    accountId: bigint,
+    input: CreateReviewMediaUploadUrlInput,
+  ): Promise<ReviewMediaUploadUrl> {
+    const purpose: UploadPurpose =
+      input.mediaType === 'VIDEO' ? 'REVIEW_VIDEO' : 'REVIEW_IMAGE';
+
+    return this.s3Service.createUploadUrl({
+      accountId,
+      purpose,
+      contentType: input.contentType,
+      contentLength: input.contentLength,
+    });
+  }
+
+  private validateRating(rating: number): void {
+    if (rating < 1 || rating > 5 || (rating * 10) % 5 !== 0) {
+      throw new BadRequestException(USER_REVIEW_ERRORS.INVALID_RATING);
+    }
+  }
+
+  private validateContent(content: string): void {
+    const trimmed = content.trim();
+    if (trimmed.length < MIN_CONTENT_LENGTH) {
+      throw new BadRequestException(USER_REVIEW_ERRORS.CONTENT_TOO_SHORT);
+    }
+    if (trimmed.length > MAX_CONTENT_LENGTH) {
+      throw new BadRequestException(USER_REVIEW_ERRORS.CONTENT_TOO_LONG);
+    }
+  }
+
+  private validateMedia(
+    media?: { mediaType: string; mediaUrl: string }[],
+  ): void {
+    if (media && media.length > MAX_MEDIA_COUNT) {
+      throw new BadRequestException(USER_REVIEW_ERRORS.TOO_MANY_MEDIA);
+    }
+  }
+
+  private mapReview(r: ReviewRow): MyReview {
+    const rating =
+      typeof r.rating === 'number'
+        ? r.rating
+        : typeof r.rating?.toNumber === 'function'
+          ? r.rating.toNumber()
+          : Number(r.rating);
+
+    return {
+      reviewId: r.id.toString(),
+      orderItemId: r.order_item_id.toString(),
+      productId: r.product_id.toString(),
+      productName: r.order_item?.product_name_snapshot ?? '',
+      productImageUrl: r.order_item?.product?.images?.[0]?.image_url ?? null,
+      storeName: r.order_item?.store?.store_name ?? '',
+      rating,
+      content: r.content,
+      media: (r.media ?? []).map((m) => ({
+        mediaType: m.media_type as 'IMAGE' | 'VIDEO',
+        mediaUrl: m.media_url,
+        thumbnailUrl: m.thumbnail_url,
+        sortOrder: m.sort_order,
+      })),
+      createdAt: r.created_at,
+    };
+  }
+}

--- a/src/features/user/services/user-review.service.ts
+++ b/src/features/user/services/user-review.service.ts
@@ -154,21 +154,10 @@ export class UserReviewService {
     const hasActiveReview = orderItem.review && !orderItem.review.deleted_at;
 
     if (hasActiveReview) {
-      // 기존 리뷰 상세를 가져오기 위해 목록 API를 활용하는 것은 비효율적이므로
-      // 간소화된 정보만 반환
+      const review = await this.reviewRepo.findReviewById(orderItem.review!.id);
+
       return {
-        review: {
-          reviewId: orderItem.review!.id.toString(),
-          orderItemId: orderItem.id.toString(),
-          productId: orderItem.product.id.toString(),
-          productName: orderItem.product_name_snapshot,
-          productImageUrl: orderItem.product.images[0]?.image_url ?? null,
-          storeName: orderItem.store.store_name,
-          rating: 0, // 상세 조회 시 별도 쿼리 필요 — 여기서는 존재 여부만 전달
-          content: null,
-          media: [],
-          createdAt: new Date(),
-        },
+        review: review ? this.mapReview(review) : null,
         canWrite: false,
         reasonIfCannotWrite: '이미 리뷰가 작성된 주문 아이템입니다.',
       };

--- a/src/features/user/services/user-review.service.ts
+++ b/src/features/user/services/user-review.service.ts
@@ -82,13 +82,19 @@ export class UserReviewService {
       throw new ConflictException(USER_REVIEW_ERRORS.REVIEW_ALREADY_EXISTS);
     }
 
-    const review = await this.reviewRepo.createReviewWithMedia({
+    // soft-delete된 기존 리뷰가 있으면 복원, 없으면 신규 생성
+    const existingDeletedReviewId = orderItem.review?.deleted_at
+      ? orderItem.review.id
+      : undefined;
+
+    const review = await this.reviewRepo.createOrRestoreReviewWithMedia({
       orderItemId,
       accountId,
       storeId: orderItem.store_id,
       productId: orderItem.product_id,
       rating: input.rating,
       content: input.content,
+      existingDeletedReviewId,
       media: (input.media ?? []).map((m, i) => ({
         media_type:
           m.mediaType === 'VIDEO'

--- a/src/features/user/types/user-review-input.type.ts
+++ b/src/features/user/types/user-review-input.type.ts
@@ -1,0 +1,24 @@
+export interface WriteReviewInput {
+  orderItemId: string;
+  rating: number;
+  content: string;
+  media?: WriteReviewMediaInput[];
+}
+
+export interface WriteReviewMediaInput {
+  mediaType: 'IMAGE' | 'VIDEO';
+  mediaUrl: string;
+  thumbnailUrl?: string;
+  sortOrder: number;
+}
+
+export interface MyReviewsInput {
+  offset?: number;
+  limit?: number;
+}
+
+export interface CreateReviewMediaUploadUrlInput {
+  mediaType: 'IMAGE' | 'VIDEO';
+  contentType: string;
+  contentLength: number;
+}

--- a/src/features/user/types/user-review-output.type.ts
+++ b/src/features/user/types/user-review-output.type.ts
@@ -1,0 +1,38 @@
+export interface MyReviewMedia {
+  mediaType: 'IMAGE' | 'VIDEO';
+  mediaUrl: string;
+  thumbnailUrl: string | null;
+  sortOrder: number;
+}
+
+export interface MyReview {
+  reviewId: string;
+  orderItemId: string;
+  productId: string;
+  productName: string;
+  productImageUrl: string | null;
+  storeName: string;
+  rating: number;
+  content: string | null;
+  media: MyReviewMedia[];
+  createdAt: Date;
+}
+
+export interface MyReviewConnection {
+  items: MyReview[];
+  totalCount: number;
+  hasMore: boolean;
+}
+
+export interface MyReviewOrNull {
+  review: MyReview | null;
+  canWrite: boolean;
+  reasonIfCannotWrite: string | null;
+}
+
+export interface ReviewMediaUploadUrl {
+  uploadUrl: string;
+  publicUrl: string;
+  key: string;
+  expiresInSeconds: number;
+}

--- a/src/features/user/user-review.graphql
+++ b/src/features/user/user-review.graphql
@@ -1,0 +1,87 @@
+extend type Query {
+  """내가 작성한 리뷰 목록"""
+  myReviews(input: MyReviewsInput): MyReviewConnection!
+  """주문 아이템에 대한 리뷰 작성 가능 여부 및 기존 리뷰"""
+  myReviewForOrderItem(orderItemId: ID!): MyReviewOrNull!
+}
+
+extend type Mutation {
+  """리뷰 미디어 업로드용 Presigned URL 발급"""
+  createReviewMediaUploadUrl(input: CreateReviewMediaUploadUrlInput!): ReviewMediaUploadUrl!
+  """리뷰 작성"""
+  writeReview(input: WriteReviewInput!): MyReview!
+  """내 리뷰 삭제(soft)"""
+  deleteMyReview(reviewId: ID!): Boolean!
+}
+
+input MyReviewsInput {
+  offset: Int = 0
+  limit: Int = 20
+}
+
+type MyReviewConnection {
+  items: [MyReview!]!
+  totalCount: Int!
+  hasMore: Boolean!
+}
+
+type MyReview {
+  reviewId: ID!
+  orderItemId: ID!
+  productId: ID!
+  productName: String!
+  productImageUrl: String
+  storeName: String!
+  rating: Float!
+  content: String
+  media: [MyReviewMedia!]!
+  createdAt: DateTime!
+}
+
+type MyReviewOrNull {
+  review: MyReview
+  canWrite: Boolean!
+  reasonIfCannotWrite: String
+}
+
+type MyReviewMedia {
+  mediaType: ReviewMediaType!
+  mediaUrl: String!
+  thumbnailUrl: String
+  sortOrder: Int!
+}
+
+enum ReviewMediaType {
+  IMAGE
+  VIDEO
+}
+
+input CreateReviewMediaUploadUrlInput {
+  mediaType: ReviewMediaType!
+  contentType: String!
+  contentLength: Int!
+}
+
+type ReviewMediaUploadUrl {
+  uploadUrl: String!
+  publicUrl: String!
+  key: String!
+  expiresInSeconds: Int!
+}
+
+input WriteReviewInput {
+  orderItemId: ID!
+  """별점 1.0 ~ 5.0 (0.5 단위)"""
+  rating: Float!
+  """최소 20자, 최대 1000자"""
+  content: String!
+  media: [WriteReviewMediaInput!]
+}
+
+input WriteReviewMediaInput {
+  mediaType: ReviewMediaType!
+  """업로드 완료 후의 publicUrl"""
+  mediaUrl: String!
+  thumbnailUrl: String
+  sortOrder: Int!
+}

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { OrderModule } from '@/features/order/order.module';
 import { ProductModule } from '@/features/product/product.module';
 import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
+import { ReviewRepository } from '@/features/user/repositories/review.repository';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserEngagementMutationResolver } from '@/features/user/resolvers/user-engagement-mutation.resolver';
 import { UserMypageQueryResolver } from '@/features/user/resolvers/user-mypage-query.resolver';
@@ -13,6 +14,8 @@ import { UserProfileMutationResolver } from '@/features/user/resolvers/user-prof
 import { UserProfileQueryResolver } from '@/features/user/resolvers/user-profile-query.resolver';
 import { UserRecentViewMutationResolver } from '@/features/user/resolvers/user-recent-view-mutation.resolver';
 import { UserRecentViewQueryResolver } from '@/features/user/resolvers/user-recent-view-query.resolver';
+import { UserReviewMutationResolver } from '@/features/user/resolvers/user-review-mutation.resolver';
+import { UserReviewQueryResolver } from '@/features/user/resolvers/user-review-query.resolver';
 import { UserSearchMutationResolver } from '@/features/user/resolvers/user-search-mutation.resolver';
 import { UserSearchQueryResolver } from '@/features/user/resolvers/user-search-query.resolver';
 import { UserEngagementService } from '@/features/user/services/user-engagement.service';
@@ -21,6 +24,7 @@ import { UserNotificationService } from '@/features/user/services/user-notificat
 import { UserOrderService } from '@/features/user/services/user-order.service';
 import { UserProfileService } from '@/features/user/services/user-profile.service';
 import { UserRecentViewService } from '@/features/user/services/user-recent-view.service';
+import { UserReviewService } from '@/features/user/services/user-review.service';
 import { UserSearchService } from '@/features/user/services/user-search.service';
 
 /**
@@ -36,8 +40,10 @@ import { UserSearchService } from '@/features/user/services/user-search.service'
     UserMypageService,
     UserOrderService,
     UserRecentViewService,
+    UserReviewService,
     UserRepository,
     RecentProductViewRepository,
+    ReviewRepository,
     UserProfileQueryResolver,
     UserNotificationQueryResolver,
     UserSearchQueryResolver,
@@ -45,6 +51,8 @@ import { UserSearchService } from '@/features/user/services/user-search.service'
     UserOrderQueryResolver,
     UserRecentViewQueryResolver,
     UserRecentViewMutationResolver,
+    UserReviewQueryResolver,
+    UserReviewMutationResolver,
     UserProfileMutationResolver,
     UserNotificationMutationResolver,
     UserSearchMutationResolver,


### PR DESCRIPTION
## Summary
마이페이지 리뷰 기능의 전체 API를 구현한다.

- **`writeReview` mutation**: 별점(0.5 단위, 1~5), 내용(20~1000자), 미디어(최대 10개) 검증. PICKED_UP 상태 주문만 허용. soft-delete된 리뷰가 있으면 재작성 가능
- **`myReviews` 쿼리**: 내가 작성한 리뷰 목록 (offset 페이지네이션)
- **`myReviewForOrderItem` 쿼리**: 주문 아이템별 리뷰 작성 가능 여부 + 기존 리뷰 존재 확인
- **`deleteMyReview` mutation**: 본인 리뷰 soft-delete
- **`createReviewMediaUploadUrl` mutation**: IMAGE → REVIEW_IMAGE, VIDEO → REVIEW_VIDEO purpose로 S3 Presigned URL 발급
- **ReviewRepository 신규**: findOrderItemForReview, createReviewWithMedia (트랜잭션), listMyReviews, softDeleteReview

## 신규 파일 (10개)
- `src/features/user/user-review.graphql`
- `src/features/user/constants/user-review-error-messages.ts`
- `src/features/user/types/user-review-input.type.ts`
- `src/features/user/types/user-review-output.type.ts`
- `src/features/user/repositories/review.repository.ts`
- `src/features/user/services/user-review.service.ts`
- `src/features/user/services/user-review.service.spec.ts` — 19개 테스트
- `src/features/user/resolvers/user-review-query.resolver.ts`
- `src/features/user/resolvers/user-review-mutation.resolver.ts`

## 수정 파일
- `src/features/user/user.module.ts` — ReviewRepository, UserReviewService, 리졸버 등록

## Test plan
- [x] `yarn lint` 0 errors, 0 warnings
- [x] `npx tsc --noEmit` 타입 체크 통과
- [x] `yarn test` 전체 473 테스트 통과 (기존 454 + 신규 19)
- [ ] PR 리뷰 후 develop 머지