### PR TITLE
fix: Dependabot 커밋 prefix 중복 표기 정리

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,9 @@ updates:
       - "dependencies"
       - "npm"
     commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(deps-dev)"
+      # include: scope 가 (deps) / (deps-dev) 를 자동으로 붙여준다.
+      # prefix에 (deps)를 또 적으면 "chore(deps)(deps): ..." 처럼 중복된다.
+      prefix: "chore"
       include: "scope"
     groups:
       # minor/patch는 묶어서 한 PR로
@@ -55,7 +56,7 @@ updates:
       - "dependencies"
       - "github-actions"
     commit-message:
-      prefix: "ci(deps)"
+      prefix: "ci"
       include: "scope"
     groups:
       actions-minor-patch:


### PR DESCRIPTION
## Summary
Dependabot 자동 PR의 커밋 메시지가 \`ci(deps)(deps): bump ...\`, \`chore(deps)(deps): bump ...\` 처럼 스코프가 중복 표기되던 문제 수정.

## 원인
\`prefix\`에 \`(deps)\`를 명시하면서 \`include: scope\`도 함께 사용 → 같은 스코프가 두 번 부착됨.

## 변경
\`prefix\`를 단순 \`ci\` / \`chore\`로 두고, 스코프 부착은 \`include: scope\`에 위임.

| 구분 | 전 | 후 |
|---|---|---|
| npm prod | \`chore(deps)(deps): ...\` | \`chore(deps): ...\` |
| npm dev | \`chore(deps-dev)(deps): ...\` | \`chore(deps-dev): ...\` |
| github-actions | \`ci(deps)(deps): ...\` | \`ci(deps): ...\` |

## Test plan
- [ ] CI green
- [ ] 다음 Dependabot 트리거 시 커밋 prefix 정상 확인