### PR TITLE
chore: codecov 코멘트를 in-place 업데이트로 변경

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,7 +13,7 @@ coverage:
 
 comment:
   layout: "reach, diff, flags, files"
-  behavior: new
+  behavior: default
   require_changes: true
 
 ignore:


### PR DESCRIPTION
## Summary
Codecov PR 코멘트가 push마다 **삭제 후 재생성**되어 알림 노이즈가 컸는데, 다른 봇(CodeRabbit, jest-coverage-report)처럼 **같은 코멘트를 조용히 수정**하도록 전환.

## 영향
- PR 리뷰 중 알림/타임라인 노이즈 감소
- 코멘트 위치가 고정되어 스크롤 친화적
- 리포트 내용 자체는 동일

## Test plan
- [ ] 이 PR에 두 번째 커밋 push 시 Codecov 코멘트가 in-place 수정되는지 확인