### PR TITLE
chore: Dependabot 메이저 ignore 규칙 확대 (jest / eslint 생태계)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,27 @@ updates:
       # NestJS 메이저 업그레이드는 broad impact라 수동 검토
       - dependency-name: "@nestjs/*"
         update-types: ["version-update:semver-major"]
+      # Jest 계열: 실DB 테스트 인프라 안정화 이후 일괄 업그레이드
+      - dependency-name: "jest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/jest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ts-jest"
+        update-types: ["version-update:semver-major"]
+      # ESLint 생태계: eslint / typescript-eslint / eslint-plugin-* 는 같이 움직여야 함
+      # (eslint-plugin-import와 typescript-eslint가 eslint 신메이저를 늦게 지원)
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript-eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@typescript-eslint/*"
+        update-types: ["version-update:semver-major"]
 
   # --- GitHub Actions ---
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
매주 반복되던 메이저 알림 노이즈 차단. PR #43, #44, #45에서 확인된 것처럼 아래 항목들은 혼자 올라가면 CI 깨지거나 맥락상 함께 올라가야 하므로 자동 PR에서 제외.

## 추가된 ignore 규칙 (메이저만)
- **Jest 계열**: `jest`, `@types/jest`, `ts-jest`
  - 실DB 테스트 인프라 안정화 이후 일괄 업그레이드
- **ESLint 생태계**: `eslint`, `@eslint/*`, `eslint-plugin-*`, `eslint-config-*`, `typescript-eslint`, `@typescript-eslint/*`
  - \`eslint-plugin-import\` / \`typescript-eslint\`가 eslint 신메이저를 늦게 지원 → 함께 묶어야 함

## 기존 유지
- Prisma 계열, NestJS 계열 (이미 등록된 규칙)

## 영향 없음
- minor/patch 업데이트는 그대로 자동 PR 생성
- 보안 패치는 별도 그룹이라 영향 없음

## Test plan
- [ ] CI 통과
- [ ] 다음 Dependabot 트리거 시 eslint/jest 메이저 PR이 안 올라오는지 관찰