### PR TITLE
chore: 배포 시 Prisma 마이그레이션 자동 적용

### DIFF
--- a/scripts/application_start.sh
+++ b/scripts/application_start.sh
@@ -15,6 +15,11 @@ ECOSYS="/home/ubuntu/project/caquick-backend/ecosystem.config.js"
 
 cd "$RUN_PATH"
 
+# DB 마이그레이션 적용 (신규 테이블/컬럼이 있을 때만 실행됨, 변경 없으면 no-op)
+echo ">> Running Prisma migrate deploy..."
+npx prisma migrate deploy
+echo ">> Prisma migrate deploy complete."
+
 if [ ! -f "$ECOSYS" ]; then
   echo "ecosystem file not found: $ECOSYS"
   exit 1


### PR DESCRIPTION
## Summary
- `scripts/application_start.sh`에서 PM2 start 직전에 `npx prisma migrate deploy` 실행 추가
- 스키마 변경이 있을 때만 실제 마이그레이션이 적용되고, 변경 없으면 no-op으로 안전하게 동작
- 수동 SSH 접속하여 마이그레이션 적용하는 절차를 자동화

## Test plan
- [ ] 개발 서버 배포 시 마이그레이션 로그 확인 (`Prisma migrate deploy complete.`)
- [ ] 마이그레이션 변경 없는 배포에서도 정상 동작 확인 (no-op)
- [ ] PM2 정상 start/reload 확인