### PR TITLE
chore: CodeQL을 ruleset의 required check로 추가

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -95,6 +95,10 @@ resource "github_repository_ruleset" "main_protection" {
       required_check {
         context = "coverage-report"
       }
+      # CodeQL 정적 보안 분석. 매트릭스 strategy의 job 이름이 그대로 check context가 된다.
+      required_check {
+        context = "Analyze (javascript-typescript)"
+      }
     }
   }
 }
@@ -138,6 +142,9 @@ resource "github_repository_ruleset" "develop_protection" {
       }
       required_check {
         context = "coverage-report"
+      }
+      required_check {
+        context = "Analyze (javascript-typescript)"
       }
     }
   }


### PR DESCRIPTION
## Summary
PR #36에서 CodeQL 첫 실행 정상 종료를 확인했으므로, main/develop ruleset의 required status checks에 CodeQL을 추가.

## 변경
`terraform/main.tf` — main/develop ruleset 양쪽에 다음 추가:
```hcl
required_check {
  context = "Analyze (javascript-typescript)"
}
```

## 적용 결과
✅ **이미 적용됨** (`terraform apply`):
- main-protection: 0 add, 1 change
- develop-protection: 0 add, 1 change

## 효과
이제 CodeQL 정적 분석에서 보안 이슈 탐지 시 main/develop 머지 차단.

## Test plan
- [x] terraform plan/apply 정상
- [ ] 이 PR 자체에서 CodeQL 체크 통과 (필수 체크 신규 적용 확인)
- [ ] CI 그린

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 저장소 보호 규칙이 업데이트되어 자바스크립트/타입스크립트 코드 분석 검사가 필수 항목으로 추가되었습니다. 기존 품질 검사 항목은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->