### PR TITLE
chore: Testcontainers 기반 실DB 테스트 인프라 구축

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -90,6 +90,7 @@ jobs:
           annotations: failed-tests
 
   pr-title:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,6 +1,8 @@
-name: PR Check
+name: CI
 
 on:
+  push:
+    branches: [main, develop]
   pull_request:
     branches: [main, develop]
 
@@ -8,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pr-check-${{ github.event.pull_request.number }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -43,12 +45,20 @@ jobs:
       - name: Test with coverage
         run: yarn test:cov
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN || '' }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+
       - name: Build
         run: |
           yarn graphql:docs
           yarn build
 
   coverage-report:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -78,21 +88,6 @@ jobs:
           test-script: yarn jest --coverage --ci
           skip-step: install
           annotations: failed-tests
-
-      - name: Reinstall dependencies (jest-coverage-report-action 이후 state 복구)
-        run: |
-          corepack enable
-          yarn install --immutable
-
-      - name: Test with lcov output for Codecov
-        run: yarn jest --coverage --ci --coverageReporters=lcov --coverageReporters=text
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN || '' }}
-          files: ./coverage/lcov.info
-          fail_ci_if_error: false
 
   pr-title:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,10 +12,9 @@ coverage:
         target: 80%
 
 comment:
-  layout: "condensed_header, condensed_files, condensed_footer"
+  layout: "header, diff, flags, components, files, footer"
+  behavior: default
   require_changes: false
-  require_base: false
-  require_head: true
   hide_project_coverage: false
 
 ignore:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "condensed_header, condensed_files, condensed_footer"
+  require_changes: false
+  require_base: false
+  require_head: true
+  hide_project_coverage: false
+
+ignore:
+  - "src/test/**"
+  - "src/config/**"
+  - "src/**/*.module.ts"
+  - "src/main.ts"
+  - "src/**/index.ts"
+  - "src/graphql/graphql.types.ts"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@nestjs/cli": "^11.0.14",
     "@nestjs/schematics": "^11.0.9",
     "@nestjs/testing": "11.1.10",
+    "@testcontainers/mysql": "^11.14.0",
     "@types/cookie-parser": "^1.4.10",
     "@types/express": "^5.0.6",
     "@types/jest": "^29",
@@ -88,12 +89,14 @@
     "jest": "^29",
     "langsmith": "^0.5.7",
     "lint-staged": "^16.4.0",
+    "mysql2": "^3.22.0",
     "openai": "^6.27.0",
     "prettier": "^3.4.2",
     "prisma": "^6.2.0",
     "source-map-support": "^0.5.21",
     "spectaql": "^3.0.6",
     "supertest": "^7.0.0",
+    "testcontainers": "^11.14.0",
     "ts-jest": "^29",
     "ts-loader": "^9.5.2",
     "ts-morph": "^27.0.2",
@@ -120,7 +123,8 @@
       "!**/*.module.ts",
       "!**/*.d.ts",
       "!**/graphql/graphql.types.ts",
-      "!**/config/**"
+      "!**/config/**",
+      "!test/**"
     ],
     "coverageThreshold": {
       "global": {
@@ -132,6 +136,9 @@
     },
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
+    "globalSetup": "<rootDir>/test/jest.global-setup.ts",
+    "globalTeardown": "<rootDir>/test/jest.global-teardown.ts",
+    "testTimeout": 60000,
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/$1"
     }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import type { Request, Response } from 'express';
 
+import { CommonModule } from '@/common/common.module';
 import authConfig from '@/config/auth.config';
 import databaseConfig from '@/config/database.config';
 import docsConfig from '@/config/docs.config';
@@ -41,6 +42,7 @@ import { PrismaModule } from '@/prisma';
       rootPath: join(process.cwd(), 'public'),
       serveRoot: '/gql-docs',
     }),
+    CommonModule,
     PrismaModule,
     LoggerModule,
     AuthGlobalModule,

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,0 +1,17 @@
+import { Global, Module } from '@nestjs/common';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { IdGenerator } from '@/common/providers/id-generator.service';
+
+/**
+ * 전역 공통 provider를 묶는 모듈.
+ *
+ * - ClockService: 현재 시각 추상화 (테스트 주입용)
+ * - IdGenerator: UUID 등 식별자 생성 추상화 (테스트 주입용)
+ */
+@Global()
+@Module({
+  providers: [ClockService, IdGenerator],
+  exports: [ClockService, IdGenerator],
+})
+export class CommonModule {}

--- a/src/common/providers/clock.service.ts
+++ b/src/common/providers/clock.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * 현재 시각을 반환하는 서비스.
+ *
+ * 테스트에서 결정적 시각을 주입할 수 있도록 `new Date()` 직접 호출을 대체한다.
+ */
+@Injectable()
+export class ClockService {
+  now(): Date {
+    return new Date();
+  }
+
+  nowMs(): number {
+    return Date.now();
+  }
+}

--- a/src/common/providers/id-generator.service.ts
+++ b/src/common/providers/id-generator.service.ts
@@ -1,0 +1,15 @@
+import { randomUUID } from 'node:crypto';
+
+import { Injectable } from '@nestjs/common';
+
+/**
+ * UUID 등 식별자 생성을 캡슐화하는 서비스.
+ *
+ * 테스트에서 결정적 식별자를 주입할 수 있도록 `randomUUID()` 직접 호출을 대체한다.
+ */
+@Injectable()
+export class IdGenerator {
+  uuid(): string {
+    return randomUUID();
+  }
+}

--- a/src/test/db/prisma-test-client.ts
+++ b/src/test/db/prisma-test-client.ts
@@ -1,0 +1,112 @@
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { PrismaClient } from '@prisma/client';
+import mysql from 'mysql2/promise';
+
+import { softDeleteExtension } from '@/prisma/soft-delete.middleware';
+
+const STATE_FILE = join(process.cwd(), '.tmp', 'test-db-state.json');
+
+interface TestDbState {
+  host: string;
+  port: number;
+  rootUser: string;
+  rootPassword: string;
+}
+
+let cachedClient: PrismaClient | null = null;
+let cachedDbUrl: string | null = null;
+let schemaApplied = false;
+
+function loadState(): TestDbState {
+  const raw = readFileSync(STATE_FILE, 'utf8');
+  return JSON.parse(raw) as TestDbState;
+}
+
+function buildDbName(): string {
+  const workerId = process.env.JEST_WORKER_ID ?? '1';
+  return `caquick_test_w${workerId}`;
+}
+
+function buildTestDbUrl(state: TestDbState, dbName: string): string {
+  return `mysql://${state.rootUser}:${encodeURIComponent(state.rootPassword)}@${state.host}:${state.port}/${dbName}`;
+}
+
+/**
+ * Worker별 테스트 DB를 준비한다.
+ * - worker별 격리된 DB 생성(없으면 CREATE)
+ * - `prisma migrate deploy`로 스키마 적용 (worker당 1회)
+ */
+async function ensureSchema(
+  state: TestDbState,
+  dbName: string,
+  dbUrl: string,
+): Promise<void> {
+  if (schemaApplied) return;
+
+  const admin = await mysql.createConnection({
+    host: state.host,
+    port: state.port,
+    user: state.rootUser,
+    password: state.rootPassword,
+  });
+  try {
+    await admin.query(
+      `CREATE DATABASE IF NOT EXISTS \`${dbName}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`,
+    );
+  } finally {
+    await admin.end();
+  }
+
+  execSync('npx prisma migrate deploy', {
+    env: {
+      ...process.env,
+      DATABASE_URL: dbUrl,
+    },
+    stdio: 'pipe',
+  });
+
+  schemaApplied = true;
+}
+
+/**
+ * 테스트용 Prisma 클라이언트를 반환한다.
+ * - worker별 전용 DB 사용
+ * - softDelete extension 적용 (운영 PrismaService와 동일 동작)
+ */
+export async function getTestPrismaClient(): Promise<PrismaClient> {
+  if (cachedClient) return cachedClient;
+
+  const state = loadState();
+  const dbName = buildDbName();
+  const dbUrl = buildTestDbUrl(state, dbName);
+  cachedDbUrl = dbUrl;
+
+  await ensureSchema(state, dbName, dbUrl);
+
+  const client = new PrismaClient({
+    datasources: { db: { url: dbUrl } },
+  }).$extends(softDeleteExtension);
+
+  cachedClient = client as unknown as PrismaClient;
+  return cachedClient;
+}
+
+export function getTestDatabaseUrl(): string {
+  if (!cachedDbUrl) {
+    throw new Error(
+      'Test database URL not initialized. Call getTestPrismaClient() first.',
+    );
+  }
+  return cachedDbUrl;
+}
+
+export async function disconnectTestPrismaClient(): Promise<void> {
+  if (cachedClient) {
+    await cachedClient.$disconnect();
+    cachedClient = null;
+    schemaApplied = false;
+  }
+}

--- a/src/test/db/truncate.ts
+++ b/src/test/db/truncate.ts
@@ -2,6 +2,25 @@ import mysql from 'mysql2/promise';
 
 import { getTestDatabaseUrl } from '@/test/db/prisma-test-client';
 
+let cachedConn: mysql.Connection | null = null;
+
+/**
+ * Worker별로 캐싱된 mysql2 연결을 반환한다.
+ * 연결이 끊겼으면 재생성한다.
+ */
+async function getConnection(): Promise<mysql.Connection> {
+  if (cachedConn) {
+    try {
+      await cachedConn.ping();
+      return cachedConn;
+    } catch {
+      cachedConn = null;
+    }
+  }
+  cachedConn = await mysql.createConnection(getTestDatabaseUrl());
+  return cachedConn;
+}
+
 /**
  * 테스트 DB의 모든 테이블을 TRUNCATE한다.
  *
@@ -11,26 +30,31 @@ import { getTestDatabaseUrl } from '@/test/db/prisma-test-client';
  * - `_prisma_migrations`는 제외 (스키마 이력 유지)
  */
 export async function truncateAll(): Promise<void> {
-  const dbUrl = getTestDatabaseUrl();
-  const conn = await mysql.createConnection(dbUrl);
+  const conn = await getConnection();
 
-  try {
-    const [rows] = await conn.query<mysql.RowDataPacket[]>(`
-      SELECT TABLE_NAME AS table_name
-      FROM information_schema.tables
-      WHERE table_schema = DATABASE()
-        AND table_type = 'BASE TABLE'
-        AND TABLE_NAME <> '_prisma_migrations'
-    `);
+  const [rows] = await conn.query<mysql.RowDataPacket[]>(`
+    SELECT TABLE_NAME AS table_name
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_type = 'BASE TABLE'
+      AND TABLE_NAME <> '_prisma_migrations'
+  `);
 
-    if (rows.length === 0) return;
+  if (rows.length === 0) return;
 
-    await conn.query('SET FOREIGN_KEY_CHECKS = 0');
-    for (const row of rows) {
-      await conn.query(`TRUNCATE TABLE \`${row.table_name}\``);
-    }
-    await conn.query('SET FOREIGN_KEY_CHECKS = 1');
-  } finally {
-    await conn.end();
+  await conn.query('SET FOREIGN_KEY_CHECKS = 0');
+  for (const row of rows) {
+    await conn.query(`TRUNCATE TABLE \`${row.table_name}\``);
+  }
+  await conn.query('SET FOREIGN_KEY_CHECKS = 1');
+}
+
+/**
+ * Worker 종료 시 캐싱된 연결을 정리한다.
+ */
+export async function closeTruncateConnection(): Promise<void> {
+  if (cachedConn) {
+    await cachedConn.end();
+    cachedConn = null;
   }
 }

--- a/src/test/db/truncate.ts
+++ b/src/test/db/truncate.ts
@@ -1,28 +1,36 @@
-import type { PrismaClient } from '@prisma/client';
+import mysql from 'mysql2/promise';
+
+import { getTestDatabaseUrl } from '@/test/db/prisma-test-client';
 
 /**
  * 테스트 DB의 모든 테이블을 TRUNCATE한다.
  *
+ * Prisma 커넥션 풀을 우회하여 단일 mysql2 연결에서 실행.
+ * → SET FOREIGN_KEY_CHECKS=0 과 TRUNCATE가 동일 세션에서 보장됨.
+ *
  * - `_prisma_migrations`는 제외 (스키마 이력 유지)
- * - 외래 키 제약 일시 해제 후 수행 → 다시 활성화
  */
-export async function truncateAll(prisma: PrismaClient): Promise<void> {
-  const rows = await prisma.$queryRawUnsafe<Array<{ table_name: string }>>(`
-    SELECT TABLE_NAME AS table_name
-    FROM information_schema.tables
-    WHERE table_schema = DATABASE()
-      AND table_type = 'BASE TABLE'
-      AND TABLE_NAME <> '_prisma_migrations'
-  `);
+export async function truncateAll(): Promise<void> {
+  const dbUrl = getTestDatabaseUrl();
+  const conn = await mysql.createConnection(dbUrl);
 
-  if (rows.length === 0) return;
-
-  await prisma.$executeRawUnsafe('SET FOREIGN_KEY_CHECKS = 0');
   try {
-    for (const { table_name } of rows) {
-      await prisma.$executeRawUnsafe(`TRUNCATE TABLE \`${table_name}\``);
+    const [rows] = await conn.query<mysql.RowDataPacket[]>(`
+      SELECT TABLE_NAME AS table_name
+      FROM information_schema.tables
+      WHERE table_schema = DATABASE()
+        AND table_type = 'BASE TABLE'
+        AND TABLE_NAME <> '_prisma_migrations'
+    `);
+
+    if (rows.length === 0) return;
+
+    await conn.query('SET FOREIGN_KEY_CHECKS = 0');
+    for (const row of rows) {
+      await conn.query(`TRUNCATE TABLE \`${row.table_name}\``);
     }
+    await conn.query('SET FOREIGN_KEY_CHECKS = 1');
   } finally {
-    await prisma.$executeRawUnsafe('SET FOREIGN_KEY_CHECKS = 1');
+    await conn.end();
   }
 }

--- a/src/test/db/truncate.ts
+++ b/src/test/db/truncate.ts
@@ -43,10 +43,13 @@ export async function truncateAll(): Promise<void> {
   if (rows.length === 0) return;
 
   await conn.query('SET FOREIGN_KEY_CHECKS = 0');
-  for (const row of rows) {
-    await conn.query(`TRUNCATE TABLE \`${row.table_name}\``);
+  try {
+    for (const row of rows) {
+      await conn.query(`TRUNCATE TABLE \`${row.table_name}\``);
+    }
+  } finally {
+    await conn.query('SET FOREIGN_KEY_CHECKS = 1');
   }
-  await conn.query('SET FOREIGN_KEY_CHECKS = 1');
 }
 
 /**

--- a/src/test/db/truncate.ts
+++ b/src/test/db/truncate.ts
@@ -1,0 +1,28 @@
+import type { PrismaClient } from '@prisma/client';
+
+/**
+ * 테스트 DB의 모든 테이블을 TRUNCATE한다.
+ *
+ * - `_prisma_migrations`는 제외 (스키마 이력 유지)
+ * - 외래 키 제약 일시 해제 후 수행 → 다시 활성화
+ */
+export async function truncateAll(prisma: PrismaClient): Promise<void> {
+  const rows = await prisma.$queryRawUnsafe<Array<{ table_name: string }>>(`
+    SELECT TABLE_NAME AS table_name
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_type = 'BASE TABLE'
+      AND TABLE_NAME <> '_prisma_migrations'
+  `);
+
+  if (rows.length === 0) return;
+
+  await prisma.$executeRawUnsafe('SET FOREIGN_KEY_CHECKS = 0');
+  try {
+    for (const { table_name } of rows) {
+      await prisma.$executeRawUnsafe(`TRUNCATE TABLE \`${table_name}\``);
+    }
+  } finally {
+    await prisma.$executeRawUnsafe('SET FOREIGN_KEY_CHECKS = 1');
+  }
+}

--- a/src/test/factories/account.factory.ts
+++ b/src/test/factories/account.factory.ts
@@ -1,0 +1,33 @@
+import type {
+  Account,
+  AccountStatus,
+  AccountType,
+  PrismaClient,
+} from '@prisma/client';
+
+import { nextSeq } from '@/test/factories/sequence';
+
+export interface AccountOverrides {
+  account_type?: AccountType;
+  status?: AccountStatus;
+  email?: string | null;
+  name?: string | null;
+}
+
+export async function createAccount(
+  prisma: PrismaClient,
+  overrides: AccountOverrides = {},
+): Promise<Account> {
+  const seq = nextSeq();
+  return prisma.account.create({
+    data: {
+      account_type: overrides.account_type ?? 'USER',
+      status: overrides.status ?? 'ACTIVE',
+      email:
+        overrides.email === undefined
+          ? `user${seq}@example.com`
+          : overrides.email,
+      name: overrides.name === undefined ? `User ${seq}` : overrides.name,
+    },
+  });
+}

--- a/src/test/factories/index.ts
+++ b/src/test/factories/index.ts
@@ -1,0 +1,7 @@
+export * from './account.factory';
+export * from './user-profile.factory';
+export * from './store.factory';
+export * from './product.factory';
+export * from './order.factory';
+export * from './review.factory';
+export * from './sequence';

--- a/src/test/factories/order.factory.ts
+++ b/src/test/factories/order.factory.ts
@@ -61,16 +61,18 @@ export async function createOrderItem(
   prisma: PrismaClient,
   overrides: OrderItemOverrides = {},
 ): Promise<OrderItem> {
-  const product =
-    overrides.product_id && overrides.store_id
-      ? null
-      : await createProduct(prisma);
+  // product_id와 store_id는 항상 같은 상품 기준으로 일관성을 유지한다
+  let productId = overrides.product_id;
+  let storeId = overrides.store_id;
+  if (!productId || !storeId) {
+    const product = await createProduct(prisma, {
+      ...(storeId ? { store_id: storeId } : {}),
+    });
+    productId = productId ?? product.id;
+    storeId = storeId ?? product.store_id;
+  }
 
-  const productId = overrides.product_id ?? product!.id;
-  const storeId = overrides.store_id ?? product!.store_id;
-
-  const order = overrides.order_id ? null : await createOrder(prisma);
-  const orderId = overrides.order_id ?? order!.id;
+  const orderId = overrides.order_id ?? (await createOrder(prisma)).id;
 
   return prisma.orderItem.create({
     data: {

--- a/src/test/factories/order.factory.ts
+++ b/src/test/factories/order.factory.ts
@@ -1,0 +1,88 @@
+import type {
+  Order,
+  OrderItem,
+  OrderStatus,
+  PrismaClient,
+} from '@prisma/client';
+
+import { createAccount } from '@/test/factories/account.factory';
+import { createProduct } from '@/test/factories/product.factory';
+import { nextSeq } from '@/test/factories/sequence';
+
+export interface OrderOverrides {
+  account_id?: bigint;
+  order_number?: string;
+  status?: OrderStatus;
+  pickup_at?: Date;
+  buyer_name?: string;
+  buyer_phone?: string;
+  subtotal_price?: number;
+  discount_price?: number;
+  total_price?: number;
+}
+
+export async function createOrder(
+  prisma: PrismaClient,
+  overrides: OrderOverrides = {},
+): Promise<Order> {
+  const seq = nextSeq();
+  const accountId =
+    overrides.account_id ??
+    (await createAccount(prisma, { account_type: 'USER' })).id;
+
+  return prisma.order.create({
+    data: {
+      account_id: accountId,
+      order_number: overrides.order_number ?? `ORD-${Date.now()}-${seq}`,
+      status: overrides.status ?? 'SUBMITTED',
+      pickup_at:
+        overrides.pickup_at ?? new Date(Date.now() + 24 * 60 * 60 * 1000),
+      buyer_name: overrides.buyer_name ?? `Buyer ${seq}`,
+      buyer_phone: overrides.buyer_phone ?? '010-0000-0000',
+      subtotal_price: overrides.subtotal_price ?? 10000,
+      discount_price: overrides.discount_price ?? 0,
+      total_price: overrides.total_price ?? 10000,
+    },
+  });
+}
+
+export interface OrderItemOverrides {
+  order_id?: bigint;
+  store_id?: bigint;
+  product_id?: bigint;
+  product_name_snapshot?: string;
+  regular_price_snapshot?: number;
+  sale_price_snapshot?: number | null;
+  quantity?: number;
+  item_subtotal_price?: number;
+}
+
+export async function createOrderItem(
+  prisma: PrismaClient,
+  overrides: OrderItemOverrides = {},
+): Promise<OrderItem> {
+  const product =
+    overrides.product_id && overrides.store_id
+      ? null
+      : await createProduct(prisma);
+
+  const productId = overrides.product_id ?? product!.id;
+  const storeId = overrides.store_id ?? product!.store_id;
+
+  const order = overrides.order_id ? null : await createOrder(prisma);
+  const orderId = overrides.order_id ?? order!.id;
+
+  return prisma.orderItem.create({
+    data: {
+      order_id: orderId,
+      store_id: storeId,
+      product_id: productId,
+      product_name_snapshot:
+        overrides.product_name_snapshot ?? 'Product snapshot',
+      regular_price_snapshot: overrides.regular_price_snapshot ?? 10000,
+      sale_price_snapshot: overrides.sale_price_snapshot ?? null,
+      quantity: overrides.quantity ?? 1,
+      item_subtotal_price: overrides.item_subtotal_price ?? 10000,
+    },
+  });
+}

--- a/src/test/factories/product.factory.ts
+++ b/src/test/factories/product.factory.ts
@@ -1,0 +1,32 @@
+import type { PrismaClient, Product } from '@prisma/client';
+
+import { nextSeq } from '@/test/factories/sequence';
+import { createStore } from '@/test/factories/store.factory';
+
+export interface ProductOverrides {
+  store_id?: bigint;
+  name?: string;
+  description?: string | null;
+  regular_price?: number;
+  sale_price?: number | null;
+  is_active?: boolean;
+}
+
+export async function createProduct(
+  prisma: PrismaClient,
+  overrides: ProductOverrides = {},
+): Promise<Product> {
+  const seq = nextSeq();
+  const storeId = overrides.store_id ?? (await createStore(prisma)).id;
+
+  return prisma.product.create({
+    data: {
+      store_id: storeId,
+      name: overrides.name ?? `Product ${seq}`,
+      description: overrides.description ?? null,
+      regular_price: overrides.regular_price ?? 10000,
+      sale_price: overrides.sale_price ?? null,
+      is_active: overrides.is_active ?? true,
+    },
+  });
+}

--- a/src/test/factories/review.factory.ts
+++ b/src/test/factories/review.factory.ts
@@ -4,49 +4,51 @@ import { createOrderItem } from '@/test/factories/order.factory';
 
 export interface ReviewOverrides {
   order_item_id?: bigint;
-  account_id?: bigint;
-  store_id?: bigint;
-  product_id?: bigint;
   rating?: number;
   content?: string | null;
 }
 
+/**
+ * Review 팩토리.
+ *
+ * - order_item_id가 주어지면 해당 아이템의 관계(account, store, product)를 그대로 사용
+ * - order_item_id가 없으면 새 order item을 생성하고 그 관계를 사용
+ * - account_id/store_id/product_id는 항상 order item에서 파생 (직접 override 불가, 일관성 보장)
+ */
 export async function createReview(
   prisma: PrismaClient,
   overrides: ReviewOverrides = {},
 ): Promise<Review> {
   let orderItemId = overrides.order_item_id;
-  let accountId = overrides.account_id;
-  let storeId = overrides.store_id;
-  let productId = overrides.product_id;
+  let accountId: bigint;
+  let storeId: bigint;
+  let productId: bigint;
 
-  if (orderItemId && (!accountId || !storeId || !productId)) {
-    // order_item_id가 주어졌으면 해당 아이템의 관계를 조회하여 일관성 유지
+  if (orderItemId) {
     const oi = await prisma.orderItem.findUniqueOrThrow({
       where: { id: orderItemId },
       include: { order: true },
     });
-    storeId = storeId ?? oi.store_id;
-    productId = productId ?? oi.product_id;
-    accountId = accountId ?? oi.order.account_id;
-  } else if (!orderItemId) {
-    // order_item_id가 없으면 새로 생성
+    storeId = oi.store_id;
+    productId = oi.product_id;
+    accountId = oi.order.account_id;
+  } else {
     const oi = await createOrderItem(prisma);
     const order = await prisma.order.findUniqueOrThrow({
       where: { id: oi.order_id },
     });
     orderItemId = oi.id;
-    storeId = storeId ?? oi.store_id;
-    productId = productId ?? oi.product_id;
-    accountId = accountId ?? order.account_id;
+    storeId = oi.store_id;
+    productId = oi.product_id;
+    accountId = order.account_id;
   }
 
   return prisma.review.create({
     data: {
       order_item_id: orderItemId,
-      account_id: accountId!,
-      store_id: storeId!,
-      product_id: productId!,
+      account_id: accountId,
+      store_id: storeId,
+      product_id: productId,
       rating: overrides.rating ?? 5,
       content:
         overrides.content === undefined

--- a/src/test/factories/review.factory.ts
+++ b/src/test/factories/review.factory.ts
@@ -20,12 +20,22 @@ export async function createReview(
   let storeId = overrides.store_id;
   let productId = overrides.product_id;
 
-  if (!orderItemId || !accountId || !storeId || !productId) {
+  if (orderItemId && (!accountId || !storeId || !productId)) {
+    // order_item_id가 주어졌으면 해당 아이템의 관계를 조회하여 일관성 유지
+    const oi = await prisma.orderItem.findUniqueOrThrow({
+      where: { id: orderItemId },
+      include: { order: true },
+    });
+    storeId = storeId ?? oi.store_id;
+    productId = productId ?? oi.product_id;
+    accountId = accountId ?? oi.order.account_id;
+  } else if (!orderItemId) {
+    // order_item_id가 없으면 새로 생성
     const oi = await createOrderItem(prisma);
     const order = await prisma.order.findUniqueOrThrow({
       where: { id: oi.order_id },
     });
-    orderItemId = orderItemId ?? oi.id;
+    orderItemId = oi.id;
     storeId = storeId ?? oi.store_id;
     productId = productId ?? oi.product_id;
     accountId = accountId ?? order.account_id;
@@ -34,9 +44,9 @@ export async function createReview(
   return prisma.review.create({
     data: {
       order_item_id: orderItemId,
-      account_id: accountId,
-      store_id: storeId,
-      product_id: productId,
+      account_id: accountId!,
+      store_id: storeId!,
+      product_id: productId!,
       rating: overrides.rating ?? 5,
       content:
         overrides.content === undefined

--- a/src/test/factories/review.factory.ts
+++ b/src/test/factories/review.factory.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient, Review } from '@prisma/client';
+
+import { createOrderItem } from '@/test/factories/order.factory';
+
+export interface ReviewOverrides {
+  order_item_id?: bigint;
+  account_id?: bigint;
+  store_id?: bigint;
+  product_id?: bigint;
+  rating?: number;
+  content?: string | null;
+}
+
+export async function createReview(
+  prisma: PrismaClient,
+  overrides: ReviewOverrides = {},
+): Promise<Review> {
+  let orderItemId = overrides.order_item_id;
+  let accountId = overrides.account_id;
+  let storeId = overrides.store_id;
+  let productId = overrides.product_id;
+
+  if (!orderItemId || !accountId || !storeId || !productId) {
+    const oi = await createOrderItem(prisma);
+    const order = await prisma.order.findUniqueOrThrow({
+      where: { id: oi.order_id },
+    });
+    orderItemId = orderItemId ?? oi.id;
+    storeId = storeId ?? oi.store_id;
+    productId = productId ?? oi.product_id;
+    accountId = accountId ?? order.account_id;
+  }
+
+  return prisma.review.create({
+    data: {
+      order_item_id: orderItemId,
+      account_id: accountId,
+      store_id: storeId,
+      product_id: productId,
+      rating: overrides.rating ?? 5,
+      content:
+        overrides.content === undefined
+          ? '좋은 제품입니다.'
+          : overrides.content,
+    },
+  });
+}

--- a/src/test/factories/sequence.ts
+++ b/src/test/factories/sequence.ts
@@ -1,0 +1,14 @@
+/**
+ * 팩토리 내부에서 유일한 순번을 생성한다.
+ * 테스트 DB는 worker별로 격리되므로 단일 in-memory 카운터로 충분하다.
+ */
+let counter = 0;
+
+export function nextSeq(): number {
+  counter += 1;
+  return counter;
+}
+
+export function resetSeq(): void {
+  counter = 0;
+}

--- a/src/test/factories/store.factory.ts
+++ b/src/test/factories/store.factory.ts
@@ -1,0 +1,39 @@
+import type { PrismaClient, Store } from '@prisma/client';
+
+import { createAccount } from '@/test/factories/account.factory';
+import { nextSeq } from '@/test/factories/sequence';
+
+export interface StoreOverrides {
+  seller_account_id?: bigint;
+  store_name?: string;
+  store_phone?: string;
+  address_full?: string;
+  address_city?: string | null;
+  address_district?: string | null;
+  address_neighborhood?: string | null;
+  is_active?: boolean;
+}
+
+export async function createStore(
+  prisma: PrismaClient,
+  overrides: StoreOverrides = {},
+): Promise<Store> {
+  const seq = nextSeq();
+  const sellerAccountId =
+    overrides.seller_account_id ??
+    (await createAccount(prisma, { account_type: 'SELLER' })).id;
+
+  return prisma.store.create({
+    data: {
+      seller_account_id: sellerAccountId,
+      store_name: overrides.store_name ?? `Store ${seq}`,
+      store_phone:
+        overrides.store_phone ?? `010-0000-${String(seq).padStart(4, '0')}`,
+      address_full: overrides.address_full ?? `서울시 테스트구 테스트동 ${seq}`,
+      address_city: overrides.address_city ?? '서울시',
+      address_district: overrides.address_district ?? '테스트구',
+      address_neighborhood: overrides.address_neighborhood ?? '테스트동',
+      is_active: overrides.is_active ?? true,
+    },
+  });
+}

--- a/src/test/factories/user-profile.factory.ts
+++ b/src/test/factories/user-profile.factory.ts
@@ -1,0 +1,37 @@
+import type { PrismaClient, UserProfile } from '@prisma/client';
+
+import { createAccount } from '@/test/factories/account.factory';
+import { nextSeq } from '@/test/factories/sequence';
+
+export interface UserProfileOverrides {
+  account_id?: bigint;
+  nickname?: string;
+  birth_date?: Date | null;
+  phone_number?: string | null;
+  profile_image_url?: string | null;
+  onboarding_completed_at?: Date | null;
+}
+
+export async function createUserProfile(
+  prisma: PrismaClient,
+  overrides: UserProfileOverrides = {},
+): Promise<UserProfile> {
+  const seq = nextSeq();
+  const accountId =
+    overrides.account_id ??
+    (await createAccount(prisma, { account_type: 'USER' })).id;
+
+  return prisma.userProfile.create({
+    data: {
+      account_id: accountId,
+      nickname: overrides.nickname ?? `nickname_${seq}`,
+      birth_date: overrides.birth_date ?? null,
+      phone_number: overrides.phone_number ?? null,
+      profile_image_url: overrides.profile_image_url ?? null,
+      onboarding_completed_at:
+        overrides.onboarding_completed_at === undefined
+          ? new Date()
+          : overrides.onboarding_completed_at,
+    },
+  });
+}

--- a/src/test/jest.global-setup.ts
+++ b/src/test/jest.global-setup.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import {
+  GenericContainer,
+  Wait,
+  type StartedTestContainer,
+} from 'testcontainers';
+
+const STATE_FILE = join(process.cwd(), '.tmp', 'test-db-state.json');
+
+/**
+ * Jest globalSetup.
+ *
+ * 1) MySQL 8 Testcontainer를 1회 기동
+ * 2) DB 접속 정보를 state 파일과 env 변수에 기록
+ * 3) worker들이 state 파일로부터 접속 정보를 읽어 worker별 DB를 구성
+ */
+export default async function globalSetup(): Promise<void> {
+  console.log('[test] starting MySQL container...');
+
+  const container: StartedTestContainer = await new GenericContainer(
+    'mysql:8.0',
+  )
+    .withExposedPorts(3306)
+    .withEnvironment({
+      MYSQL_ROOT_PASSWORD: 'test',
+      MYSQL_DATABASE: 'caquick_test_root',
+    })
+    .withCommand([
+      '--character-set-server=utf8mb4',
+      '--collation-server=utf8mb4_unicode_ci',
+    ])
+    .withWaitStrategy(Wait.forHealthCheck())
+    .withHealthCheck({
+      test: [
+        'CMD-SHELL',
+        'mysqladmin ping -h localhost -u root -ptest || exit 1',
+      ],
+      interval: 2_000_000_000, // 2s in nanoseconds
+      timeout: 5_000_000_000,
+      retries: 30,
+      startPeriod: 10_000_000_000,
+    })
+    .withStartupTimeout(120_000)
+    .start();
+
+  const host = container.getHost();
+  const port = container.getMappedPort(3306);
+  const rootUser = 'root';
+  const rootPassword = 'test';
+
+  const state = {
+    containerId: container.getId(),
+    host,
+    port,
+    rootUser,
+    rootPassword,
+  };
+
+  mkdirSync(dirname(STATE_FILE), { recursive: true });
+  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), 'utf8');
+
+  process.env.TEST_DB_HOST = host;
+  process.env.TEST_DB_PORT = String(port);
+  process.env.TEST_DB_ROOT_USER = rootUser;
+  process.env.TEST_DB_ROOT_PASSWORD = rootPassword;
+
+  (
+    globalThis as unknown as { __TESTCONTAINER__?: StartedTestContainer }
+  ).__TESTCONTAINER__ = container;
+
+  console.log(`[test] MySQL container ready at ${host}:${port}`);
+}

--- a/src/test/jest.global-teardown.ts
+++ b/src/test/jest.global-teardown.ts
@@ -1,0 +1,21 @@
+import { existsSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { StartedTestContainer } from 'testcontainers';
+
+const STATE_FILE = join(process.cwd(), '.tmp', 'test-db-state.json');
+
+export default async function globalTeardown(): Promise<void> {
+  const container = (
+    globalThis as unknown as { __TESTCONTAINER__?: StartedTestContainer }
+  ).__TESTCONTAINER__;
+
+  if (container) {
+    console.log('[test] stopping MySQL container...');
+    await container.stop({ timeout: 5000 });
+  }
+
+  if (existsSync(STATE_FILE)) {
+    unlinkSync(STATE_FILE);
+  }
+}

--- a/src/test/modules/testing-module.builder.ts
+++ b/src/test/modules/testing-module.builder.ts
@@ -1,0 +1,36 @@
+import type { ModuleMetadata } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import type { PrismaClient } from '@prisma/client';
+
+import { PrismaService } from '@/prisma/prisma.service';
+import { getTestPrismaClient } from '@/test/db/prisma-test-client';
+
+/**
+ * 실DB(Testcontainers) Prisma 클라이언트를 PrismaService 위치에 주입한
+ * TestingModule을 생성한다.
+ *
+ * 사용 예:
+ * ```ts
+ * const { module, prisma } = await createTestingModuleWithRealDb({
+ *   providers: [SomeService, SomeRepository],
+ * });
+ * ```
+ */
+export async function createTestingModuleWithRealDb(
+  metadata: ModuleMetadata,
+): Promise<{ module: TestingModule; prisma: PrismaClient }> {
+  const prisma = await getTestPrismaClient();
+
+  const module = await Test.createTestingModule({
+    ...metadata,
+    providers: [
+      ...(metadata.providers ?? []),
+      {
+        provide: PrismaService,
+        useValue: prisma,
+      },
+    ],
+  }).compile();
+
+  return { module, prisma };
+}

--- a/src/test/sample.real-db.spec.ts
+++ b/src/test/sample.real-db.spec.ts
@@ -3,7 +3,7 @@ import type { PrismaClient } from '@prisma/client';
 import { ClockService } from '@/common/providers/clock.service';
 import { IdGenerator } from '@/common/providers/id-generator.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
-import { truncateAll } from '@/test/db/truncate';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
 import { createAccount, createUserProfile } from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
@@ -27,6 +27,7 @@ describe('Test DB infra pipeline', () => {
   });
 
   afterAll(async () => {
+    await closeTruncateConnection();
     await disconnectTestPrismaClient();
   });
 

--- a/src/test/sample.real-db.spec.ts
+++ b/src/test/sample.real-db.spec.ts
@@ -31,7 +31,7 @@ describe('Test DB infra pipeline', () => {
   });
 
   beforeEach(async () => {
-    await truncateAll(prisma);
+    await truncateAll();
   });
 
   it('Testcontainer MySQL에 실제로 쓰기/읽기가 가능하다', async () => {

--- a/src/test/sample.real-db.spec.ts
+++ b/src/test/sample.real-db.spec.ts
@@ -1,0 +1,84 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { IdGenerator } from '@/common/providers/id-generator.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { truncateAll } from '@/test/db/truncate';
+import { createAccount, createUserProfile } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * Test DB 인프라 파이프라인 검증용 샘플 스펙.
+ *
+ * 여기서 녹색이 나와야 PR 1 인프라가 동작한다고 본다.
+ */
+describe('Test DB infra pipeline', () => {
+  let prisma: PrismaClient;
+  let clock: ClockService;
+  let idGen: IdGenerator;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ClockService, IdGenerator],
+    });
+    prisma = p;
+    clock = module.get(ClockService);
+    idGen = module.get(IdGenerator);
+  });
+
+  afterAll(async () => {
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll(prisma);
+  });
+
+  it('Testcontainer MySQL에 실제로 쓰기/읽기가 가능하다', async () => {
+    const account = await createAccount(prisma, { account_type: 'USER' });
+    const found = await prisma.account.findUnique({
+      where: { id: account.id },
+    });
+
+    expect(found).not.toBeNull();
+    expect(found!.account_type).toBe('USER');
+    expect(found!.status).toBe('ACTIVE');
+  });
+
+  it('softDelete extension이 적용되어 있다 (deleted_at 자동 필터)', async () => {
+    const account = await createAccount(prisma);
+    await prisma.account.update({
+      where: { id: account.id },
+      data: { deleted_at: new Date() },
+    });
+
+    // findFirst는 READ_ACTIONS에 포함 → soft-delete 필터 자동 적용
+    const foundDefault = await prisma.account.findFirst({
+      where: { id: account.id },
+    });
+    expect(foundDefault).toBeNull();
+
+    // 명시적으로 deleted_at 조건을 주면 조회 가능
+    const foundExplicit = await prisma.account.findFirst({
+      where: { id: account.id, deleted_at: { not: null } },
+    });
+    expect(foundExplicit).not.toBeNull();
+  });
+
+  it('팩토리 체인이 참조 무결성을 지킨다', async () => {
+    const profile = await createUserProfile(prisma);
+    expect(profile.account_id).toBeGreaterThan(0n);
+
+    const account = await prisma.account.findUnique({
+      where: { id: profile.account_id },
+    });
+    expect(account).not.toBeNull();
+  });
+
+  it('ClockService와 IdGenerator가 DI로 주입된다', () => {
+    expect(clock).toBeInstanceOf(ClockService);
+    expect(idGen).toBeInstanceOf(IdGenerator);
+    expect(typeof clock.now().getTime()).toBe('number');
+    expect(idGen.uuid()).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,6 +1544,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@balena/dockerignore@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@balena/dockerignore@npm:1.0.2"
+  checksum: 10c0/0bcb067e86f6734ab943ce4ce9a7c8611f2e983a70bccebf9d2309db57695c09dded7faf5be49c929c4c9e9a9174ae55fc625626de0fb9958823c37423d12f4e
+  languageName: node
+  linkType: hard
+
 "@bcoe/v8-coverage@npm:^0.2.3":
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
@@ -2790,6 +2797,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@grpc/grpc-js@npm:^1.11.1":
+  version: 1.14.3
+  resolution: "@grpc/grpc-js@npm:1.14.3"
+  dependencies:
+    "@grpc/proto-loader": "npm:^0.8.0"
+    "@js-sdsl/ordered-map": "npm:^4.4.2"
+  checksum: 10c0/f41f06a311b93cca8c472d56e21387e0f7b57bb2337a91d15ea4279bac8ec4fa0de6bd0d881201229ab800c0f0c55277911ecb850e057f20a828d0ddd623551d
+  languageName: node
+  linkType: hard
+
+"@grpc/proto-loader@npm:^0.7.13":
+  version: 0.7.15
+  resolution: "@grpc/proto-loader@npm:0.7.15"
+  dependencies:
+    lodash.camelcase: "npm:^4.3.0"
+    long: "npm:^5.0.0"
+    protobufjs: "npm:^7.2.5"
+    yargs: "npm:^17.7.2"
+  bin:
+    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
+  checksum: 10c0/514a134a724b56d73d0a202b7e02c84479da21e364547bacb2f4995ebc0d52412a1a21653add9f004ebd146c1e6eb4bcb0b8846fdfe1bfa8a98ed8f3d203da4a
+  languageName: node
+  linkType: hard
+
+"@grpc/proto-loader@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@grpc/proto-loader@npm:0.8.0"
+  dependencies:
+    lodash.camelcase: "npm:^4.3.0"
+    long: "npm:^5.0.0"
+    protobufjs: "npm:^7.5.3"
+    yargs: "npm:^17.7.2"
+  bin:
+    proto-loader-gen-types: build/bin/proto-loader-gen-types.js
+  checksum: 10c0/a27da3b85d5d17bab956d536786c717287eae46ca264ea9ec774db90ff571955bae2705809f431b4622fbf3be9951d7c7bbb1360b2015ee88abe1587cf3d6fe0
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -3441,6 +3486,22 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10c0/4b30ec8cd56c5fd9a661f088230af01e0c1a3888d11ffb6b47639700f71225be21d1f7e168048d6d4f9449207b978a235c07c8f15c07705685d16dc06280e9d9
+  languageName: node
+  linkType: hard
+
+"@js-sdsl/ordered-map@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "@js-sdsl/ordered-map@npm:4.4.2"
+  checksum: 10c0/cc7e15dc4acf6d9ef663757279600bab70533d847dcc1ab01332e9e680bd30b77cdf9ad885cc774276f51d98b05a013571c940e5b360985af5eb798dc1a2ee2b
+  languageName: node
+  linkType: hard
+
+"@kwsites/file-exists@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/file-exists@npm:1.1.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+  checksum: 10c0/39e693239a72ccd8408bb618a0200e4a8d61682057ca7ae2c87668d7e69196e8d7e2c9cde73db6b23b3b0230169a15e5f1bfe086539f4be43e767b2db68e8ee4
   languageName: node
   linkType: hard
 
@@ -4849,6 +4910,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testcontainers/mysql@npm:^11.14.0":
+  version: 11.14.0
+  resolution: "@testcontainers/mysql@npm:11.14.0"
+  dependencies:
+    testcontainers: "npm:^11.14.0"
+  checksum: 10c0/473d468b7a7db16f44a6d4358aa6708a4852c5360c714bafe003ece446bbcd18ecf2c11b1af69afae2b231b99e6bcf0ca03887922232b2f3e3ebcc3c5d71dac7
+  languageName: node
+  linkType: hard
+
 "@theguild/federation-composition@npm:^0.21.3":
   version: 0.21.3
   resolution: "@theguild/federation-composition@npm:0.21.3"
@@ -5010,6 +5080,27 @@ __metadata:
   version: 2.1.5
   resolution: "@types/cookiejar@npm:2.1.5"
   checksum: 10c0/af38c3d84aebb3ccc6e46fb6afeeaac80fb26e63a487dd4db5a8b87e6ad3d4b845ba1116b2ae90d6f886290a36200fa433d8b1f6fe19c47da6b81872ce9a2764
+  languageName: node
+  linkType: hard
+
+"@types/docker-modem@npm:*":
+  version: 3.0.6
+  resolution: "@types/docker-modem@npm:3.0.6"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/ssh2": "npm:*"
+  checksum: 10c0/d3ffd273148bc883ff9b1a972b1f84c1add6d9a197d2f4fc9774db4c814f39c2e51cc649385b55d781c790c16fb0bf9c1f4c62499bd0f372a4b920190919445d
+  languageName: node
+  linkType: hard
+
+"@types/dockerode@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@types/dockerode@npm:4.0.1"
+  dependencies:
+    "@types/docker-modem": "npm:*"
+    "@types/node": "npm:*"
+    "@types/ssh2": "npm:*"
+  checksum: 10c0/d504d5568624e629663633da9df4a88757d55548e399f2001c478bcdc55ee2e2a4c2fc8a903c4616ebe820a411e256ad5a5caa9c0fb244dca0a5dbc0eb333e45
   languageName: node
   linkType: hard
 
@@ -5177,10 +5268,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=13.7.0":
+  version: 25.6.0
+  resolution: "@types/node@npm:25.6.0"
+  dependencies:
+    undici-types: "npm:~7.19.0"
+  checksum: 10c0/d2d2015630ff098a201407f55f5077a20270ae4f465c739b40865cd9933b91b9c5d2b85568eadaf3db0801b91e267333ca7eb39f007428b173d1cdab4b339ac5
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^10.0.3":
   version: 10.17.60
   resolution: "@types/node@npm:10.17.60"
   checksum: 10c0/0742294912a6e79786cdee9ed77cff6ee8ff007b55d8e21170fc3e5994ad3a8101fea741898091876f8dc32b0a5ae3d64537b7176799e92da56346028d2cbcd2
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.11.18":
+  version: 18.19.130
+  resolution: "@types/node@npm:18.19.130"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10c0/22ba2bc9f8863101a7e90a56aaeba1eb3ebdc51e847cef4a6d188967ab1acbce9b4f92251372fd0329ecb924bbf610509e122c3dfe346c04dbad04013d4ad7d0
   languageName: node
   linkType: hard
 
@@ -5268,6 +5377,34 @@ __metadata:
     "@types/http-errors": "npm:*"
     "@types/node": "npm:*"
   checksum: 10c0/a3c6126bdbf9685e6c7dc03ad34639666eff32754e912adeed9643bf3dd3aa0ff043002a7f69039306e310d233eb8e160c59308f95b0a619f32366bbc48ee094
+  languageName: node
+  linkType: hard
+
+"@types/ssh2-streams@npm:*":
+  version: 0.1.13
+  resolution: "@types/ssh2-streams@npm:0.1.13"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/c0734417ae1d964bcc0681e4cd45f6d25d49e87c1eba54a934dc9a78c40bf76ba4935a414561b6dec5fe0c9c42fe7ad94ef79a4e1592940d934f9c75a704ebb0
+  languageName: node
+  linkType: hard
+
+"@types/ssh2@npm:*":
+  version: 1.15.5
+  resolution: "@types/ssh2@npm:1.15.5"
+  dependencies:
+    "@types/node": "npm:^18.11.18"
+  checksum: 10c0/750e402ce60d6dd67011bf1a811dcbbe638da14baca30c0952b50bad646c4ef8d6fc400894e20f5d2f8882e38b4c35eb6d4f5fe2ecd1d1b1a2f9efef9cf6e773
+  languageName: node
+  linkType: hard
+
+"@types/ssh2@npm:^0.5.48":
+  version: 0.5.52
+  resolution: "@types/ssh2@npm:0.5.52"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/ssh2-streams": "npm:*"
+  checksum: 10c0/95c52fd3438dedae6a59ca87b6558cb36568db6b9144c6c8a28c168739e04c51e27c02908aae14950b7b5020e1c40fea039b1203ae2734c356a40a050fd51c84
   languageName: node
   linkType: hard
 
@@ -5851,6 +5988,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"abort-controller@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "abort-controller@npm:3.0.0"
+  dependencies:
+    event-target-shim: "npm:^5.0.0"
+  checksum: 10c0/90ccc50f010250152509a344eb2e71977fbf8db0ab8f1061197e3275ddf6c61a41a6edfd7b9409c664513131dd96e962065415325ef23efa5db931b382d24ca5
+  languageName: node
+  linkType: hard
+
 "accepts@npm:^2.0.0":
   version: 2.0.0
   resolution: "accepts@npm:2.0.0"
@@ -6098,6 +6244,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"archiver-utils@npm:^5.0.0, archiver-utils@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "archiver-utils@npm:5.0.2"
+  dependencies:
+    glob: "npm:^10.0.0"
+    graceful-fs: "npm:^4.2.0"
+    is-stream: "npm:^2.0.1"
+    lazystream: "npm:^1.0.0"
+    lodash: "npm:^4.17.15"
+    normalize-path: "npm:^3.0.0"
+    readable-stream: "npm:^4.0.0"
+  checksum: 10c0/3782c5fa9922186aa1a8e41ed0c2867569faa5f15c8e5e6418ea4c1b730b476e21bd68270b3ea457daf459ae23aaea070b2b9f90cf90a59def8dc79b9e4ef538
+  languageName: node
+  linkType: hard
+
+"archiver@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "archiver@npm:7.0.1"
+  dependencies:
+    archiver-utils: "npm:^5.0.2"
+    async: "npm:^3.2.4"
+    buffer-crc32: "npm:^1.0.0"
+    readable-stream: "npm:^4.0.0"
+    readdir-glob: "npm:^1.1.2"
+    tar-stream: "npm:^3.0.0"
+    zip-stream: "npm:^6.0.1"
+  checksum: 10c0/02afd87ca16f6184f752db8e26884e6eff911c476812a0e7f7b26c4beb09f06119807f388a8e26ed2558aa8ba9db28646ebd147a4f99e46813b8b43158e1438e
+  languageName: node
+  linkType: hard
+
 "arg@npm:^4.1.0":
   version: 4.1.3
   resolution: "arg@npm:4.1.3"
@@ -6256,7 +6432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1@npm:~0.2.3":
+"asn1@npm:^0.2.6, asn1@npm:~0.2.3":
   version: 0.2.6
   resolution: "asn1@npm:0.2.6"
   dependencies:
@@ -6286,6 +6462,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async-lock@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "async-lock@npm:1.4.1"
+  checksum: 10c0/f696991c7d894af1dc91abc81cc4f14b3785190a35afb1646d8ab91138238d55cabd83bfdd56c42663a008d72b3dc39493ff83797e550effc577d1ccbde254af
+  languageName: node
+  linkType: hard
+
 "async-retry@npm:^1.2.1":
   version: 1.3.3
   resolution: "async-retry@npm:1.3.3"
@@ -6304,7 +6487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.2.3, async@npm:^3.2.5, async@npm:~3.2.0":
+"async@npm:^3.2.3, async@npm:^3.2.4, async@npm:^3.2.5, async@npm:~3.2.0":
   version: 3.2.6
   resolution: "async@npm:3.2.6"
   checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
@@ -6341,10 +6524,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aws-ssl-profiles@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "aws-ssl-profiles@npm:1.1.2"
+  checksum: 10c0/e5f59a4146fe3b88ad2a84f814886c788557b80b744c8cbcb1cbf8cf5ba19cc006a7a12e88819adc614ecda9233993f8f1d1f3b612cbc2f297196df9e8f4f66e
+  languageName: node
+  linkType: hard
+
 "aws4@npm:^1.8.0":
   version: 1.13.2
   resolution: "aws4@npm:1.13.2"
   checksum: 10c0/c993d0d186d699f685d73113733695d648ec7d4b301aba2e2a559d0cd9c1c902308cc52f4095e1396b23fddbc35113644e7f0a6a32753636306e41e3ed6f1e79
+  languageName: node
+  linkType: hard
+
+"b4a@npm:^1.6.4":
+  version: 1.8.0
+  resolution: "b4a@npm:1.8.0"
+  peerDependencies:
+    react-native-b4a: "*"
+  peerDependenciesMeta:
+    react-native-b4a:
+      optional: true
+  checksum: 10c0/27eab5c50ea1f1314f36256f160d2e6d6950f55f02ee4942732ecafd8bcc4b3a2ed209fab532b288770d41df2befa97a2745175c06471875b716eb87abf31519
   languageName: node
   linkType: hard
 
@@ -6441,6 +6643,82 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bare-events@npm:^2.5.4, bare-events@npm:^2.7.0":
+  version: 2.8.2
+  resolution: "bare-events@npm:2.8.2"
+  peerDependencies:
+    bare-abort-controller: "*"
+  peerDependenciesMeta:
+    bare-abort-controller:
+      optional: true
+  checksum: 10c0/53fef240cf2cdcca62f78b6eead90ddb5a59b0929f414b13a63764c2b4f9de98ea8a578d033b04d64bb7b86dfbc402e937984e69950855cc3754c7b63da7db21
+  languageName: node
+  linkType: hard
+
+"bare-fs@npm:^4.0.1, bare-fs@npm:^4.5.5":
+  version: 4.7.1
+  resolution: "bare-fs@npm:4.7.1"
+  dependencies:
+    bare-events: "npm:^2.5.4"
+    bare-path: "npm:^3.0.0"
+    bare-stream: "npm:^2.6.4"
+    bare-url: "npm:^2.2.2"
+    fast-fifo: "npm:^1.3.2"
+  peerDependencies:
+    bare-buffer: "*"
+  peerDependenciesMeta:
+    bare-buffer:
+      optional: true
+  checksum: 10c0/4dc67f6dd0264b817941c2b8cbfc42b6abc3980984cdfd129c4d1f22517cb29f6b99a69fc1e3e87f3a9c997e8c94114604bb67fff10574b2adf0966510cf0222
+  languageName: node
+  linkType: hard
+
+"bare-os@npm:^3.0.1":
+  version: 3.8.7
+  resolution: "bare-os@npm:3.8.7"
+  checksum: 10c0/6541b223a196a58b52e1103ef1f04d35018c1b56b6c250410fc54680767624273691ece741eb88502c95b058ab90b632972348a9231410df05c5df61a62c9c08
+  languageName: node
+  linkType: hard
+
+"bare-path@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "bare-path@npm:3.0.0"
+  dependencies:
+    bare-os: "npm:^3.0.1"
+  checksum: 10c0/56a3ca82a9f808f4976cb1188640ac206546ce0ddff582afafc7bd2a6a5b31c3bd16422653aec656eeada2830cfbaa433c6cbf6d6b4d9eba033d5e06d60d9a68
+  languageName: node
+  linkType: hard
+
+"bare-stream@npm:^2.6.4":
+  version: 2.13.0
+  resolution: "bare-stream@npm:2.13.0"
+  dependencies:
+    streamx: "npm:^2.25.0"
+    teex: "npm:^1.0.1"
+  peerDependencies:
+    bare-abort-controller: "*"
+    bare-buffer: "*"
+    bare-events: "*"
+  peerDependenciesMeta:
+    bare-abort-controller:
+      optional: true
+    bare-buffer:
+      optional: true
+    bare-events:
+      optional: true
+  checksum: 10c0/3c81f169d3bda8af430c5cb0a1cf29f3f697f25fb0863941582112e588680fdfe28357083edcee4c099d3df5a7e3f4145ccc9552d9c7d9b5cab195644fff53d5
+  languageName: node
+  linkType: hard
+
+"bare-url@npm:^2.2.2":
+  version: 2.4.0
+  resolution: "bare-url@npm:2.4.0"
+  dependencies:
+    bare-path: "npm:^3.0.0"
+  checksum: 10c0/b349bf4d3826d6e9fea40aae0b8aaba6e7e83af89feac93ad0b87721c11e0dd84eb651549275242c5ae07a3a21d24620b76bf59c434db65e9605a6e3180f8af2
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -6473,7 +6751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bcrypt-pbkdf@npm:^1.0.0":
+"bcrypt-pbkdf@npm:^1.0.0, bcrypt-pbkdf@npm:^1.0.2":
   version: 1.0.2
   resolution: "bcrypt-pbkdf@npm:1.0.2"
   dependencies:
@@ -6482,7 +6760,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bl@npm:^4.1.0":
+"bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
   dependencies:
@@ -6597,6 +6875,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-crc32@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "buffer-crc32@npm:1.0.0"
+  checksum: 10c0/8b86e161cee4bb48d5fa622cbae4c18f25e4857e5203b89e23de59e627ab26beb82d9d7999f2b8de02580165f61f83f997beaf02980cdf06affd175b651921ab
+  languageName: node
+  linkType: hard
+
 "buffer-equal-constant-time@npm:^1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
@@ -6621,12 +6906,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: "npm:^1.3.1"
+    ieee754: "npm:^1.2.1"
+  checksum: 10c0/2a905fbbcde73cc5d8bd18d1caa23715d5f83a5935867c2329f0ac06104204ba7947be098fe1317fbd8830e26090ff8e764f08cd14fefc977bb248c3487bcbd0
+  languageName: node
+  linkType: hard
+
+"buildcheck@npm:~0.0.6":
+  version: 0.0.7
+  resolution: "buildcheck@npm:0.0.7"
+  checksum: 10c0/987c605267b1b6311bb2ac0638b073d322370267445a6d059da27985fce0b41f85a59d3a9aa9af839e8ac2d63da8af07be6dc737f8bd5323e1dfe6779ad67228
+  languageName: node
+  linkType: hard
+
 "busboy@npm:^1.6.0":
   version: 1.6.0
   resolution: "busboy@npm:1.6.0"
   dependencies:
     streamsearch: "npm:^1.1.0"
   checksum: 10c0/fa7e836a2b82699b6e074393428b91ae579d4f9e21f5ac468e1b459a244341d722d2d22d10920cdd849743dbece6dca11d72de939fb75a7448825cf2babfba1f
+  languageName: node
+  linkType: hard
+
+"byline@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "byline@npm:5.0.0"
+  checksum: 10c0/33fb64cd84440b3652a99a68d732c56ef18a748ded495ba38e7756a242fab0d4654b9b8ce269fd0ac14c5f97aa4e3c369613672b280a1f60b559b34223105c85
   languageName: node
   linkType: hard
 
@@ -6798,6 +7107,7 @@ __metadata:
     "@nestjs/swagger": "npm:^11.2.3"
     "@nestjs/testing": "npm:11.1.10"
     "@prisma/client": "npm:^6.2.0"
+    "@testcontainers/mysql": "npm:^11.14.0"
     "@types/cookie-parser": "npm:^1.4.10"
     "@types/express": "npm:^5.0.6"
     "@types/jest": "npm:^29"
@@ -6824,6 +7134,7 @@ __metadata:
     langsmith: "npm:^0.5.7"
     lint-staged: "npm:^16.4.0"
     logform: "npm:^2.7.0"
+    mysql2: "npm:^3.22.0"
     openai: "npm:^6.27.0"
     openid-client: "npm:5.7.1"
     passport: "npm:^0.7.0"
@@ -6835,6 +7146,7 @@ __metadata:
     source-map-support: "npm:^0.5.21"
     spectaql: "npm:^3.0.6"
     supertest: "npm:^7.0.0"
+    testcontainers: "npm:^11.14.0"
     ts-jest: "npm:^29"
     ts-loader: "npm:^9.5.2"
     ts-morph: "npm:^27.0.2"
@@ -6971,6 +7283,13 @@ __metadata:
   dependencies:
     readdirp: "npm:^4.0.1"
   checksum: 10c0/a58b9df05bb452f7d105d9e7229ac82fa873741c0c40ddcc7bb82f8a909fbe3f7814c9ebe9bc9a2bef9b737c0ec6e2d699d179048ef06ad3ec46315df0ebe6ad
+  languageName: node
+  linkType: hard
+
+"chownr@npm:^1.1.1":
+  version: 1.1.4
+  resolution: "chownr@npm:1.1.4"
+  checksum: 10c0/ed57952a84cc0c802af900cf7136de643d3aba2eecb59d29344bc2f3f9bf703a301b9d84cdc71f82c3ffc9ccde831b0d92f5b45f91727d6c9da62f23aef9d9db
   languageName: node
   linkType: hard
 
@@ -7279,6 +7598,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compress-commons@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "compress-commons@npm:6.0.2"
+  dependencies:
+    crc-32: "npm:^1.2.0"
+    crc32-stream: "npm:^6.0.0"
+    is-stream: "npm:^2.0.1"
+    normalize-path: "npm:^3.0.0"
+    readable-stream: "npm:^4.0.0"
+  checksum: 10c0/2347031b7c92c8ed5011b07b93ec53b298fa2cd1800897532ac4d4d1aeae06567883f481b6e35f13b65fc31b190c751df6635434d525562f0203fde76f1f0814
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -7554,6 +7886,36 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/a5d4d95599687532ee072bca60170133c24d4e08cd795529e0f22c6ce5fde9409eaf4f26e36e3d671f43270ef858fc68f3c7b0ec28e58fac7ddebda5b7725306
+  languageName: node
+  linkType: hard
+
+"cpu-features@npm:~0.0.10":
+  version: 0.0.10
+  resolution: "cpu-features@npm:0.0.10"
+  dependencies:
+    buildcheck: "npm:~0.0.6"
+    nan: "npm:^2.19.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/0c4a12904657b22477ffbcfd2b4b2bdd45b174f283616b18d9e1ade495083f9f6098493feb09f4ae2d0b36b240f9ecd32cfb4afe210cf0d0f8f0cc257bd58e54
+  languageName: node
+  linkType: hard
+
+"crc-32@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "crc-32@npm:1.2.2"
+  bin:
+    crc32: bin/crc32.njs
+  checksum: 10c0/11dcf4a2e77ee793835d49f2c028838eae58b44f50d1ff08394a610bfd817523f105d6ae4d9b5bef0aad45510f633eb23c903e9902e4409bed1ce70cb82b9bf0
+  languageName: node
+  linkType: hard
+
+"crc32-stream@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "crc32-stream@npm:6.0.0"
+  dependencies:
+    crc-32: "npm:^1.2.0"
+    readable-stream: "npm:^4.0.0"
+  checksum: 10c0/bf9c84571ede2d119c2b4f3a9ef5eeb9ff94b588493c0d3862259af86d3679dcce1c8569dd2b0a6eff2f35f5e2081cc1263b846d2538d4054da78cf34f262a3d
   languageName: node
   linkType: hard
 
@@ -7835,6 +8197,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"denque@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "denque@npm:2.1.0"
+  checksum: 10c0/f9ef81aa0af9c6c614a727cb3bd13c5d7db2af1abf9e6352045b86e85873e629690f6222f4edd49d10e4ccf8f078bbeec0794fafaf61b659c0589d0c511ec363
+  languageName: node
+  linkType: hard
+
 "depd@npm:2.0.0, depd@npm:^2.0.0, depd@npm:~2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
@@ -7928,6 +8297,42 @@ __metadata:
   dependencies:
     path-type: "npm:^4.0.0"
   checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
+  languageName: node
+  linkType: hard
+
+"docker-compose@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "docker-compose@npm:1.4.2"
+  dependencies:
+    yaml: "npm:^2.2.2"
+  checksum: 10c0/2cd9182dafeac8ac3fed57e5aac85be5dec18eaa0241026d202e418577bfe185ab97ae2e066be01ade4ae55ffdcab04f4b40c754f3b2d11c314d6ca0117b51fa
+  languageName: node
+  linkType: hard
+
+"docker-modem@npm:^5.0.7":
+  version: 5.0.7
+  resolution: "docker-modem@npm:5.0.7"
+  dependencies:
+    debug: "npm:^4.1.1"
+    readable-stream: "npm:^3.5.0"
+    split-ca: "npm:^1.0.1"
+    ssh2: "npm:^1.15.0"
+  checksum: 10c0/987dd7b04de57241d4e0fbdb5c44d41f898f5f520a3f6dbc6542c27cf9e84c91c44bf0c1bee2469be83096cb2941ea5e4a1bd3f57f60eb508c1d790d27ada8f9
+  languageName: node
+  linkType: hard
+
+"dockerode@npm:^4.0.10":
+  version: 4.0.10
+  resolution: "dockerode@npm:4.0.10"
+  dependencies:
+    "@balena/dockerignore": "npm:^1.0.2"
+    "@grpc/grpc-js": "npm:^1.11.1"
+    "@grpc/proto-loader": "npm:^0.7.13"
+    docker-modem: "npm:^5.0.7"
+    protobufjs: "npm:^7.3.2"
+    tar-fs: "npm:^2.1.4"
+    uuid: "npm:^10.0.0"
+  checksum: 10c0/064930c4446ee833227417952ee9450b6f2a0045bfb93041ce36dd3f831fd6f24b7f87b44b6ff067782d0f121e5e530044e7e9ef538ef0c83133928a486d2d47
   languageName: node
   linkType: hard
 
@@ -8178,6 +8583,15 @@ __metadata:
   dependencies:
     iconv-lite: "npm:^0.6.2"
   checksum: 10c0/36d938712ff00fe1f4bac88b43bcffb5930c1efa57bbcdca9d67e1d9d6c57cfb1200fb01efe0f3109b2ce99b231f90779532814a81370a1bd3274a0f58585039
+  languageName: node
+  linkType: hard
+
+"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
+  version: 1.4.5
+  resolution: "end-of-stream@npm:1.4.5"
+  dependencies:
+    once: "npm:^1.4.0"
+  checksum: 10c0/b0701c92a10b89afb1cb45bf54a5292c6f008d744eb4382fa559d54775ff31617d1d7bc3ef617575f552e24fad2c7c1a1835948c66b3f3a4be0a6c1f35c883d8
   languageName: node
   linkType: hard
 
@@ -8675,6 +9089,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-target-shim@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "event-target-shim@npm:5.0.1"
+  checksum: 10c0/0255d9f936215fd206156fd4caa9e8d35e62075d720dc7d847e89b417e5e62cf1ce6c9b4e0a1633a9256de0efefaf9f8d26924b1f3c8620cffb9db78e7d3076b
+  languageName: node
+  linkType: hard
+
 "eventemitter2@npm:~0.4.13":
   version: 0.4.14
   resolution: "eventemitter2@npm:0.4.14"
@@ -8703,7 +9124,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:^3.2.0":
+"events-universal@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "events-universal@npm:1.0.1"
+  dependencies:
+    bare-events: "npm:^2.7.0"
+  checksum: 10c0/a1d9a5e9f95843650f8ec240dd1221454c110189a9813f32cdf7185759b43f1f964367ac7dca4ebc69150b59043f2d77c7e122b0d03abf7c25477ea5494785a5
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.2.0, events@npm:^3.3.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
@@ -8847,6 +9277,13 @@ __metadata:
   version: 1.3.0
   resolution: "fast-diff@npm:1.3.0"
   checksum: 10c0/5c19af237edb5d5effda008c891a18a585f74bf12953be57923f17a3a4d0979565fc64dbc73b9e20926b9d895f5b690c618cbb969af0cf022e3222471220ad29
+  languageName: node
+  linkType: hard
+
+"fast-fifo@npm:^1.2.0, fast-fifo@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "fast-fifo@npm:1.3.2"
+  checksum: 10c0/d53f6f786875e8b0529f784b59b4b05d4b5c31c651710496440006a398389a579c8dbcd2081311478b5bf77f4b0b21de69109c5a4eabea9d8e8783d1eb864e4c
   languageName: node
   linkType: hard
 
@@ -9295,6 +9732,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-constants@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fs-constants@npm:1.0.0"
+  checksum: 10c0/a0cde99085f0872f4d244e83e03a46aa387b74f5a5af750896c6b05e9077fac00e9932fdf5aef84f2f16634cd473c63037d7a512576da7d5c2b9163d1909f3a8
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^10.0.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
@@ -9385,6 +9829,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generate-function@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "generate-function@npm:2.3.1"
+  dependencies:
+    is-property: "npm:^1.0.2"
+  checksum: 10c0/4645cf1da90375e46a6f1dc51abc9933e5eafa4cd1a44c2f7e3909a30a4e9a1a08c14cd7d5b32da039da2dba2a085e1ed4597b580c196c3245b2d35d8bc0de5d
+  languageName: node
+  linkType: hard
+
 "generator-function@npm:^2.0.0":
   version: 2.0.1
   resolution: "generator-function@npm:2.0.1"
@@ -9445,6 +9898,13 @@ __metadata:
   version: 3.2.0
   resolution: "get-port@npm:3.2.0"
   checksum: 10c0/1b6c3fe89074be3753d9ddf3d67126ea351ab9890537fe53fefebc2912d1d66fdc112451bbc76d33ae5ceb6ca70be2a91017944e3ee8fb0814ac9b295bf2a5b8
+  languageName: node
+  linkType: hard
+
+"get-port@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "get-port@npm:7.2.0"
+  checksum: 10c0/4ed741d9008ad15a24e2098c8971918025cc8241624245e704ecc62bb65160db5c79de5d7112acdaabccbe0714cd0704008c74d43a1f7a24a5875e58b84621be
   languageName: node
   linkType: hard
 
@@ -9565,7 +10025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.3.3":
+"glob@npm:^10.0.0, glob@npm:^10.3.3":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:
@@ -10291,6 +10751,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:~0.4.13":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
@@ -10712,6 +11181,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-property@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "is-property@npm:1.0.2"
+  checksum: 10c0/33ab65a136e4ba3f74d4f7d9d2a013f1bd207082e11cedb160698e8d5394644e873c39668d112a402175ccbc58a087cef87198ed46829dbddb479115a0257283
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
@@ -10749,7 +11225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-stream@npm:^2.0.0":
+"is-stream@npm:^2.0.0, is-stream@npm:^2.0.1":
   version: 2.0.1
   resolution: "is-stream@npm:2.0.1"
   checksum: 10c0/7c284241313fc6efc329b8d7f08e16c0efeb6baab1b4cd0ba579eb78e5af1aa5da11e68559896a2067cd6c526bd29241dda4eb1225e627d5aa1a89a76d4635a5
@@ -11755,6 +12231,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lazystream@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "lazystream@npm:1.0.1"
+  dependencies:
+    readable-stream: "npm:^2.0.5"
+  checksum: 10c0/ea4e509a5226ecfcc303ba6782cc269be8867d372b9bcbd625c88955df1987ea1a20da4643bf9270336415a398d33531ebf0d5f0d393b9283dc7c98bfcbd7b69
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -12032,6 +12517,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash@npm:^4.17.15":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:^4.0.0, log-symbols@npm:^4.1.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -12080,6 +12572,13 @@ __metadata:
   version: 4.0.0
   resolution: "long@npm:4.0.0"
   checksum: 10c0/50a6417d15b06104dbe4e3d4a667c39b137f130a9108ea8752b352a4cfae047531a3ac351c181792f3f8768fe17cca6b0f406674a541a86fb638aaac560d83ed
+  languageName: node
+  linkType: hard
+
+"long@npm:^5.0.0, long@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
   languageName: node
   linkType: hard
 
@@ -12151,6 +12650,13 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
+  languageName: node
+  linkType: hard
+
+"lru.min@npm:^1.1.0, lru.min@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "lru.min@npm:1.1.4"
+  checksum: 10c0/d9cce4d9988ced2b2dd199f47016adefda27e8405a7f63b86a54e574d254bb0099ff9e91846b0c20379348e7a03d6f4de8b8f8cdfd5265b36eb3ec07bcf72f96
   languageName: node
   linkType: hard
 
@@ -12433,6 +12939,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^5.1.0":
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
@@ -12534,6 +13049,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mkdirp-classic@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "mkdirp-classic@npm:0.5.3"
+  checksum: 10c0/95371d831d196960ddc3833cc6907e6b8f67ac5501a6582f47dfae5eb0f092e9f8ce88e0d83afcae95d6e2b61a01741ba03714eeafb6f7a6e9dcc158ac85b168
+  languageName: node
+  linkType: hard
+
 "mkdirp@npm:^0.5.6":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
@@ -12542,6 +13064,15 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: 10c0/e2e2be789218807b58abced04e7b49851d9e46e88a2f9539242cc8a92c9b5c3a0b9bab360bd3014e02a140fc4fbc58e31176c408b493f8a2a6f4986bd7527b01
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "mkdirp@npm:3.0.1"
+  bin:
+    mkdirp: dist/cjs/src/bin.js
+  checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
   languageName: node
   linkType: hard
 
@@ -12600,6 +13131,42 @@ __metadata:
   version: 2.0.0
   resolution: "mute-stream@npm:2.0.0"
   checksum: 10c0/2cf48a2087175c60c8dcdbc619908b49c07f7adcfc37d29236b0c5c612d6204f789104c98cc44d38acab7b3c96f4a3ec2cfdc4934d0738d876dbefa2a12c69f4
+  languageName: node
+  linkType: hard
+
+"mysql2@npm:^3.22.0":
+  version: 3.22.0
+  resolution: "mysql2@npm:3.22.0"
+  dependencies:
+    aws-ssl-profiles: "npm:^1.1.2"
+    denque: "npm:^2.1.0"
+    generate-function: "npm:^2.3.1"
+    iconv-lite: "npm:^0.7.2"
+    long: "npm:^5.3.2"
+    lru.min: "npm:^1.1.4"
+    named-placeholders: "npm:^1.1.6"
+    sql-escaper: "npm:^1.3.3"
+  peerDependencies:
+    "@types/node": ">= 8"
+  checksum: 10c0/f7902bcb33d3a7806e1e0c6814d2f0c875a24aac1c49a98cf040083bbdd7aa7f2e202e1e40e3842d434429172f36f8dc74e43f6b0e1bd3a1abb94f7159fba992
+  languageName: node
+  linkType: hard
+
+"named-placeholders@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "named-placeholders@npm:1.1.6"
+  dependencies:
+    lru.min: "npm:^1.1.0"
+  checksum: 10c0/65b7ffaf932a371602e4153808601e8f377d7fc85fa15b491ee821418e52ab4950155b840803a6eaf3d5b94d6e8aedc1bee723475541cb4713feb3544dca9336
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.19.0, nan@npm:^2.23.0":
+  version: 2.26.2
+  resolution: "nan@npm:2.26.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/ff204c964729279cf3abb8b170c77753ed36092e2235f11bfb0204dfd3e8cc2d5a3bcfdfd3b677f06a0743d7f835d873dce59f23a2dbf6fb671d9351cc655d73
   languageName: node
   linkType: hard
 
@@ -13032,7 +13599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0, once@npm:^1.4.0":
+"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -13678,6 +14245,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: 10c0/40c3ce4b7e6d4b8c3355479df77aeed46f81b279818ccdc500124e6a5ab882c0cc81ff7ea16384873a95a74c4570b01b120f287abbdd4c877931460eca6084b3
+  languageName: node
+  linkType: hard
+
 "promise-retry@npm:^2.0.1":
   version: 2.0.1
   resolution: "promise-retry@npm:2.0.1"
@@ -13716,10 +14290,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"proper-lockfile@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "proper-lockfile@npm:4.1.2"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    retry: "npm:^0.12.0"
+    signal-exit: "npm:^3.0.2"
+  checksum: 10c0/2f265dbad15897a43110a02dae55105c04d356ec4ed560723dcb9f0d34bc4fb2f13f79bb930e7561be10278e2314db5aca2527d5d3dcbbdee5e6b331d1571f6d
+  languageName: node
+  linkType: hard
+
+"properties-reader@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "properties-reader@npm:3.0.1"
+  dependencies:
+    "@kwsites/file-exists": "npm:^1.1.1"
+    mkdirp: "npm:^3.0.1"
+  checksum: 10c0/271fae77b717e25aa5773ab1e769f416ccfdc3606a62f25cd76b2cceeb04278f2ee0e4d671ff2c06391a5e093b4b1097f9ce3916fddd4de34077a4a6e92ccb48
+  languageName: node
+  linkType: hard
+
 "proto-list@npm:~1.2.1":
   version: 1.2.4
   resolution: "proto-list@npm:1.2.4"
   checksum: 10c0/b9179f99394ec8a68b8afc817690185f3b03933f7b46ce2e22c1930dc84b60d09f5ad222beab4e59e58c6c039c7f7fcf620397235ef441a356f31f9744010e12
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.2, protobufjs@npm:^7.5.3":
+  version: 7.5.5
+  resolution: "protobufjs@npm:7.5.5"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.0.0"
+  checksum: 10c0/3d48896a916761e3e60b52f80027eb4fba3f5a6e3f8461e04939db18812db2cb0db4c73d03e1134a960e99525ae1d236f076a0bc01273016f573b76f33ffbd47
   languageName: node
   linkType: hard
 
@@ -13746,6 +14361,16 @@ __metadata:
   dependencies:
     punycode: "npm:^2.3.1"
   checksum: 10c0/d8d45a99e4ca62ca12ac3c373e63d80d2368d38892daa40cfddaa1eb908be98cd549ac059783ef3a56cfd96d57ae8e2fd9ae53d1378d90d42bc661ff924e102a
+  languageName: node
+  linkType: hard
+
+"pump@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "pump@npm:3.0.4"
+  dependencies:
+    end-of-stream: "npm:^1.1.0"
+    once: "npm:^1.3.1"
+  checksum: 10c0/2780e66b5471c19e3e3e1063b84f3f6a3a08367f24c5ed552f98cd5901e6ada27c7ad6495d4244f553fd03b01884a4561933064f053f47c8994d84fd352768ea
   languageName: node
   linkType: hard
 
@@ -13857,7 +14482,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.2.2":
+"readable-stream@npm:^2.0.5, readable-stream@npm:^2.2.2":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
   dependencies:
@@ -13872,7 +14497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.2, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.2":
+"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -13880,6 +14505,28 @@ __metadata:
     string_decoder: "npm:^1.1.1"
     util-deprecate: "npm:^1.0.1"
   checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^4.0.0":
+  version: 4.7.0
+  resolution: "readable-stream@npm:4.7.0"
+  dependencies:
+    abort-controller: "npm:^3.0.0"
+    buffer: "npm:^6.0.3"
+    events: "npm:^3.3.0"
+    process: "npm:^0.11.10"
+    string_decoder: "npm:^1.3.0"
+  checksum: 10c0/fd86d068da21cfdb10f7a4479f2e47d9c0a9b0c862fc0c840a7e5360201580a55ac399c764b12a4f6fa291f8cee74d9c4b7562e0d53b3c4b2769f2c98155d957
+  languageName: node
+  linkType: hard
+
+"readdir-glob@npm:^1.1.2":
+  version: 1.1.3
+  resolution: "readdir-glob@npm:1.1.3"
+  dependencies:
+    minimatch: "npm:^5.1.0"
+  checksum: 10c0/a37e0716726650845d761f1041387acd93aa91b28dd5381950733f994b6c349ddc1e21e266ec7cc1f9b92e205a7a972232f9b89d5424d07361c2c3753d5dbace
   languageName: node
   linkType: hard
 
@@ -14769,6 +15416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-ca@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "split-ca@npm:1.0.1"
+  checksum: 10c0/f339170b84c6b4706fcf4c60cc84acb36574c0447566bd713301a8d9b4feff7f4627efc8c334bec24944a3e2f35bc596bd58c673c9980d6bfe3137aae1116ba7
+  languageName: node
+  linkType: hard
+
 "sponge-case@npm:^1.0.1":
   version: 1.0.1
   resolution: "sponge-case@npm:1.0.1"
@@ -14789,6 +15443,40 @@ __metadata:
   version: 1.0.3
   resolution: "sprintf-js@npm:1.0.3"
   checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
+  languageName: node
+  linkType: hard
+
+"sql-escaper@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "sql-escaper@npm:1.3.3"
+  checksum: 10c0/aa6545685745f4d457a6993cd7b442ac39d54aae6780d15e5ed1ff929f298f6c10562b9e09ddcbedcdf5c3601161e5ee39d3e8d435b1d168775f121946d1bf44
+  languageName: node
+  linkType: hard
+
+"ssh-remote-port-forward@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "ssh-remote-port-forward@npm:1.0.4"
+  dependencies:
+    "@types/ssh2": "npm:^0.5.48"
+    ssh2: "npm:^1.4.0"
+  checksum: 10c0/33a441af12817577ea30d089b03c19f980d2fb2370933123a35026dc6be40f2dfce067e4dfc173e23d745464537ff647aa1bb7469be5571cc21f7cdb25181c09
+  languageName: node
+  linkType: hard
+
+"ssh2@npm:^1.15.0, ssh2@npm:^1.4.0":
+  version: 1.17.0
+  resolution: "ssh2@npm:1.17.0"
+  dependencies:
+    asn1: "npm:^0.2.6"
+    bcrypt-pbkdf: "npm:^1.0.2"
+    cpu-features: "npm:~0.0.10"
+    nan: "npm:^2.23.0"
+  dependenciesMeta:
+    cpu-features:
+      optional: true
+    nan:
+      optional: true
+  checksum: 10c0/637c1b7e8070fc8a3027f8abf771cd98419f56eaf3817171180e768004d4dea26c65fb3763294ed2f784429857f196c83c4f6889d2c31cc0e2648ea5ad730665
   languageName: node
   linkType: hard
 
@@ -14873,6 +15561,17 @@ __metadata:
   version: 1.1.0
   resolution: "streamsearch@npm:1.1.0"
   checksum: 10c0/fbd9aecc2621364384d157f7e59426f4bfd385e8b424b5aaa79c83a6f5a1c8fd2e4e3289e95de1eb3511cb96bb333d6281a9919fafce760e4edb35b2cd2facab
+  languageName: node
+  linkType: hard
+
+"streamx@npm:^2.12.5, streamx@npm:^2.15.0, streamx@npm:^2.25.0":
+  version: 2.25.0
+  resolution: "streamx@npm:2.25.0"
+  dependencies:
+    events-universal: "npm:^1.0.0"
+    fast-fifo: "npm:^1.3.2"
+    text-decoder: "npm:^1.1.0"
+  checksum: 10c0/1ecc4b722050e9088b99cde59d035e846ac97cedc3ef14a00b196d9c0b6f47d9fd18df454a19f56f0f586ab4f23fb7229069b9e8eaf22072a21bd9c909d4e0ea
   languageName: node
   linkType: hard
 
@@ -14995,7 +15694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
+"string_decoder@npm:^1.1.1, string_decoder@npm:^1.3.0":
   version: 1.3.0
   resolution: "string_decoder@npm:1.3.0"
   dependencies:
@@ -15248,6 +15947,60 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tar-fs@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "tar-fs@npm:2.1.4"
+  dependencies:
+    chownr: "npm:^1.1.1"
+    mkdirp-classic: "npm:^0.5.2"
+    pump: "npm:^3.0.0"
+    tar-stream: "npm:^2.1.4"
+  checksum: 10c0/decb25acdc6839182c06ec83cba6136205bda1db984e120c8ffd0d80182bc5baa1d916f9b6c5c663ea3f9975b4dd49e3c6bb7b1707cbcdaba4e76042f43ec84c
+  languageName: node
+  linkType: hard
+
+"tar-fs@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "tar-fs@npm:3.1.2"
+  dependencies:
+    bare-fs: "npm:^4.0.1"
+    bare-path: "npm:^3.0.0"
+    pump: "npm:^3.0.0"
+    tar-stream: "npm:^3.1.5"
+  dependenciesMeta:
+    bare-fs:
+      optional: true
+    bare-path:
+      optional: true
+  checksum: 10c0/9dcbbbef9cdfc27f47651fe679f15952a6a8e6b3c9761c4bf3f416ace41cf462fb6292519bd3e041cadfcc0b89043a6bdecb46ff19f770b6864b77dcde7bad46
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^2.1.4":
+  version: 2.2.0
+  resolution: "tar-stream@npm:2.2.0"
+  dependencies:
+    bl: "npm:^4.0.3"
+    end-of-stream: "npm:^1.4.1"
+    fs-constants: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^3.1.1"
+  checksum: 10c0/2f4c910b3ee7196502e1ff015a7ba321ec6ea837667220d7bcb8d0852d51cb04b87f7ae471008a6fb8f5b1a1b5078f62f3a82d30c706f20ada1238ac797e7692
+  languageName: node
+  linkType: hard
+
+"tar-stream@npm:^3.0.0, tar-stream@npm:^3.1.5":
+  version: 3.1.8
+  resolution: "tar-stream@npm:3.1.8"
+  dependencies:
+    b4a: "npm:^1.6.4"
+    bare-fs: "npm:^4.5.5"
+    fast-fifo: "npm:^1.2.0"
+    streamx: "npm:^2.15.0"
+  checksum: 10c0/c4bf369de2302fcf30218d091167a5372ee79b69a1b5bb493ddb7714193ca805719558966334bab1f2775c8142826865f24e25459ff1c5f0a096bc3a3d5c5ce2
+  languageName: node
+  linkType: hard
+
 "tar@npm:^7.5.2":
   version: 7.5.2
   resolution: "tar@npm:7.5.2"
@@ -15258,6 +16011,15 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10c0/a7d8b801139b52f93a7e34830db0de54c5aa45487c7cb551f6f3d44a112c67f1cb8ffdae856b05fd4f17b1749911f1c26f1e3a23bbe0279e17fd96077f13f467
+  languageName: node
+  linkType: hard
+
+"teex@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "teex@npm:1.0.1"
+  dependencies:
+    streamx: "npm:^2.12.5"
+  checksum: 10c0/8df9166c037ba694b49d32a49858e314c60e513d55ac5e084dbf1ddbb827c5fa43cc389a81e87684419c21283308e9d68bb068798189c767ec4c252f890b8a77
   languageName: node
   linkType: hard
 
@@ -15305,6 +16067,38 @@ __metadata:
     glob: "npm:^7.1.4"
     minimatch: "npm:^3.0.4"
   checksum: 10c0/019d33d81adff3f9f1bfcff18125fb2d3c65564f437d9be539270ee74b994986abb8260c7c2ce90e8f30162178b09dbbce33c6389273afac4f36069c48521f57
+  languageName: node
+  linkType: hard
+
+"testcontainers@npm:^11.14.0":
+  version: 11.14.0
+  resolution: "testcontainers@npm:11.14.0"
+  dependencies:
+    "@balena/dockerignore": "npm:^1.0.2"
+    "@types/dockerode": "npm:^4.0.1"
+    archiver: "npm:^7.0.1"
+    async-lock: "npm:^1.4.1"
+    byline: "npm:^5.0.0"
+    debug: "npm:^4.4.3"
+    docker-compose: "npm:^1.4.2"
+    dockerode: "npm:^4.0.10"
+    get-port: "npm:^7.2.0"
+    proper-lockfile: "npm:^4.1.2"
+    properties-reader: "npm:^3.0.1"
+    ssh-remote-port-forward: "npm:^1.0.4"
+    tar-fs: "npm:^3.1.2"
+    tmp: "npm:^0.2.5"
+    undici: "npm:^7.24.5"
+  checksum: 10c0/a94294bb5f51a05c01252b7e0cdaa321696bed92a42d5d72e1467ae27d2a6547a63e287d8153b748dda3578df1ee08c1bf882919e6223ed3a26fefe91da88326
+  languageName: node
+  linkType: hard
+
+"text-decoder@npm:^1.1.0":
+  version: 1.2.7
+  resolution: "text-decoder@npm:1.2.7"
+  dependencies:
+    b4a: "npm:^1.6.4"
+  checksum: 10c0/929938ed154fbadb660a7f3d1aca30b7e53649a731af7583168fcfba0c158046325d35d945926e2a512bb62d1a49a7818151c987ea38b48853f01e1615722fc5
   languageName: node
   linkType: hard
 
@@ -15401,6 +16195,13 @@ __metadata:
   version: 0.2.4
   resolution: "tmp@npm:0.2.4"
   checksum: 10c0/ac4a7538a9ddb89ead6f4ee019bc23c28ce31549a0bd0ba499a64f81e0804b1e9a3a758622b33807a1f9644dbde9a0205637985f9450abdba1d5062704f98782
+  languageName: node
+  linkType: hard
+
+"tmp@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "tmp@npm:0.2.5"
+  checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e
   languageName: node
   linkType: hard
 
@@ -15867,6 +16668,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~6.21.0":
   version: 6.21.0
   resolution: "undici-types@npm:6.21.0"
@@ -15878,6 +16686,20 @@ __metadata:
   version: 7.16.0
   resolution: "undici-types@npm:7.16.0"
   checksum: 10c0/3033e2f2b5c9f1504bdc5934646cb54e37ecaca0f9249c983f7b1fc2e87c6d18399ebb05dc7fd5419e02b2e915f734d872a65da2e3eeed1813951c427d33cc9a
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~7.19.0":
+  version: 7.19.2
+  resolution: "undici-types@npm:7.19.2"
+  checksum: 10c0/7159f10546f9f6c47d36776bb1bbf8671e87c1e587a6fee84ae1f111ae8de4f914efa8ca0dfcd224f4f4a9dfc3f6028f627ccb5ddaccf82d7fd54671b89fac3e
+  languageName: node
+  linkType: hard
+
+"undici@npm:^7.24.5":
+  version: 7.25.0
+  resolution: "undici@npm:7.25.0"
+  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
   languageName: node
   linkType: hard
 
@@ -16574,21 +17396,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.2.2, yaml@npm:^2.8.2":
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
+  languageName: node
+  linkType: hard
+
 "yaml@npm:^2.3.1":
   version: 2.8.2
   resolution: "yaml@npm:2.8.2"
   bin:
     yaml: bin.mjs
   checksum: 10c0/703e4dc1e34b324aa66876d63618dcacb9ed49f7e7fe9b70f1e703645be8d640f68ab84f12b86df8ac960bac37acf5513e115de7c970940617ce0343c8c9cd96
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.8.2":
-  version: 2.8.3
-  resolution: "yaml@npm:2.8.3"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/ddff0e11c1b467728d7eb4633db61c5f5de3d8e9373cf84d08fb0cdee03e1f58f02b9f1c51a4a8a865751695addbd465a77f73f1079be91fe5493b29c305fd77
   languageName: node
   linkType: hard
 
@@ -16606,7 +17428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.0.0, yargs@npm:^17.3.1":
+"yargs@npm:^17.0.0, yargs@npm:^17.3.1, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -16639,5 +17461,16 @@ __metadata:
   version: 2.1.3
   resolution: "yoctocolors-cjs@npm:2.1.3"
   checksum: 10c0/584168ef98eb5d913473a4858dce128803c4a6cd87c0f09e954fa01126a59a33ab9e513b633ad9ab953786ed16efdd8c8700097a51635aafaeed3fef7712fa79
+  languageName: node
+  linkType: hard
+
+"zip-stream@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "zip-stream@npm:6.0.1"
+  dependencies:
+    archiver-utils: "npm:^5.0.0"
+    compress-commons: "npm:^6.0.2"
+    readable-stream: "npm:^4.0.0"
+  checksum: 10c0/50f2fb30327fb9d09879abf7ae2493705313adf403e794b030151aaae00009162419d60d0519e807673ec04d442e140c8879ca14314df0a0192de3b233e8f28b
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary
- **Testcontainers MySQL 8** 기반 실DB 테스트 인프라 구축 (Mock DB → Real DB 전환의 기반)
- Jest `globalSetup`/`globalTeardown`으로 컨테이너 자동 기동/종료
- Worker별 격리 DB + `prisma migrate deploy`로 스키마 적용, `TRUNCATE` 헬퍼로 테스트 간 리셋
- `ClockService`, `IdGenerator` DI 추상화 추가 (시간/UUID 결정적 테스트 기반)
- 핵심 팩토리 셋 7종 (Account, UserProfile, Store, Product, Order, OrderItem, Review)
- Codecov 전체 리포트 활성화 + base 커버리지 업로드 설정
- **기존 mock 테스트에 영향 없음** — 31 스위트 536 테스트 전부 통과 확인

## 주요 변경
- `testcontainers`, `@testcontainers/mysql`, `mysql2` devDependency 추가
- `src/test/` 디렉터리 신규 생성 (컨테이너/DB/팩토리/모듈 빌더)
- `src/common/common.module.ts` + `ClockService`, `IdGenerator` 전역 등록
- Jest 설정: `globalSetup`, `globalTeardown`, `testTimeout: 60s` 추가
- `truncateAll`: Prisma 커넥션 풀 대신 mysql2 단일 연결 사용 (FK 제약 해제 보장)
- `truncateAll`: Worker별 mysql2 커넥션 캐싱 (매 테스트 TCP 연결 오버헤드 제거)
- `codecov.yml` 추가: 전체 리포트 레이아웃 (`header, diff, flags, components, files, footer`)
- CI 워크플로: `push` 트리거 추가 (main/develop base 커버리지 업로드), Codecov 업로드를 check job으로 통합

## Test plan
- [x] 샘플 실DB 테스트 4건 통과 (쓰기/읽기, softDelete, 팩토리 체인, DI 검증)
- [x] 기존 mock 테스트 31 스위트 전부 통과
- [x] TypeScript 타입 체크 통과
- [x] ESLint 통과
- [x] CI 통과 확인 (check + coverage-report + codecov/patch 모두 pass)