### PR TITLE
chore: PR 커버리지 리포트 강화 + develop 브랜치 CI 적용

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -50,11 +50,11 @@ jobs:
 
   coverage-report:
     runs-on: ubuntu-latest
+    needs: check
     timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
-      checks: write
 
     steps:
       - name: Checkout
@@ -71,17 +71,8 @@ jobs:
           corepack enable
           yarn install --immutable
 
-      - name: Coverage Report (jest-coverage-report)
-        uses: ArtiomTr/jest-coverage-report-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-script: yarn jest --coverage --ci
-          skip-step: install
-          annotations: failed-tests
-
-      - name: Test with lcov output for Codecov
+      - name: Test with lcov output
         run: yarn jest --coverage --ci --coverageReporters=lcov --coverageReporters=text
-        continue-on-error: true
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,7 +2,7 @@ name: PR Check
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 permissions:
   contents: read
@@ -71,12 +71,24 @@ jobs:
           corepack enable
           yarn install --immutable
 
-      - name: Coverage Report
+      - name: Coverage Report (jest-coverage-report)
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: yarn jest --coverage --ci
           skip-step: install
+          annotations: failed-tests
+
+      - name: Test with lcov output for Codecov
+        run: yarn jest --coverage --ci --coverageReporters=lcov --coverageReporters=text
+        continue-on-error: true
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN || '' }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
 
   pr-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- **PR 트리거 확장**: `branches: [main]` → `[main, develop]` — develop 대상 PR에도 CI + 커버리지 댓글 적용
- `jest-coverage-report-action`에 `annotations: failed-tests` 옵션 추가 — 실패 테스트 위치를 PR diff에 표시
- Codecov 연동 추가
  - `jest --coverageReporters=lcov` → `codecov/codecov-action@v5`로 업로드
  - 파일별 커버리지, PR diff 내 커버되지 않는 라인 마킹, 히스토리 추적
  - public 리포이므로 `CODECOV_TOKEN`은 optional (없어도 동작)

## Test plan
- [ ] develop 대상 PR에서 CI 워크플로우 실행 확인
- [ ] Codecov 댓글 생성 확인 (Codecov 활성화 후)