### PR TITLE
chore: 배포 시 Prisma 마이그레이션 자동 적용

### DIFF
--- a/scripts/application_start.sh
+++ b/scripts/application_start.sh
@@ -15,6 +15,11 @@ ECOSYS="/home/ubuntu/project/caquick-backend/ecosystem.config.js"
 
 cd "$RUN_PATH"
 
+# DB 마이그레이션 적용 (신규 테이블/컬럼이 있을 때만 실행됨, 변경 없으면 no-op)
+echo ">> Running Prisma migrate deploy..."
+npx prisma migrate deploy
+echo ">> Prisma migrate deploy complete."
+
 if [ ! -f "$ECOSYS" ]; then
   echo "ecosystem file not found: $ECOSYS"
   exit 1


### PR DESCRIPTION
## Summary
- 배포 스크립트(`scripts/application_start.sh`)에서 PM2 기동 전에 `npx prisma migrate deploy` 실행
- 신규 마이그레이션이 있을 때만 적용되고, 변경이 없으면 no-op이므로 매 배포에 안전하게 포함 가능

## Test plan
- [ ] main 병합 후 CodeDeploy 배포 시 `>> Running Prisma migrate deploy...` 로그 확인
- [ ] 운영 DB에 신규 마이그레이션이 정상 반영되는지 확인
- [ ] 마이그레이션 변경이 없는 배포에서 no-op으로 동작하는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 애플리케이션 시작 시 데이터베이스 마이그레이션이 자동으로 실행되어 데이터베이스 스키마가 최신 상태로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->