### PR TITLE
chore: Dependabot + CodeQL 활성화 + Actions SHA pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+# Dependabot 자동 업데이트 설정.
+# - npm: 애플리케이션 런타임/개발 의존성
+# - github-actions: 워크플로에서 사용하는 액션 버전 (SHA pin 포함)
+# 보안 패치는 별도 PR로 우선 생성되며, 일반 업데이트는 묶어서 노이즈를 줄인다.
+version: 2
+updates:
+  # --- npm ---
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      # minor/patch는 묶어서 한 PR로
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      # 보안 패치는 메이저 포함해 별도로 묶음 (빠르게 머지하기 위함)
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    ignore:
+      # Prisma 계열은 schema 마이그레이션 호환성 확인 필요 → 수동 업데이트
+      - dependency-name: "@prisma/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "prisma"
+        update-types: ["version-update:semver-major"]
+      # NestJS 메이저 업그레이드는 broad impact라 수동 검토
+      - dependency-name: "@nestjs/*"
+        update-types: ["version-update:semver-major"]
+
+  # --- GitHub Actions ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+      include: "scope"
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # 매주 월요일 03:00 UTC (= 12:00 KST) 정기 스캔. 의존성 업데이트 없이도 새로운 룰 반영.
+    - cron: "0 3 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended: 기본(security) + 추가 보안 룰
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js (24.x) & Yarn cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24.x"
           cache: "yarn"
@@ -80,7 +80,7 @@ jobs:
           (cd bundle && zip -r "../$ARTIFACT" .)
 
       - name: Configure AWS credentials (Access Key)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           sparse-checkout: .github/scripts
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js (24.x) & Yarn cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24.x"
           cache: "yarn"
@@ -48,7 +48,7 @@ jobs:
         run: yarn test:cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN || '' }}
           files: ./coverage/lcov.info
@@ -70,10 +70,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js (24.x) & Yarn cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24.x"
           cache: "yarn"
@@ -84,7 +84,7 @@ jobs:
           yarn install --immutable
 
       - name: Coverage Report (jest-coverage-report)
-        uses: ArtiomTr/jest-coverage-report-action@v2
+        uses: ArtiomTr/jest-coverage-report-action@7f750dd50f5585533321eb7ebc482b936b49a5d4 # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-script: yarn jest --coverage --ci
@@ -98,7 +98,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         with:
           subjectPattern: ^.+$
           subjectPatternError: |


### PR DESCRIPTION
## Summary
- **Dependabot**: npm + GitHub Actions 자동 의존성 업데이트
- **CodeQL**: JS/TS 정적 보안 분석 (security-extended)
- **Actions SHA pinning**: 기존 워크플로 3종의 액션을 태그 → 커밋 SHA로 전환

## 1) Dependabot (`.github/dependabot.yml`)
- **npm**: 주 1회(월 09:00 KST), minor/patch는 그룹화, 보안 패치 별도 PR
- **github-actions**: 주 1회, 그룹화
- **수동 검토 대상** (자동 PR 제외): `@prisma/*`, `prisma`, `@nestjs/*` 메이저 버전
- 레이블: `dependencies`, `npm` / `github-actions`
- 커밋 메시지: `chore(deps): ...` / `ci(deps): ...`

## 2) CodeQL (`.github/workflows/codeql.yml`)
- 언어: `javascript-typescript`
- 쿼리 셋: `security-extended` (기본 보안 + 추가 보안 룰)
- 트리거: `main`/`develop` push·PR + 매주 월 12:00 KST 스케줄
- 결과: Security 탭에 통합

> 첫 실행 검증 후, 안정적으로 돌면 Terraform Ruleset의 `required_status_checks`에 CodeQL을 추가할 예정.

## 3) Actions SHA pin
태그는 mutable이라 이론적으로 공급망 공격 가능. 커밋 SHA로 고정해 방어. Dependabot이 이후 자동 갱신.

| 액션 | SHA | 버전 |
|---|---|---|
| actions/checkout | `34e11487...` | v4.3.1 |
| actions/setup-node | `49933ea5...` | v4.4.0 |
| codecov/codecov-action | `75cd1169...` | v5.5.4 |
| ArtiomTr/jest-coverage-report-action | `7f750dd5...` | v2 |
| amannn/action-semantic-pull-request | `e32d7e60...` | v5 |
| aws-actions/configure-aws-credentials | `7474bc46...` | v4.3.1 |
| github/codeql-action/* | `ce64ddcb...` | v3.35.2 |

## Test plan
- [ ] CI (`check`, `pr-title`, `coverage-report`) 전부 green
- [ ] CodeQL 첫 실행 정상 종료 (Security 탭에 결과 반영)
- [ ] Dependabot이 첫 주 월요일에 PR 생성 확인 (관찰만)