### PR TITLE
chore: Dependabot ignore 확대 (typescript, openid-client) + 라벨 정리

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,7 @@ updates:
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
     labels:
-      - "dependencies"
-      - "npm"
+      - "📦 Dependencies"
     commit-message:
       # include: scope 가 (deps) / (deps-dev) 를 자동으로 붙여준다.
       # prefix에 (deps)를 또 적으면 "chore(deps)(deps): ..." 처럼 중복된다.
@@ -63,6 +62,13 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@typescript-eslint/*"
         update-types: ["version-update:semver-major"]
+      # TypeScript 메이저: rootDir/strict 검증 강화 등 tsconfig & 코드 변경 필요
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # openid-client v6: v5 대비 API 전면 재설계 (Issuer/Client/TokenSet 제거)
+      # → oidc-client.service.ts 재작성 동반되는 별도 마이그레이션 PR로 처리
+      - dependency-name: "openid-client"
+        update-types: ["version-update:semver-major"]
 
   # --- GitHub Actions ---
   - package-ecosystem: "github-actions"
@@ -74,8 +80,7 @@ updates:
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
     labels:
-      - "dependencies"
-      - "github-actions"
+      - "📦 Dependencies"
     commit-message:
       prefix: "ci"
       include: "scope"


### PR DESCRIPTION
## Summary
- \`typescript\`, \`openid-client\` 메이저를 Dependabot ignore에 추가
- Dependabot PR 자동 라벨을 실제 존재하는 \`📦 Dependencies\`로 통일

## 추가된 ignore 사유
| 패키지 | 이유 |
|---|---|
| \`typescript\` | TS 6에서 \`rootDir\` strict 검증 강화 → tsconfig + 코드 변경 필요 (PR #54 확인) |
| \`openid-client\` | v6은 \`Issuer\` / \`Client\` / \`TokenSet\` 제거된 재설계 → auth 서비스 재작성 필요 (PR #55 확인) |

## 라벨 정리
기존 dependabot.yml이 지정하던 라벨 3종(\`dependencies\`, \`npm\`, \`github-actions\`)이 레포에 미생성 상태였음 → Dependabot PR들에 라벨이 아예 안 붙었음. 새로 생성한 \`📦 Dependencies\` 하나로 통일.

## Test plan
- [ ] CI 통과
- [ ] 차주 Dependabot 트리거 시 typescript/openid-client 메이저 PR 생성 안 됨
- [ ] 차주 Dependabot PR에 \`📦 Dependencies\` 라벨 자동 부착