### PR TITLE
chore: Codecov PR 댓글 상세 리포트 복원

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -50,9 +50,14 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN || '' }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
-          fail_ci_if_error: false
+          # disable_search: 지정한 파일만 업로드 (자동 탐색 결과와 섞이지 않도록)
+          disable_search: true
+          name: backend-lcov
+          # 업로드 실패 시 조용히 넘어가지 않고 CI 실패로 가시화 (진단/운영 모두 권장).
+          fail_ci_if_error: true
+          verbose: true
 
       - name: Build
         run: |

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,14 +7,24 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        base: auto
     patch:
       default:
         target: 80%
+        threshold: 0%
 
 comment:
-  layout: "reach, diff, flags, files"
+  # 상세 리포트 복원 설정 (2026-04 리서치 기반):
+  # - hide_project_coverage: false → 댓글 상단에 프로젝트 요약 포함
+  # - require_changes: false → 커버리지 변화 없는 PR에서도 댓글 갱신 유지
+  # - require_base/head: true → 유의미한 비교가 가능할 때만 댓글 (운영 모드)
+  # - layout: reach(deprecated)/flags(미사용) 제거. header/diff/files/footer 표준
+  layout: "header, diff, files, footer"
   behavior: default
-  require_changes: true
+  require_changes: false
+  require_base: true
+  require_head: true
+  hide_project_coverage: false
 
 ignore:
   - "src/test/**"


### PR DESCRIPTION
## Summary
ChatGPT 딥 리서치 ([docs/codecov-gpt-deep-research.md](docs/codecov-gpt-deep-research.md)) 기반으로 Codecov PR 댓글의 프로젝트 요약/Coverage Diff/파일별 Δ를 복원하기 위한 확정 설정 적용.

## 보장 범위
- ✅ 프로젝트 요약 / Coverage Diff / 파일별 Coverage Δ 렌더
- ❌ 구형 \`reach\` 그래프/트리맵 (Codecov 공식적으로 deprecated)

## 별도 후속 조치
**Dependabot Secret에 \`CODECOV_TOKEN\` 등록 필요**:
- Settings → Secrets and variables → **Dependabot** → New repository secret
- Name: \`CODECOV_TOKEN\`, Value: 기존 Actions용 Secret과 동일
- 이걸 해야 Dependabot PR에서도 Codecov 체크가 정상 표시됨

## Test plan
- [ ] 이 PR 자체에서 Codecov 체크 통과 (fail_ci_if_error: true 하에서 업로드 성공 확인)
- [ ] 머지 후 \`src/**\` 실제 소스 파일을 수정하는 별도 테스트 PR로 \`codecov/project\` 체크 + 댓글의 project summary / Coverage Diff / Files Δ 모두 표시되는지 확인