### PR TITLE
chore: 브랜치 보호 규칙을 Terraform으로 코드화

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,15 @@
+# Terraform local state — 절대 커밋 금지
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+
+# 프로바이더 바이너리 / 작업 디렉토리
+.terraform/
+# 주의: .terraform.lock.hcl 은 provider 버전 고정용이므로 커밋한다 (yarn.lock과 동일한 역할)
+
+# 변수 파일 (민감값이 들어갈 수 있음)
+*.tfvars
+!*.tfvars.example
+
+# 플랜 산출물
+*.tfplan

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.11.1"
+  constraints = "~> 6.4"
+  hashes = [
+    "h1:nanzeesukYMHAFrSaq7rnWx7iRDHMpme5KzQI3m/ZZo=",
+    "zh:0a5262b033a30d8a77ebf844dc3afd7e726d5f53ac1c9d4072cf9157820d1f73",
+    "zh:437236181326f92d1a7c56985b2ac3223efd73f75c528323b90f4b7d1b781090",
+    "zh:49a12c14d1d3a143a124ba81f15fbf18714af90752c993698c76e84fa85da004",
+    "zh:61eaf17b559a26ca14deb597375a6678d054d739e8b81c586ef1d0391c307916",
+    "zh:7f3f1e2c36f4787ca9a5aeb5317b8c3f6cc652368d1f8f00fb80f404109d4db1",
+    "zh:85a232f2e96e5adafa2676f38a96b8cc074e96f715caf6ee1d169431174897d2",
+    "zh:979d005af2a9003d887413195948c899e9f5aba4a79cce1eed40f3ba50301af1",
+    "zh:b8c8cd3254504d2184d2b2233ad41b5fdfda91a36fc864926cbc5c7eee1bfea3",
+    "zh:d00959e62930fb75d2b97c1d66ab0143120541d5a1b3f26d3551f24cb0361f83",
+    "zh:d0b544eed171c7563387fe87f0af3d238bb3804798159b4d0453c97927237daf",
+    "zh:ecfa19b1219aa55b1ece98d8cff5b1494dc0387329c8ae0d8f762ec3871fb75d",
+    "zh:f2c99825f38c92ac599ad36b9d093ea0c0d790fd0c02e861789e14735a605f86",
+    "zh:f33b5abe14ad5fb9978da5dbd3bc6989f69766150d4b30ed283a2c281871eda3",
+    "zh:f6c2fe9dd958c554170dc0c35ca41b60fcc6253304cde0b9941c5c872b18ac54",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -22,6 +22,28 @@ export GITHUB_TOKEN=$(gh auth token)
 
 필요 스코프: `repo` (classic) 또는 `Administration: Read and write` (fine-grained).
 
+## 최초 셋업 (fresh state)
+
+새 머신에서 처음 apply하거나 state 파일을 잃어버렸을 때, `github_repository`는 이미 존재하는 레포라 그냥 `terraform apply` 하면 "이미 존재함" 에러로 실패한다. **import 먼저 실행해야 한다.**
+
+```bash
+cd terraform
+terraform init
+
+# 레포 리소스 import (이미 존재하는 레포를 state에 연결)
+terraform import github_repository.caquick_be caquick-be
+
+# Ruleset들도 state 잃어버린 경우 import 필요 (ruleset_id는 GitHub UI 또는 gh api로 확인)
+# gh api repos/CaQuick/caquick-be/rulesets --jq '.[] | {id, name}'
+terraform import github_repository_ruleset.main_protection caquick-be:<ruleset_id>
+terraform import github_repository_ruleset.develop_protection caquick-be:<ruleset_id>
+
+# import 후 plan 돌려서 drift 없는지 확인
+terraform plan
+```
+
+> owner는 provider 인증(`GITHUB_TOKEN`)에서 자동 결정되므로 import 시 별도 지정 불필요.
+
 ## 일상 작업 흐름
 
 ```bash

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,59 @@
+# Terraform — GitHub 레포 설정 관리
+
+이 디렉토리는 `CaQuick/caquick-be` 레포의 GitHub 쪽 설정(레포 옵션, 브랜치 Rulesets 등)을 **Infrastructure as Code**로 관리한다.
+
+## 관리 범위
+
+- 레포 머지 옵션 (`delete_branch_on_merge`, `allow_auto_merge` 등)
+- `main` 브랜치 Ruleset (삭제/force push 차단, PR 필수, CI 통과 필수)
+- `develop` 브랜치 Ruleset (동일 수준)
+
+> **관리 밖**: 레포 이름/가시성/이슈 탭 등 이미 설정된 값은 `lifecycle.ignore_changes`로 제외 — UI에서 편하게 바꿔도 Terraform이 되돌리지 않는다.
+
+## 사전 준비
+
+```bash
+# 1. Terraform 설치
+brew install terraform
+
+# 2. GitHub 인증 (gh CLI 토큰 재사용 — classic PAT를 새로 만들 필요 없음)
+export GITHUB_TOKEN=$(gh auth token)
+```
+
+필요 스코프: `repo` (classic) 또는 `Administration: Read and write` (fine-grained).
+
+## 일상 작업 흐름
+
+```bash
+cd terraform
+
+# 초기 1회
+terraform init
+
+# 변경 미리보기 (실제 적용 X)
+terraform plan
+
+# 적용
+terraform apply
+```
+
+## 변경 방법
+
+1. `.tf` 파일 수정
+2. `terraform plan`으로 diff 확인
+3. PR 올려서 리뷰 (설정 변경도 코드 리뷰 대상)
+4. 머지 후 `terraform apply` 실행
+
+## State 관리
+
+로컬 state (`terraform.tfstate`) 방식을 쓴다. 협업자가 늘거나 CI에서 apply가 필요해지면 remote backend(S3/Terraform Cloud) 도입을 검토한다.
+
+⚠️ **state 파일은 절대 커밋 금지** (`.gitignore` 처리됨). 파일이 소실되면 `terraform import`로 재구축 가능.
+
+## 긴급 우회
+
+Ruleset이 본인 작업을 막는 긴급 상황이면:
+
+1. GitHub UI에서 임시로 Ruleset 비활성화 (`Enforcement status: Disabled`)
+2. 작업 후 재활성화
+3. 변경이 코드와 어긋나면 `terraform plan`에서 drift로 잡힘 → 코드 동기화

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,14 +22,21 @@ resource "github_repository" "caquick_be" {
   allow_auto_merge       = true
   delete_branch_on_merge = true
 
+  # Dependabot vulnerability alerts 명시적 활성화 (drift 탐지 가능하도록).
+  # provider v6.12.0 부터 deprecated 예정 → 상위 버전 마이그레이션 시
+  # github_repository_vulnerability_alerts 전용 리소스로 이관 필요.
+  vulnerability_alerts = true
+
   # 기타 플래그는 현재 상태 유지 (drift 방지 목적의 명시)
   has_issues      = data.github_repository.this.has_issues
   has_projects    = data.github_repository.this.has_projects
   has_wiki        = data.github_repository.this.has_wiki
   has_discussions = data.github_repository.this.has_discussions
 
-  # 아래 필드는 Terraform이 기본값으로 되돌리려 하지 않도록 ignore
+  # 실수로 인한 레포 전체 삭제 방지. 의도적 삭제가 필요하면 일시적으로 false로 내리고 destroy.
   lifecycle {
+    prevent_destroy = true
+
     ignore_changes = [
       description,
       visibility,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,137 @@
+############################################
+# 레포 기본 설정
+############################################
+# 레포 자체는 이미 생성되어 있으므로 data로 참조만 한다 (파괴 방지).
+data "github_repository" "this" {
+  name = var.repository_name
+}
+
+# 머지 동작 관련 옵션만 Terraform으로 관리한다.
+# - delete_branch_on_merge: 머지된 PR의 head 브랜치 자동 삭제 (정리 자동화)
+# - allow_auto_merge      : CI 통과 후 자동 머지 허용
+# - 머지 방식은 현재 관행 유지 (merge commit / squash / rebase 모두 허용)
+resource "github_repository" "caquick_be" {
+  name        = data.github_repository.this.name
+  description = data.github_repository.this.description
+  visibility  = data.github_repository.this.visibility
+
+  # 머지 흐름
+  allow_merge_commit     = true
+  allow_squash_merge     = true
+  allow_rebase_merge     = true
+  allow_auto_merge       = true
+  delete_branch_on_merge = true
+
+  # 기타 플래그는 현재 상태 유지 (drift 방지 목적의 명시)
+  has_issues      = data.github_repository.this.has_issues
+  has_projects    = data.github_repository.this.has_projects
+  has_wiki        = data.github_repository.this.has_wiki
+  has_discussions = data.github_repository.this.has_discussions
+
+  # 아래 필드는 Terraform이 기본값으로 되돌리려 하지 않도록 ignore
+  lifecycle {
+    ignore_changes = [
+      description,
+      visibility,
+      has_issues,
+      has_projects,
+      has_wiki,
+      has_discussions,
+      topics,
+      homepage_url,
+    ]
+  }
+}
+
+############################################
+# Branch Ruleset: main (운영 브랜치, 가장 강한 보호)
+############################################
+resource "github_repository_ruleset" "main_protection" {
+  name        = "main-protection"
+  repository  = data.github_repository.this.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+
+  rules {
+    # 삭제 금지
+    deletion = true
+
+    # force push 금지
+    non_fast_forward = true
+
+    # PR 경유 필수 (직접 push 차단)
+    pull_request {
+      required_approving_review_count   = 0
+      dismiss_stale_reviews_on_push     = false
+      require_code_owner_review         = false
+      require_last_push_approval        = false
+      required_review_thread_resolution = false
+    }
+
+    # CI 상태 체크 필수
+    required_status_checks {
+      strict_required_status_checks_policy = false # branch up-to-date 강제 여부 (꺼두면 merge 편의성 ↑)
+
+      required_check {
+        context = "check"
+      }
+      required_check {
+        context = "pr-title"
+      }
+      required_check {
+        context = "coverage-report"
+      }
+    }
+  }
+}
+
+############################################
+# Branch Ruleset: develop (통합 브랜치, main보다 살짝 느슨)
+############################################
+resource "github_repository_ruleset" "develop_protection" {
+  name        = "develop-protection"
+  repository  = data.github_repository.this.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["refs/heads/develop"]
+      exclude = []
+    }
+  }
+
+  rules {
+    deletion         = true
+    non_fast_forward = true
+
+    pull_request {
+      required_approving_review_count   = 0
+      dismiss_stale_reviews_on_push     = false
+      require_code_owner_review         = false
+      require_last_push_approval        = false
+      required_review_thread_resolution = false
+    }
+
+    required_status_checks {
+      strict_required_status_checks_policy = false
+
+      required_check {
+        context = "check"
+      }
+      required_check {
+        context = "pr-title"
+      }
+      required_check {
+        context = "coverage-report"
+      }
+    }
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,6 @@
+# GitHub provider.
+# 인증은 GITHUB_TOKEN 환경변수로 주입한다 (classic PAT: repo 스코프 / fine-grained: Administration:write).
+# 로컬 세션에서는 `export GITHUB_TOKEN=$(gh auth token)` 으로 gh CLI 토큰을 그대로 재사용할 수 있다.
+provider "github" {
+  owner = var.github_owner
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "github_owner" {
+  description = "GitHub organization (or user) name that owns the repository."
+  type        = string
+  default     = "CaQuick"
+}
+
+variable "repository_name" {
+  description = "Target repository name."
+  type        = string
+  default     = "caquick-be"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.4"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `main` / `develop` Branch Ruleset 신규 도입: 삭제/force push 차단, PR 필수, CI 통과 필수
- 레포 설정: `delete_branch_on_merge`, `allow_auto_merge` 활성화 (머지된 브랜치 누적 방지)
- 앞으로 설정 변경도 **PR 리뷰 + diff 확인 + drift 탐지** 대상

## Terraform 도입 배경
- Audit log는 사후 기록일 뿐, "현재 기대값"을 표현 못함
- 설정 변경을 코드 리뷰 대상으로 만들고, drift 탐지/롤백 가능하게 하기 위함
- 1인 운영 기준이라 **로컬 state + gh CLI 토큰 재사용** 방식으로 최소 셋업

## 구성
- `terraform/versions.tf` — provider 버전 고정 (`integrations/github ~> 6.4`)
- `terraform/providers.tf` — GITHUB_TOKEN 기반 인증
- `terraform/main.tf` — 레포 설정 + main/develop Rulesets
- `terraform/variables.tf` — owner/repo 변수
- `terraform/.gitignore` — state/vars 커밋 방지
- `terraform/README.md` — 사용법/apply 절차

## 적용 상태
`terraform apply` 로 GitHub에 반영 완료
- main-protection Ruleset 생성
- develop-protection Ruleset 생성
- 레포 머지 옵션 업데이트

## 주의
- 이 PR 머지 시점부터 main/develop 직접 push 차단됨 (의도된 동작)
- 긴급 우회: GitHub UI에서 Ruleset 일시 비활성화 → 작업 → 재활성화 (drift 발생 시 plan에서 감지)

## Test plan
- [x] `terraform plan` 결과 검토 (2 add, 1 change, 0 destroy)
- [x] `terraform apply` 정상 완료
- [ ] CI 체크 통과 확인
- [ ] 머지 후 re-plan 돌려서 drift 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Terraform 인프라 설정 파일 추가 (초기화, 프로바이더, 변수, 버전 및 상태 관리)
  * 리포지토리 병합 옵션 및 main/develop 브랜치 규칙 관리를 위한 Terraform 구성 추가

* **Documentation**
  * Terraform을 통한 리포지토리 설정 관리 방법, 설치 요구사항, 워크플로우 가이드 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->