### PR TITLE
test: user feature 실DB 전환 (1/2) — profile / onboarding / recent-view

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,10 +126,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 70,
-        "branches": 58,
-        "functions": 58,
-        "lines": 70
+        "statements": 80,
+        "branches": 73,
+        "functions": 73,
+        "lines": 80
       }
     },
     "coverageDirectory": "../coverage",

--- a/src/features/user/resolvers/user-profile.resolver.spec.ts
+++ b/src/features/user/resolvers/user-profile.resolver.spec.ts
@@ -1,0 +1,166 @@
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+import type { PrismaClient } from '@prisma/client';
+
+import { UserRepository } from '@/features/user/repositories/user.repository';
+import { UserProfileMutationResolver } from '@/features/user/resolvers/user-profile-mutation.resolver';
+import { UserProfileQueryResolver } from '@/features/user/resolvers/user-profile-query.resolver';
+import { UserProfileService } from '@/features/user/services/user-profile.service';
+import { S3Service } from '@/global/storage/s3.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createAccount, createUserProfile } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 전체 경로를 검증하는 통합 테스트.
+ * 단위 단계의 상세 분기/예외는 *.service.spec.ts에서 담당하고, 이 파일에서는
+ * resolver 어댑터 레이어가 정상적으로 의존성을 배선하는지만 1-2 케이스로 확인한다.
+ */
+describe('User Profile Resolvers (real DB)', () => {
+  let queryResolver: UserProfileQueryResolver;
+  let mutationResolver: UserProfileMutationResolver;
+  let prisma: PrismaClient;
+  let s3Service: jest.Mocked<S3Service>;
+
+  beforeAll(async () => {
+    s3Service = {
+      createUploadUrl: jest.fn(),
+    } as unknown as jest.Mocked<S3Service>;
+
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        UserProfileQueryResolver,
+        UserProfileMutationResolver,
+        UserProfileService,
+        UserRepository,
+        { provide: S3Service, useValue: s3Service },
+      ],
+    });
+
+    queryResolver = module.get(UserProfileQueryResolver);
+    mutationResolver = module.get(UserProfileMutationResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    jest.clearAllMocks();
+  });
+
+  describe('Query.me', () => {
+    it('accountId(string) → BigInt 변환 후 서비스/DB까지 이어져 프로필을 반환한다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        email: 'user@example.com',
+        name: '길동',
+      });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        nickname: 'gildong',
+      });
+
+      const result = await queryResolver.me({
+        accountId: account.id.toString(),
+      });
+
+      expect(result.accountId).toBe(account.id.toString());
+      expect(result.profile.nickname).toBe('gildong');
+    });
+
+    it('존재하지 않는 accountId면 서비스 에러를 그대로 전파한다', async () => {
+      await expect(queryResolver.me({ accountId: '999999' })).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('Mutation.updateMyProfile', () => {
+    it('프로필 업데이트 요청이 DB에 반영된다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const result = await mutationResolver.updateMyProfile(
+        { accountId: account.id.toString() },
+        { nickname: 'newNick' },
+      );
+
+      expect(result.profile.nickname).toBe('newNick');
+
+      const saved = await prisma.userProfile.findUniqueOrThrow({
+        where: { account_id: account.id },
+      });
+      expect(saved.nickname).toBe('newNick');
+    });
+
+    it('닉네임 중복은 ConflictException으로 전파된다', async () => {
+      const other = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, {
+        account_id: other.id,
+        nickname: 'taken',
+      });
+
+      const me = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: me.id });
+
+      await expect(
+        mutationResolver.updateMyProfile(
+          { accountId: me.id.toString() },
+          { nickname: 'taken' },
+        ),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('Mutation.deleteMyAccount', () => {
+    it('resolver → service 경로로 soft-delete가 수행된다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        email: 'del@example.com',
+      });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const ok = await mutationResolver.deleteMyAccount({
+        accountId: account.id.toString(),
+      });
+
+      expect(ok).toBe(true);
+      const deleted = await prisma.account.findUniqueOrThrow({
+        where: { id: account.id },
+      });
+      expect(deleted.deleted_at).not.toBeNull();
+    });
+  });
+
+  describe('Mutation.createProfileImageUploadUrl', () => {
+    it('S3 mock 결과를 그대로 반환한다 (요청 시점에 계정 활성 검증 수행)', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const expected = {
+        uploadUrl: 'https://presigned.example.com',
+        publicUrl: 'https://s3.example.com/x.jpg',
+        key: 'profile-images/x/uuid.jpg',
+        expiresInSeconds: 600,
+      };
+      s3Service.createUploadUrl.mockResolvedValue(expected);
+
+      const result = await mutationResolver.createProfileImageUploadUrl(
+        { accountId: account.id.toString() },
+        { contentType: 'image/jpeg', contentLength: 1024 },
+      );
+
+      expect(result).toEqual(expected);
+      expect(s3Service.createUploadUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: account.id,
+          purpose: 'PROFILE_IMAGE',
+        }),
+      );
+    });
+  });
+});

--- a/src/features/user/resolvers/user-recent-view.resolver.spec.ts
+++ b/src/features/user/resolvers/user-recent-view.resolver.spec.ts
@@ -1,0 +1,131 @@
+import { NotFoundException } from '@nestjs/common';
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
+import { UserRecentViewMutationResolver } from '@/features/user/resolvers/user-recent-view-mutation.resolver';
+import { UserRecentViewQueryResolver } from '@/features/user/resolvers/user-recent-view-query.resolver';
+import { UserRecentViewService } from '@/features/user/services/user-recent-view.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createProduct,
+  createRecentProductView,
+  createStore,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * Resolver ↔ Service ↔ Repositories ↔ DB 통합 경로 검증.
+ * 분기별 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('User Recent View Resolvers (real DB)', () => {
+  let queryResolver: UserRecentViewQueryResolver;
+  let mutationResolver: UserRecentViewMutationResolver;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        UserRecentViewQueryResolver,
+        UserRecentViewMutationResolver,
+        UserRecentViewService,
+        RecentProductViewRepository,
+        ProductRepository,
+      ],
+    });
+
+    queryResolver = module.get(UserRecentViewQueryResolver);
+    mutationResolver = module.get(UserRecentViewMutationResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  describe('Query.myRecentViewedProducts', () => {
+    it('accountId 변환 + DB 조회 결과를 커넥션 형태로 반환한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const store = await createStore(prisma, { store_name: '베이커리' });
+      const product = await createProduct(prisma, {
+        store_id: store.id,
+        name: '밤 케이크',
+      });
+      await createRecentProductView(prisma, {
+        account_id: account.id,
+        product_id: product.id,
+      });
+
+      const result = await queryResolver.myRecentViewedProducts(
+        { accountId: account.id.toString() },
+        { offset: 0, limit: 20 },
+      );
+
+      expect(result.totalCount).toBe(1);
+      expect(result.items[0]).toMatchObject({
+        productId: product.id.toString(),
+        productName: '밤 케이크',
+        storeName: '베이커리',
+      });
+    });
+  });
+
+  describe('Mutation.recordProductView', () => {
+    it('유효한 productId면 view를 DB에 생성한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const product = await createProduct(prisma, { is_active: true });
+
+      const ok = await mutationResolver.recordProductView(
+        { accountId: account.id.toString() },
+        product.id.toString(),
+      );
+
+      expect(ok).toBe(true);
+      const row = await prisma.recentProductView.findUniqueOrThrow({
+        where: {
+          account_id_product_id: {
+            account_id: account.id,
+            product_id: product.id,
+          },
+        },
+      });
+      expect(row.deleted_at).toBeNull();
+    });
+
+    it('상품이 없으면 NotFoundException이 전파된다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await expect(
+        mutationResolver.recordProductView(
+          { accountId: account.id.toString() },
+          '999999',
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('Mutation.clearRecentViewedProducts', () => {
+    it('계정의 모든 view를 soft-delete한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      for (let i = 0; i < 2; i++) {
+        await createRecentProductView(prisma, { account_id: account.id });
+      }
+
+      const ok = await mutationResolver.clearRecentViewedProducts({
+        accountId: account.id.toString(),
+      });
+
+      expect(ok).toBe(true);
+      const remaining = await prisma.recentProductView.count({
+        where: { account_id: account.id, deleted_at: null },
+      });
+      expect(remaining).toBe(0);
+    });
+  });
+});

--- a/src/features/user/resolvers/user.resolver.spec.ts
+++ b/src/features/user/resolvers/user.resolver.spec.ts
@@ -5,10 +5,6 @@ import { UserMypageQueryResolver } from '@/features/user/resolvers/user-mypage-q
 import { UserNotificationMutationResolver } from '@/features/user/resolvers/user-notification-mutation.resolver';
 import { UserNotificationQueryResolver } from '@/features/user/resolvers/user-notification-query.resolver';
 import { UserOrderQueryResolver } from '@/features/user/resolvers/user-order-query.resolver';
-import { UserProfileMutationResolver } from '@/features/user/resolvers/user-profile-mutation.resolver';
-import { UserProfileQueryResolver } from '@/features/user/resolvers/user-profile-query.resolver';
-import { UserRecentViewMutationResolver } from '@/features/user/resolvers/user-recent-view-mutation.resolver';
-import { UserRecentViewQueryResolver } from '@/features/user/resolvers/user-recent-view-query.resolver';
 import { UserReviewMutationResolver } from '@/features/user/resolvers/user-review-mutation.resolver';
 import { UserReviewQueryResolver } from '@/features/user/resolvers/user-review-query.resolver';
 import { UserSearchMutationResolver } from '@/features/user/resolvers/user-search-mutation.resolver';
@@ -17,17 +13,9 @@ import { UserEngagementService } from '@/features/user/services/user-engagement.
 import { UserMypageService } from '@/features/user/services/user-mypage.service';
 import { UserNotificationService } from '@/features/user/services/user-notification.service';
 import { UserOrderService } from '@/features/user/services/user-order.service';
-import { UserProfileService } from '@/features/user/services/user-profile.service';
-import { UserRecentViewService } from '@/features/user/services/user-recent-view.service';
 import { UserReviewService } from '@/features/user/services/user-review.service';
 import { UserSearchService } from '@/features/user/services/user-search.service';
 import type {
-  CompleteOnboardingInput,
-  UpdateMyProfileImageInput,
-  UpdateMyProfileInput,
-} from '@/features/user/types/user-input.type';
-import type {
-  MePayload,
   NotificationConnection,
   SearchHistoryConnection,
   ViewerCounts,
@@ -36,20 +24,6 @@ import type {
 // ---------------------------------------------------------------------------
 // 공통 mock 데이터
 // ---------------------------------------------------------------------------
-
-const mockMePayload: MePayload = {
-  accountId: '1',
-  email: 'test@example.com',
-  name: 'Test User',
-  accountType: 'USER',
-  profile: {
-    nickname: 'tester',
-    birthDate: null,
-    phoneNumber: null,
-    profileImageUrl: null,
-    onboardingCompletedAt: null,
-  },
-};
 
 const mockViewerCounts: ViewerCounts = {
   unreadNotificationCount: 3,
@@ -84,150 +58,8 @@ const mockSearchHistoryConnection: SearchHistoryConnection = {
   hasMore: false,
 };
 
-// ---------------------------------------------------------------------------
-// UserProfileQueryResolver
-// ---------------------------------------------------------------------------
-
-describe('UserProfileQueryResolver', () => {
-  let resolver: UserProfileQueryResolver;
-  let profileService: jest.Mocked<UserProfileService>;
-
-  beforeEach(async () => {
-    profileService = {
-      me: jest.fn(),
-    } as unknown as jest.Mocked<UserProfileService>;
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        UserProfileQueryResolver,
-        { provide: UserProfileService, useValue: profileService },
-      ],
-    }).compile();
-
-    resolver = module.get<UserProfileQueryResolver>(UserProfileQueryResolver);
-  });
-
-  it('me는 accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-    profileService.me.mockResolvedValue(mockMePayload);
-
-    const user = { accountId: '1' };
-    const result = await resolver.me(user);
-
-    expect(profileService.me).toHaveBeenCalledWith(BigInt(1));
-    expect(result).toBe(mockMePayload);
-  });
-
-  it('me는 서비스 에러를 그대로 전파해야 한다', async () => {
-    const error = new Error('User not found');
-    profileService.me.mockRejectedValue(error);
-
-    const user = { accountId: '1' };
-    await expect(resolver.me(user)).rejects.toThrow(error);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// UserProfileMutationResolver
-// ---------------------------------------------------------------------------
-
-describe('UserProfileMutationResolver', () => {
-  let resolver: UserProfileMutationResolver;
-  let profileService: jest.Mocked<UserProfileService>;
-
-  beforeEach(async () => {
-    profileService = {
-      completeOnboarding: jest.fn(),
-      updateMyProfile: jest.fn(),
-      updateMyProfileImage: jest.fn(),
-      deleteMyAccount: jest.fn(),
-    } as unknown as jest.Mocked<UserProfileService>;
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        UserProfileMutationResolver,
-        { provide: UserProfileService, useValue: profileService },
-      ],
-    }).compile();
-
-    resolver = module.get<UserProfileMutationResolver>(
-      UserProfileMutationResolver,
-    );
-  });
-
-  it('completeOnboarding은 accountId를 BigInt로 변환하고 input을 서비스에 전달해야 한다', async () => {
-    profileService.completeOnboarding.mockResolvedValue(mockMePayload);
-
-    const user = { accountId: '1' };
-    const input: CompleteOnboardingInput = {
-      nickname: 'newbie',
-      name: 'New User',
-      birthDate: new Date('1990-01-01'),
-      phoneNumber: '010-1234-5678',
-    };
-
-    const result = await resolver.completeOnboarding(user, input);
-
-    expect(profileService.completeOnboarding).toHaveBeenCalledWith(
-      BigInt(1),
-      input,
-    );
-    expect(result).toBe(mockMePayload);
-  });
-
-  it('updateMyProfile은 accountId를 BigInt로 변환하고 input을 서비스에 전달해야 한다', async () => {
-    profileService.updateMyProfile.mockResolvedValue(mockMePayload);
-
-    const user = { accountId: '2' };
-    const input: UpdateMyProfileInput = { nickname: 'updated' };
-
-    const result = await resolver.updateMyProfile(user, input);
-
-    expect(profileService.updateMyProfile).toHaveBeenCalledWith(
-      BigInt(2),
-      input,
-    );
-    expect(result).toBe(mockMePayload);
-  });
-
-  it('updateMyProfileImage는 accountId를 BigInt로 변환하고 input을 서비스에 전달해야 한다', async () => {
-    profileService.updateMyProfileImage.mockResolvedValue(mockMePayload);
-
-    const user = { accountId: '3' };
-    const input: UpdateMyProfileImageInput = {
-      profileImageUrl: 'https://example.com/img.png',
-    };
-
-    const result = await resolver.updateMyProfileImage(user, input);
-
-    expect(profileService.updateMyProfileImage).toHaveBeenCalledWith(
-      BigInt(3),
-      input,
-    );
-    expect(result).toBe(mockMePayload);
-  });
-
-  it('deleteMyAccount는 accountId를 BigInt로 변환하여 서비스에 전달해야 한다', async () => {
-    profileService.deleteMyAccount.mockResolvedValue(true);
-
-    const user = { accountId: '4' };
-    const result = await resolver.deleteMyAccount(user);
-
-    expect(profileService.deleteMyAccount).toHaveBeenCalledWith(BigInt(4));
-    expect(result).toBe(true);
-  });
-
-  it('completeOnboarding은 서비스 에러를 그대로 전파해야 한다', async () => {
-    const error = new Error('Nickname already exists.');
-    profileService.completeOnboarding.mockRejectedValue(error);
-
-    const user = { accountId: '1' };
-    const input: CompleteOnboardingInput = { nickname: 'dup' };
-
-    await expect(resolver.completeOnboarding(user, input)).rejects.toThrow(
-      error,
-    );
-  });
-});
+// UserProfile Query/Mutation Resolvers 통합 테스트는
+// user-profile.resolver.spec.ts (실DB 기반)로 분리되었다.
 
 // ---------------------------------------------------------------------------
 // UserNotificationQueryResolver
@@ -634,96 +466,8 @@ describe('UserOrderQueryResolver', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// UserRecentViewQueryResolver / MutationResolver
-// ---------------------------------------------------------------------------
-
-describe('UserRecentViewQueryResolver', () => {
-  let resolver: UserRecentViewQueryResolver;
-  let recentViewService: jest.Mocked<UserRecentViewService>;
-
-  beforeEach(async () => {
-    recentViewService = {
-      list: jest.fn(),
-    } as unknown as jest.Mocked<UserRecentViewService>;
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        UserRecentViewQueryResolver,
-        { provide: UserRecentViewService, useValue: recentViewService },
-      ],
-    }).compile();
-
-    resolver = module.get<UserRecentViewQueryResolver>(
-      UserRecentViewQueryResolver,
-    );
-  });
-
-  it('myRecentViewedProducts는 서비스에 위임해야 한다', async () => {
-    const mockResult = { items: [], totalCount: 0, hasMore: false };
-    recentViewService.list.mockResolvedValue(mockResult);
-
-    const user = { accountId: '1' };
-    const result = await resolver.myRecentViewedProducts(user, {
-      offset: 0,
-      limit: 20,
-    });
-
-    expect(recentViewService.list).toHaveBeenCalledWith(BigInt(1), {
-      offset: 0,
-      limit: 20,
-    });
-    expect(result).toBe(mockResult);
-  });
-});
-
-describe('UserRecentViewMutationResolver', () => {
-  let resolver: UserRecentViewMutationResolver;
-  let recentViewService: jest.Mocked<UserRecentViewService>;
-
-  beforeEach(async () => {
-    recentViewService = {
-      record: jest.fn(),
-      deleteOne: jest.fn(),
-      clearAll: jest.fn(),
-    } as unknown as jest.Mocked<UserRecentViewService>;
-
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        UserRecentViewMutationResolver,
-        { provide: UserRecentViewService, useValue: recentViewService },
-      ],
-    }).compile();
-
-    resolver = module.get<UserRecentViewMutationResolver>(
-      UserRecentViewMutationResolver,
-    );
-  });
-
-  it('recordProductView는 서비스에 위임해야 한다', async () => {
-    recentViewService.record.mockResolvedValue(true);
-    const result = await resolver.recordProductView({ accountId: '1' }, '200');
-    expect(recentViewService.record).toHaveBeenCalledWith(BigInt(1), '200');
-    expect(result).toBe(true);
-  });
-
-  it('deleteRecentViewedProduct는 서비스에 위임해야 한다', async () => {
-    recentViewService.deleteOne.mockResolvedValue(true);
-    const result = await resolver.deleteRecentViewedProduct(
-      { accountId: '1' },
-      '200',
-    );
-    expect(recentViewService.deleteOne).toHaveBeenCalledWith(BigInt(1), '200');
-    expect(result).toBe(true);
-  });
-
-  it('clearRecentViewedProducts는 서비스에 위임해야 한다', async () => {
-    recentViewService.clearAll.mockResolvedValue(true);
-    const result = await resolver.clearRecentViewedProducts({ accountId: '1' });
-    expect(recentViewService.clearAll).toHaveBeenCalledWith(BigInt(1));
-    expect(result).toBe(true);
-  });
-});
+// UserRecentView Query/Mutation Resolvers 통합 테스트는
+// user-recent-view.resolver.spec.ts (실DB 기반)로 분리되었다.
 
 // ---------------------------------------------------------------------------
 // UserReviewQueryResolver / MutationResolver

--- a/src/features/user/services/user-base.service.spec.ts
+++ b/src/features/user/services/user-base.service.spec.ts
@@ -228,10 +228,15 @@ describe('UserBaseService (real DB)', () => {
       expect(result?.getFullYear()).toBe(1990);
     });
 
-    it('오늘 날짜는 미래로 취급하지 않는다', () => {
+    it('오늘 날짜는 미래로 취급하지 않고 그대로 반환한다', () => {
       const today = new Date();
       today.setHours(12, 0, 0, 0);
-      expect(service.testNormalizeBirthDate(today)).toBeInstanceOf(Date);
+
+      const result = service.testNormalizeBirthDate(today);
+
+      expect(result).toBeInstanceOf(Date);
+      // 시간은 00:00:00으로 내부 정규화되지만 날짜 자체는 오늘과 같아야 함
+      expect(result?.toDateString()).toBe(today.toDateString());
     });
   });
 

--- a/src/features/user/services/user-base.service.spec.ts
+++ b/src/features/user/services/user-base.service.spec.ts
@@ -3,10 +3,14 @@ import {
   ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { AccountType } from '@prisma/client';
+import type { PrismaClient } from '@prisma/client';
 
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserBaseService } from '@/features/user/services/user-base.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createAccount, createUserProfile } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
 /** UserBaseService는 abstract이므로 테스트용 concrete 클래스를 만든다 */
 class TestableUserBaseService extends UserBaseService {
@@ -14,7 +18,6 @@ class TestableUserBaseService extends UserBaseService {
     super(repo);
   }
 
-  // protected 메서드를 public으로 노출
   public testRequireActiveUser(accountId: bigint) {
     return this.requireActiveUser(accountId);
   }
@@ -44,146 +47,155 @@ class TestableUserBaseService extends UserBaseService {
   }
 }
 
-describe('UserBaseService', () => {
+describe('UserBaseService (real DB)', () => {
   let service: TestableUserBaseService;
-  let repo: jest.Mocked<UserRepository>;
+  let prisma: PrismaClient;
 
-  beforeEach(() => {
-    repo = {
-      findAccountWithProfile: jest.fn(),
-    } as unknown as jest.Mocked<UserRepository>;
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [UserRepository],
+    });
+    const repo = module.get(UserRepository);
     service = new TestableUserBaseService(repo);
+    prisma = p;
   });
 
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  // ─────────────────────────────────────────────
+  // requireActiveUser — DB 상태 의존
+  // ─────────────────────────────────────────────
   describe('requireActiveUser', () => {
-    it('활성 USER 계정이면 계정 정보를 반환해야 한다', async () => {
-      const activeAccount = {
-        id: BigInt(1),
-        deleted_at: null,
-        account_type: AccountType.USER,
-        user_profile: {
-          deleted_at: null,
-          nickname: 'test',
-        },
-      };
-      repo.findAccountWithProfile.mockResolvedValue(activeAccount as never);
+    it('활성 USER 계정이면 계정 + 프로필 정보를 반환한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
 
-      const result = await service.testRequireActiveUser(BigInt(1));
-      expect(result.id).toBe(BigInt(1));
-      expect(result.account_type).toBe(AccountType.USER);
+      const result = await service.testRequireActiveUser(account.id);
+
+      expect(result.id).toBe(account.id);
+      expect(result.account_type).toBe('USER');
+      expect(result.user_profile).not.toBeNull();
     });
 
-    it('계정이 없으면 UnauthorizedException을 던져야 한다', async () => {
-      repo.findAccountWithProfile.mockResolvedValue(null);
-      await expect(service.testRequireActiveUser(BigInt(1))).rejects.toThrow(
+    it('계정이 존재하지 않으면 UnauthorizedException을 던진다', async () => {
+      await expect(
+        service.testRequireActiveUser(BigInt(999999)),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('soft delete 된 계정이면 UnauthorizedException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+      await prisma.account.update({
+        where: { id: account.id },
+        data: { deleted_at: new Date() },
+      });
+
+      await expect(service.testRequireActiveUser(account.id)).rejects.toThrow(
         UnauthorizedException,
       );
     });
 
-    it('삭제된 계정이면 UnauthorizedException을 던져야 한다', async () => {
-      repo.findAccountWithProfile.mockResolvedValue({
-        id: BigInt(1),
-        deleted_at: new Date(),
-        account_type: AccountType.USER,
-        user_profile: { deleted_at: null },
-      } as never);
-      await expect(service.testRequireActiveUser(BigInt(1))).rejects.toThrow(
-        UnauthorizedException,
-      );
-    });
+    it('USER 이외 타입(SELLER)이면 ForbiddenException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'SELLER' });
 
-    it('USER 계정이 아니면 ForbiddenException을 던져야 한다', async () => {
-      repo.findAccountWithProfile.mockResolvedValue({
-        id: BigInt(1),
-        deleted_at: null,
-        account_type: AccountType.SELLER,
-        user_profile: { deleted_at: null },
-      } as never);
-      await expect(service.testRequireActiveUser(BigInt(1))).rejects.toThrow(
+      await expect(service.testRequireActiveUser(account.id)).rejects.toThrow(
         ForbiddenException,
       );
     });
 
-    it('프로필이 없으면 UnauthorizedException을 던져야 한다', async () => {
-      repo.findAccountWithProfile.mockResolvedValue({
-        id: BigInt(1),
-        deleted_at: null,
-        account_type: AccountType.USER,
-        user_profile: null,
-      } as never);
-      await expect(service.testRequireActiveUser(BigInt(1))).rejects.toThrow(
+    it('프로필이 없는 USER 계정이면 UnauthorizedException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+
+      await expect(service.testRequireActiveUser(account.id)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('프로필이 soft delete 된 경우 UnauthorizedException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const profile = await createUserProfile(prisma, {
+        account_id: account.id,
+      });
+      await prisma.userProfile.update({
+        where: { id: profile.id },
+        data: { deleted_at: new Date() },
+      });
+
+      await expect(service.testRequireActiveUser(account.id)).rejects.toThrow(
         UnauthorizedException,
       );
     });
   });
 
+  // ─────────────────────────────────────────────
+  // 순수 함수 — DB 의존 없음
+  // ─────────────────────────────────────────────
   describe('normalizeNickname', () => {
-    it('길이가 2 미만이면 BadRequestException을 던져야 한다', () => {
+    it('길이가 하한 미만이면 BadRequestException을 던진다', () => {
       expect(() => service.testNormalizeNickname('a')).toThrow(
         BadRequestException,
       );
     });
 
-    it('길이가 20 초과이면 BadRequestException을 던져야 한다', () => {
+    it('길이가 상한 초과이면 BadRequestException을 던진다', () => {
       expect(() => service.testNormalizeNickname('a'.repeat(21))).toThrow(
         BadRequestException,
       );
     });
 
-    it('허용되지 않는 문자가 포함되면 BadRequestException을 던져야 한다', () => {
+    it('허용되지 않는 특수문자가 포함되면 BadRequestException을 던진다', () => {
       expect(() => service.testNormalizeNickname('nick name!')).toThrow(
         BadRequestException,
       );
     });
 
-    it('유효한 닉네임을 반환해야 한다', () => {
-      expect(service.testNormalizeNickname('닉네임_test1')).toBe(
+    it('앞뒤 공백을 제거하고 유효한 닉네임을 반환한다', () => {
+      expect(service.testNormalizeNickname('  닉네임_test1  ')).toBe(
         '닉네임_test1',
       );
     });
   });
 
   describe('normalizeName', () => {
-    it('null이면 null을 반환해야 한다', () => {
+    it('null/undefined/공백-only이면 null을 반환한다', () => {
       expect(service.testNormalizeName(null)).toBeNull();
-    });
-
-    it('undefined이면 null을 반환해야 한다', () => {
       expect(service.testNormalizeName(undefined)).toBeNull();
-    });
-
-    it('빈 문자열이면 null을 반환해야 한다', () => {
       expect(service.testNormalizeName('   ')).toBeNull();
     });
 
-    it('공백이 제거된 이름을 반환해야 한다', () => {
+    it('앞뒤 공백을 제거한 이름을 반환한다', () => {
       expect(service.testNormalizeName('  홍길동  ')).toBe('홍길동');
     });
   });
 
   describe('normalizePhoneNumber', () => {
-    it('길이가 7 미만이면 BadRequestException을 던져야 한다', () => {
+    it('null/undefined/공백-only이면 null을 반환한다', () => {
+      expect(service.testNormalizePhoneNumber(null)).toBeNull();
+      expect(service.testNormalizePhoneNumber(undefined)).toBeNull();
+      expect(service.testNormalizePhoneNumber('   ')).toBeNull();
+    });
+
+    it('길이가 하한 미만이면 BadRequestException을 던진다', () => {
       expect(() => service.testNormalizePhoneNumber('12345')).toThrow(
         BadRequestException,
       );
     });
 
-    it('숫자와 하이픈 외 문자가 포함되면 BadRequestException을 던져야 한다', () => {
+    it('숫자와 하이픈 외 문자가 포함되면 BadRequestException을 던진다', () => {
       expect(() => service.testNormalizePhoneNumber('010-abc-1234')).toThrow(
         BadRequestException,
       );
     });
 
-    it('null/undefined이면 null을 반환해야 한다', () => {
-      expect(service.testNormalizePhoneNumber(null)).toBeNull();
-      expect(service.testNormalizePhoneNumber(undefined)).toBeNull();
-    });
-
-    it('빈 문자열이면 null을 반환해야 한다', () => {
-      expect(service.testNormalizePhoneNumber('   ')).toBeNull();
-    });
-
-    it('유효한 전화번호를 반환해야 한다', () => {
+    it('유효한 전화번호를 반환한다', () => {
       expect(service.testNormalizePhoneNumber('010-1234-5678')).toBe(
         '010-1234-5678',
       );
@@ -191,59 +203,73 @@ describe('UserBaseService', () => {
   });
 
   describe('normalizeBirthDate', () => {
-    it('유효하지 않은 날짜면 BadRequestException을 던져야 한다', () => {
+    it('null/undefined이면 null을 반환한다', () => {
+      expect(service.testNormalizeBirthDate(null)).toBeNull();
+      expect(service.testNormalizeBirthDate(undefined)).toBeNull();
+    });
+
+    it('유효하지 않은 날짜 문자열이면 BadRequestException을 던진다', () => {
       expect(() => service.testNormalizeBirthDate('not-a-date')).toThrow(
         BadRequestException,
       );
     });
 
-    it('미래 날짜면 BadRequestException을 던져야 한다', () => {
-      expect(() =>
-        service.testNormalizeBirthDate(new Date('2099-01-01')),
-      ).toThrow(BadRequestException);
+    it('미래 날짜면 BadRequestException을 던진다', () => {
+      const future = new Date();
+      future.setFullYear(future.getFullYear() + 1);
+      expect(() => service.testNormalizeBirthDate(future)).toThrow(
+        BadRequestException,
+      );
     });
 
-    it('null/undefined이면 null을 반환해야 한다', () => {
-      expect(service.testNormalizeBirthDate(null)).toBeNull();
-      expect(service.testNormalizeBirthDate(undefined)).toBeNull();
-    });
-
-    it('문자열 날짜를 Date 객체로 변환해야 한다', () => {
+    it('문자열 날짜를 Date 객체로 변환한다', () => {
       const result = service.testNormalizeBirthDate('1990-05-15');
       expect(result).toBeInstanceOf(Date);
       expect(result?.getFullYear()).toBe(1990);
     });
 
-    it('오늘 날짜면 정상 처리해야 한다', () => {
+    it('오늘 날짜는 미래로 취급하지 않는다', () => {
       const today = new Date();
       today.setHours(12, 0, 0, 0);
-      const result = service.testNormalizeBirthDate(today);
-      expect(result).toBeInstanceOf(Date);
+      expect(service.testNormalizeBirthDate(today)).toBeInstanceOf(Date);
     });
   });
 
   describe('normalizePaginationInput', () => {
-    it('offset이 음수이면 BadRequestException을 던져야 한다', () => {
+    it('offset 음수면 BadRequestException을 던진다', () => {
       expect(() =>
         service.testNormalizePaginationInput({ offset: -1 }),
       ).toThrow(BadRequestException);
     });
 
-    it('limit이 0 이하이면 BadRequestException을 던져야 한다', () => {
+    it('limit이 0 이하면 BadRequestException을 던진다', () => {
       expect(() => service.testNormalizePaginationInput({ limit: 0 })).toThrow(
         BadRequestException,
       );
     });
 
-    it('limit이 50 초과이면 BadRequestException을 던져야 한다', () => {
+    it('limit이 상한(50) 초과면 BadRequestException을 던진다', () => {
       expect(() => service.testNormalizePaginationInput({ limit: 51 })).toThrow(
         BadRequestException,
       );
     });
 
-    it('기본값을 올바르게 설정해야 한다', () => {
-      const result = service.testNormalizePaginationInput();
-      expect(result).toEqual({ offset: 0, limit: 20, unreadOnly: false });
+    it('입력이 없으면 기본값을 반환한다', () => {
+      expect(service.testNormalizePaginationInput()).toEqual({
+        offset: 0,
+        limit: 20,
+        unreadOnly: false,
+      });
+    });
+
+    it('unreadOnly 값을 boolean으로 강제 변환한다', () => {
+      expect(
+        service.testNormalizePaginationInput({
+          offset: 0,
+          limit: 10,
+          unreadOnly: null,
+        }).unreadOnly,
+      ).toBe(false);
     });
   });
 });

--- a/src/features/user/services/user-profile.service.spec.ts
+++ b/src/features/user/services/user-profile.service.spec.ts
@@ -3,346 +3,402 @@ import {
   ConflictException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
-import { AccountType } from '@prisma/client';
+import type { PrismaClient } from '@prisma/client';
 
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserProfileService } from '@/features/user/services/user-profile.service';
 import { S3Service } from '@/global/storage/s3.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createAccount, createUserProfile } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
-describe('UserProfileService', () => {
+describe('UserProfileService (real DB)', () => {
   let service: UserProfileService;
-  let repo: jest.Mocked<UserRepository>;
+  let prisma: PrismaClient;
   let s3Service: jest.Mocked<S3Service>;
 
-  const baseAccount = {
-    id: BigInt(1),
-    account_type: AccountType.USER,
-    email: 'test@example.com',
-    name: 'Test User',
-    deleted_at: null,
-    user_profile: {
-      nickname: 'tester',
-      birth_date: null,
-      phone_number: null,
-      profile_image_url: null,
-      onboarding_completed_at: null,
-      deleted_at: null,
-    },
-  };
-
-  beforeEach(async () => {
-    repo = {
-      findAccountWithProfile: jest.fn(),
-      isNicknameTaken: jest.fn(),
-      completeOnboarding: jest.fn(),
-      updateProfile: jest.fn(),
-      updateProfileImage: jest.fn(),
-      softDeleteAccount: jest.fn(),
-    } as unknown as jest.Mocked<UserRepository>;
-
+  beforeAll(async () => {
     s3Service = {
       createUploadUrl: jest.fn(),
     } as unknown as jest.Mocked<S3Service>;
 
-    const module: TestingModule = await Test.createTestingModule({
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
       providers: [
         UserProfileService,
-        { provide: UserRepository, useValue: repo },
+        UserRepository,
         { provide: S3Service, useValue: s3Service },
       ],
-    }).compile();
-
-    service = module.get<UserProfileService>(UserProfileService);
-  });
-
-  it('me는 인증된 유저 정보를 반환해야 한다', async () => {
-    repo.findAccountWithProfile.mockResolvedValue(baseAccount);
-
-    const result = await service.me(BigInt(1));
-
-    expect(result).toEqual({
-      accountId: '1',
-      email: 'test@example.com',
-      name: 'Test User',
-      accountType: AccountType.USER,
-      profile: {
-        nickname: 'tester',
-        birthDate: null,
-        phoneNumber: null,
-        profileImageUrl: null,
-        onboardingCompletedAt: null,
-      },
-    });
-  });
-
-  it('계정이 없으면 UnauthorizedException을 던져야 한다', async () => {
-    repo.findAccountWithProfile.mockResolvedValue(null);
-
-    await expect(service.me(BigInt(1))).rejects.toThrow(UnauthorizedException);
-  });
-
-  it('닉네임이 중복이면 ConflictException을 던져야 한다', async () => {
-    repo.findAccountWithProfile.mockResolvedValue(baseAccount);
-    repo.isNicknameTaken.mockResolvedValue(true);
-
-    await expect(
-      service.updateMyProfile(BigInt(1), { nickname: 'tester2' }),
-    ).rejects.toThrow(ConflictException);
-  });
-
-  it('deleteMyAccount는 soft delete를 수행해야 한다', async () => {
-    repo.findAccountWithProfile.mockResolvedValue(baseAccount);
-
-    const result = await service.deleteMyAccount(BigInt(1));
-
-    expect(result).toBe(true);
-    expect(repo.softDeleteAccount).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountId: BigInt(1),
-        deletedNickname: 'deleted_1',
-      }),
-    );
-  });
-
-  describe('checkNicknameAvailability', () => {
-    beforeEach(() => {
-      repo.findAccountWithProfile.mockResolvedValue(baseAccount);
     });
 
-    it('사용 가능한 닉네임이면 available: true를 반환해야 한다', async () => {
-      repo.isNicknameTaken.mockResolvedValue(false);
-
-      const result = await service.checkNicknameAvailability(
-        'newNick',
-        BigInt(1),
-      );
-
-      expect(result).toEqual({ available: true, reason: null });
-    });
-
-    it('이미 사용 중인 닉네임이면 available: false를 반환해야 한다', async () => {
-      repo.isNicknameTaken.mockResolvedValue(true);
-
-      const result = await service.checkNicknameAvailability(
-        'takenNick',
-        BigInt(1),
-      );
-
-      expect(result.available).toBe(false);
-      expect(result.reason).toContain('이미 사용 중');
-    });
-
-    it('닉네임이 너무 짧으면 available: false를 반환해야 한다', async () => {
-      const result = await service.checkNicknameAvailability('a', BigInt(1));
-
-      expect(result.available).toBe(false);
-      expect(result.reason).toContain('2~20자');
-    });
-
-    it('닉네임에 특수문자가 포함되면 available: false를 반환해야 한다', async () => {
-      const result = await service.checkNicknameAvailability(
-        'nick@name',
-        BigInt(1),
-      );
-
-      expect(result.available).toBe(false);
-      expect(result.reason).toContain('한글, 영문, 숫자, 언더스코어');
-    });
+    service = module.get(UserProfileService);
+    prisma = p;
   });
 
-  describe('completeOnboarding', () => {
-    it('온보딩을 완료하고 프로필을 반환해야 한다', async () => {
-      const accountWithoutName = { ...baseAccount, name: null };
-      repo.findAccountWithProfile
-        .mockResolvedValueOnce(accountWithoutName)
-        .mockResolvedValueOnce(baseAccount);
-      repo.isNicknameTaken.mockResolvedValue(false);
-      repo.completeOnboarding.mockResolvedValue(undefined as never);
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
 
-      const result = await service.completeOnboarding(BigInt(1), {
+  beforeEach(async () => {
+    await truncateAll();
+    jest.clearAllMocks();
+  });
+
+  // ─── me ───
+  describe('me', () => {
+    it('활성 USER의 프로필 정보를 MePayload로 반환한다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        email: 'me@example.com',
         name: '홍길동',
-        nickname: 'newNick',
+      });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        nickname: 'gildong',
+      });
+
+      const result = await service.me(account.id);
+
+      expect(result).toMatchObject({
+        accountId: account.id.toString(),
+        email: 'me@example.com',
+        name: '홍길동',
+        accountType: 'USER',
+        profile: { nickname: 'gildong' },
+      });
+    });
+
+    it('계정이 없으면 UnauthorizedException을 던진다', async () => {
+      await expect(service.me(BigInt(999999))).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  // ─── completeOnboarding ───
+  describe('completeOnboarding', () => {
+    it('이름 미존재 + 입력 이름이 있으면 Account.name과 프로필을 갱신한다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: null,
+      });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        onboarding_completed_at: null,
+      });
+
+      const result = await service.completeOnboarding(account.id, {
+        name: '홍길동',
+        nickname: 'gildong1',
         birthDate: new Date('1990-01-01'),
         phoneNumber: '010-1234-5678',
       });
 
-      expect(repo.completeOnboarding).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accountId: BigInt(1),
-          name: '홍길동',
-          nickname: 'newNick',
-        }),
-      );
-      expect(result.accountId).toBe('1');
+      expect(result.name).toBe('홍길동');
+      expect(result.profile.nickname).toBe('gildong1');
+      expect(result.profile.onboardingCompletedAt).toBeInstanceOf(Date);
+
+      const saved = await prisma.account.findUniqueOrThrow({
+        where: { id: account.id },
+      });
+      expect(saved.name).toBe('홍길동');
     });
 
-    it('계정에 이름이 이미 있으면 name 필드를 null로 전달해야 한다', async () => {
-      // baseAccount에는 name: 'Test User'가 있음
-      repo.findAccountWithProfile
-        .mockResolvedValueOnce(baseAccount)
-        .mockResolvedValueOnce(baseAccount);
-      repo.isNicknameTaken.mockResolvedValue(false);
-      repo.completeOnboarding.mockResolvedValue(undefined as never);
+    it('이미 Account.name이 존재하면 입력 name은 무시되고 기존 이름을 유지한다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: '기존이름',
+      });
+      await createUserProfile(prisma, { account_id: account.id });
 
-      await service.completeOnboarding(BigInt(1), {
+      const result = await service.completeOnboarding(account.id, {
         nickname: 'newNick',
         name: '새이름',
       });
 
-      expect(repo.completeOnboarding).toHaveBeenCalledWith(
-        expect.objectContaining({ name: null }),
-      );
+      expect(result.name).toBe('기존이름');
     });
 
-    it('계정에 이름이 없고 input에도 이름이 없으면 BadRequestException을 던져야 한다', async () => {
-      const accountWithoutName = { ...baseAccount, name: null };
-      repo.findAccountWithProfile.mockResolvedValue(accountWithoutName);
+    it('Account.name과 입력 name이 모두 없으면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: null,
+      });
+      await createUserProfile(prisma, { account_id: account.id });
 
       await expect(
-        service.completeOnboarding(BigInt(1), {
+        service.completeOnboarding(account.id, {
           nickname: 'newNick',
           name: null,
         }),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('닉네임이 중복이면 ConflictException을 던져야 한다', async () => {
-      repo.findAccountWithProfile.mockResolvedValue(baseAccount);
-      repo.isNicknameTaken.mockResolvedValue(true);
+    it('닉네임이 이미 다른 계정에서 사용 중이면 ConflictException을 던진다', async () => {
+      const other = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, {
+        account_id: other.id,
+        nickname: 'takenNick',
+      });
+
+      const me = await createAccount(prisma, {
+        account_type: 'USER',
+        name: '길동',
+      });
+      await createUserProfile(prisma, { account_id: me.id });
 
       await expect(
-        service.completeOnboarding(BigInt(1), {
-          nickname: 'taken',
-          name: '홍길동',
-        }),
+        service.completeOnboarding(me.id, { nickname: 'takenNick' }),
       ).rejects.toThrow(ConflictException);
     });
   });
 
+  // ─── updateMyProfile ───
   describe('updateMyProfile', () => {
-    it('업데이트 필드가 없으면 BadRequestException을 던져야 한다', async () => {
-      repo.findAccountWithProfile.mockResolvedValue(baseAccount);
+    it('변경할 필드가 하나도 없으면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
 
-      await expect(service.updateMyProfile(BigInt(1), {})).rejects.toThrow(
+      await expect(service.updateMyProfile(account.id, {})).rejects.toThrow(
         BadRequestException,
       );
     });
 
-    it('birthDate만 업데이트하면 성공해야 한다', async () => {
-      repo.findAccountWithProfile
-        .mockResolvedValueOnce(baseAccount)
-        .mockResolvedValueOnce(baseAccount);
-      repo.updateProfile.mockResolvedValue(undefined as never);
-
-      const result = await service.updateMyProfile(BigInt(1), {
-        birthDate: new Date('1990-06-15'),
+    it('birthDate만 단독 업데이트한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        birth_date: null,
       });
 
-      expect(repo.updateProfile).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accountId: BigInt(1),
-          birthDate: expect.any(Date),
-        }),
-      );
-      expect(result.accountId).toBe('1');
+      const result = await service.updateMyProfile(account.id, {
+        birthDate: new Date('1995-03-20'),
+      });
+
+      expect(result.profile.birthDate).toBeInstanceOf(Date);
+      expect((result.profile.birthDate as Date).getFullYear()).toBe(1995);
     });
 
-    it('phoneNumber만 업데이트하면 성공해야 한다', async () => {
-      repo.findAccountWithProfile
-        .mockResolvedValueOnce(baseAccount)
-        .mockResolvedValueOnce(baseAccount);
-      repo.updateProfile.mockResolvedValue(undefined as never);
+    it('phoneNumber만 단독 업데이트한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        phone_number: null,
+      });
 
-      await service.updateMyProfile(BigInt(1), {
+      const result = await service.updateMyProfile(account.id, {
         phoneNumber: '010-9999-8888',
       });
 
-      expect(repo.updateProfile).toHaveBeenCalledWith(
-        expect.objectContaining({ phoneNumber: '010-9999-8888' }),
-      );
+      expect(result.profile.phoneNumber).toBe('010-9999-8888');
     });
 
-    it('닉네임이 undefined가 아니지만 중복 아니면 성공해야 한다', async () => {
-      repo.findAccountWithProfile
-        .mockResolvedValueOnce(baseAccount)
-        .mockResolvedValueOnce(baseAccount);
-      repo.isNicknameTaken.mockResolvedValue(false);
-      repo.updateProfile.mockResolvedValue(undefined as never);
+    it('사용 가능한 닉네임으로 변경한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        nickname: 'oldNick',
+      });
 
-      await service.updateMyProfile(BigInt(1), { nickname: 'uniqueNick' });
+      const result = await service.updateMyProfile(account.id, {
+        nickname: 'newNick',
+      });
 
-      expect(repo.isNicknameTaken).toHaveBeenCalledWith(
-        'uniqueNick',
-        BigInt(1),
-      );
-      expect(repo.updateProfile).toHaveBeenCalled();
+      expect(result.profile.nickname).toBe('newNick');
+    });
+
+    it('닉네임이 다른 계정에서 이미 쓰이면 ConflictException을 던진다', async () => {
+      const other = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, {
+        account_id: other.id,
+        nickname: 'taken',
+      });
+
+      const me = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: me.id });
+
+      await expect(
+        service.updateMyProfile(me.id, { nickname: 'taken' }),
+      ).rejects.toThrow(ConflictException);
     });
   });
 
+  // ─── updateMyProfileImage ───
   describe('updateMyProfileImage', () => {
-    it('유효한 URL이면 프로필 이미지를 업데이트해야 한다', async () => {
-      repo.findAccountWithProfile
-        .mockResolvedValueOnce(baseAccount)
-        .mockResolvedValueOnce(baseAccount);
-      repo.updateProfileImage.mockResolvedValue(undefined as never);
+    it('유효한 URL이면 프로필 이미지를 업데이트한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
 
-      const result = await service.updateMyProfileImage(BigInt(1), {
+      const result = await service.updateMyProfileImage(account.id, {
         profileImageUrl: 'https://s3.example.com/profile.jpg',
       });
 
-      expect(repo.updateProfileImage).toHaveBeenCalledWith({
-        accountId: BigInt(1),
-        profileImageUrl: 'https://s3.example.com/profile.jpg',
-      });
-      expect(result.accountId).toBe('1');
+      expect(result.profile.profileImageUrl).toBe(
+        'https://s3.example.com/profile.jpg',
+      );
     });
 
-    it('URL이 빈 문자열이면 BadRequestException을 던져야 한다', async () => {
-      repo.findAccountWithProfile.mockResolvedValue(baseAccount);
+    it('URL이 공백-only면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
 
       await expect(
-        service.updateMyProfileImage(BigInt(1), { profileImageUrl: '   ' }),
+        service.updateMyProfileImage(account.id, { profileImageUrl: '   ' }),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('URL이 2048자 초과이면 BadRequestException을 던져야 한다', async () => {
-      repo.findAccountWithProfile.mockResolvedValue(baseAccount);
+    it('URL이 2048자를 초과하면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
 
       await expect(
-        service.updateMyProfileImage(BigInt(1), {
+        service.updateMyProfileImage(account.id, {
           profileImageUrl: 'https://s3.example.com/' + 'a'.repeat(2030),
         }),
       ).rejects.toThrow(BadRequestException);
     });
   });
 
-  describe('createProfileImageUploadUrl', () => {
-    beforeEach(() => {
-      repo.findAccountWithProfile.mockResolvedValue(baseAccount);
+  // ─── checkNicknameAvailability ───
+  describe('checkNicknameAvailability', () => {
+    it('사용 가능한 닉네임이면 available: true', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const result = await service.checkNicknameAvailability(
+        'freshNick',
+        account.id,
+      );
+
+      expect(result).toEqual({ available: true, reason: null });
     });
 
-    it('S3Service에 PROFILE_IMAGE purpose로 위임해야 한다', async () => {
-      const mockResult = {
-        uploadUrl: 'https://presigned-url.com',
+    it('이미 사용 중인 닉네임이면 available: false + 사유 반환', async () => {
+      const other = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, {
+        account_id: other.id,
+        nickname: 'takenNick',
+      });
+
+      const me = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: me.id });
+
+      const result = await service.checkNicknameAvailability(
+        'takenNick',
+        me.id,
+      );
+
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain('이미 사용 중');
+    });
+
+    it('자기 자신이 이미 쓰고 있는 닉네임은 사용 가능으로 판정한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        nickname: 'myNick',
+      });
+
+      const result = await service.checkNicknameAvailability(
+        'myNick',
+        account.id,
+      );
+
+      expect(result.available).toBe(true);
+    });
+
+    it('너무 짧으면 available: false + 길이 사유', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const result = await service.checkNicknameAvailability('a', account.id);
+
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain('2~20자');
+    });
+
+    it('특수문자가 포함되면 available: false + 문자 사유', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const result = await service.checkNicknameAvailability(
+        'nick@name',
+        account.id,
+      );
+
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain('한글');
+    });
+  });
+
+  // ─── createProfileImageUploadUrl (S3 mock 유지) ───
+  describe('createProfileImageUploadUrl', () => {
+    it('S3Service.createUploadUrl에 PROFILE_IMAGE purpose로 위임한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const uploadResult = {
+        uploadUrl: 'https://presigned.example.com',
         publicUrl: 'https://s3.example.com/profile.jpg',
-        key: 'profile-images/1/2026-04-13/uuid.jpg',
+        key: 'profile-images/x/2026-04-21/uuid.jpg',
         expiresInSeconds: 600,
       };
-      s3Service.createUploadUrl.mockResolvedValue(mockResult);
+      s3Service.createUploadUrl.mockResolvedValue(uploadResult);
 
-      const result = await service.createProfileImageUploadUrl(BigInt(1), {
+      const result = await service.createProfileImageUploadUrl(account.id, {
         contentType: 'image/jpeg',
         contentLength: 1024 * 1024,
       });
 
-      expect(result).toEqual(mockResult);
+      expect(result).toEqual(uploadResult);
       expect(s3Service.createUploadUrl).toHaveBeenCalledWith({
-        accountId: BigInt(1),
+        accountId: account.id,
         purpose: 'PROFILE_IMAGE',
         contentType: 'image/jpeg',
         contentLength: 1024 * 1024,
       });
+    });
+  });
+
+  // ─── deleteMyAccount ───
+  describe('deleteMyAccount', () => {
+    it('계정/프로필을 soft delete하고 닉네임은 deleted_{id}로 치환한다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        email: 'delete@example.com',
+      });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        nickname: 'preDelete',
+      });
+
+      const result = await service.deleteMyAccount(account.id);
+
+      expect(result).toBe(true);
+
+      const deletedAccount = await prisma.account.findUniqueOrThrow({
+        where: { id: account.id },
+      });
+      expect(deletedAccount.deleted_at).toBeInstanceOf(Date);
+      expect(deletedAccount.email).toBeNull();
+
+      const deletedProfile = await prisma.userProfile.findUniqueOrThrow({
+        where: { account_id: account.id },
+      });
+      expect(deletedProfile.deleted_at).toBeInstanceOf(Date);
+      expect(deletedProfile.nickname).toBe(`deleted_${account.id.toString()}`);
+    });
+
+    it('삭제된 계정은 이후 me() 호출 시 UnauthorizedException', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      await service.deleteMyAccount(account.id);
+
+      await expect(service.me(account.id)).rejects.toThrow(
+        UnauthorizedException,
+      );
     });
   });
 });

--- a/src/features/user/services/user-recent-view.service.spec.ts
+++ b/src/features/user/services/user-recent-view.service.spec.ts
@@ -1,168 +1,340 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
+import type { PrismaClient } from '@prisma/client';
 
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
 import { UserRecentViewService } from '@/features/user/services/user-recent-view.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createProduct,
+  createRecentProductView,
+  createStore,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
-describe('UserRecentViewService', () => {
+const MAX_RECENT_VIEWS = 50;
+
+describe('UserRecentViewService (real DB)', () => {
   let service: UserRecentViewService;
-  let recentViewRepo: jest.Mocked<RecentProductViewRepository>;
-  let productRepo: jest.Mocked<ProductRepository>;
+  let prisma: PrismaClient;
 
-  const accountId = BigInt(1);
-
-  beforeEach(async () => {
-    recentViewRepo = {
-      findRecentByAccountPaginated: jest.fn(),
-      upsertView: jest.fn(),
-      countByAccount: jest.fn(),
-      deleteOldestOverLimit: jest.fn(),
-      softDeleteByProduct: jest.fn(),
-      softDeleteAllByAccount: jest.fn(),
-    } as unknown as jest.Mocked<RecentProductViewRepository>;
-
-    productRepo = {
-      findActiveProduct: jest.fn(),
-    } as unknown as jest.Mocked<ProductRepository>;
-
-    const module: TestingModule = await Test.createTestingModule({
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
       providers: [
         UserRecentViewService,
-        { provide: RecentProductViewRepository, useValue: recentViewRepo },
-        { provide: ProductRepository, useValue: productRepo },
+        RecentProductViewRepository,
+        ProductRepository,
       ],
-    }).compile();
-
-    service = module.get<UserRecentViewService>(UserRecentViewService);
-  });
-
-  describe('list', () => {
-    it('최근 본 상품 목록을 반환해야 한다', async () => {
-      recentViewRepo.findRecentByAccountPaginated.mockResolvedValue({
-        items: [
-          {
-            product_id: BigInt(200),
-            viewed_at: new Date('2026-04-12'),
-            product: {
-              name: '레터링 케이크',
-              regular_price: 45000,
-              sale_price: 40000,
-              store: { store_name: '스웨이드 베이커리' },
-              images: [{ image_url: 'https://s3.example.com/cake.jpg' }],
-            },
-          },
-        ],
-        totalCount: 1,
-      });
-
-      const result = await service.list(accountId);
-
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0]).toMatchObject({
-        productId: '200',
-        productName: '레터링 케이크',
-        storeName: '스웨이드 베이커리',
-      });
-      expect(result.totalCount).toBe(1);
-      expect(result.hasMore).toBe(false);
     });
 
-    it('offset + limit < totalCount이면 hasMore가 true여야 한다', async () => {
-      recentViewRepo.findRecentByAccountPaginated.mockResolvedValue({
-        items: [],
-        totalCount: 25,
+    service = module.get(UserRecentViewService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  // ─── list ───
+  describe('list', () => {
+    it('최근 본 순서로 정렬된 상품 커넥션을 반환한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const store = await createStore(prisma, { store_name: '베이커리A' });
+      const p1 = await createProduct(prisma, {
+        store_id: store.id,
+        name: '케이크1',
+        regular_price: 10000,
+        sale_price: 9000,
+      });
+      const p2 = await createProduct(prisma, {
+        store_id: store.id,
+        name: '케이크2',
+        regular_price: 20000,
       });
 
-      const result = await service.list(accountId, { offset: 0, limit: 20 });
+      // p1은 더 이전, p2는 최근에 봄
+      await createRecentProductView(prisma, {
+        account_id: account.id,
+        product_id: p1.id,
+        viewed_at: new Date('2026-04-01'),
+      });
+      await createRecentProductView(prisma, {
+        account_id: account.id,
+        product_id: p2.id,
+        viewed_at: new Date('2026-04-20'),
+      });
 
+      const result = await service.list(account.id);
+
+      expect(result.totalCount).toBe(2);
+      expect(result.hasMore).toBe(false);
+      expect(result.items).toHaveLength(2);
+      // 최근 본 것(p2)이 먼저
+      expect(result.items[0]).toMatchObject({
+        productId: p2.id.toString(),
+        productName: '케이크2',
+        storeName: '베이커리A',
+        regularPrice: 20000,
+      });
+      expect(result.items[1].productId).toBe(p1.id.toString());
+      expect(result.items[1].salePrice).toBe(9000);
+    });
+
+    it('pagination: offset + limit < totalCount면 hasMore true', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const store = await createStore(prisma);
+      for (let i = 0; i < 3; i++) {
+        const p = await createProduct(prisma, { store_id: store.id });
+        await createRecentProductView(prisma, {
+          account_id: account.id,
+          product_id: p.id,
+          viewed_at: new Date(2026, 3, 20 - i),
+        });
+      }
+
+      const result = await service.list(account.id, { offset: 0, limit: 2 });
+
+      expect(result.items).toHaveLength(2);
+      expect(result.totalCount).toBe(3);
       expect(result.hasMore).toBe(true);
     });
 
-    it('limit이 0이면 에러를 던져야 한다', async () => {
-      await expect(service.list(accountId, { limit: 0 })).rejects.toThrow(
+    it('soft-delete된 view는 포함되지 않는다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createRecentProductView(prisma, {
+        account_id: account.id,
+        deleted_at: new Date(),
+      });
+
+      const result = await service.list(account.id);
+
+      expect(result.totalCount).toBe(0);
+      expect(result.items).toHaveLength(0);
+    });
+
+    it('is_active=false 상품은 목록에서 제외된다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const inactiveProduct = await createProduct(prisma, { is_active: false });
+      await createRecentProductView(prisma, {
+        account_id: account.id,
+        product_id: inactiveProduct.id,
+      });
+
+      const result = await service.list(account.id);
+
+      expect(result.totalCount).toBe(0);
+    });
+
+    it('limit이 0 이하면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await expect(service.list(account.id, { limit: 0 })).rejects.toThrow(
         BadRequestException,
       );
     });
 
-    it('offset이 음수이면 에러를 던져야 한다', async () => {
-      await expect(service.list(accountId, { offset: -1 })).rejects.toThrow(
+    it('limit이 상한(50)을 초과하면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await expect(service.list(account.id, { limit: 51 })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('offset이 음수면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await expect(service.list(account.id, { offset: -1 })).rejects.toThrow(
         BadRequestException,
       );
     });
   });
 
+  // ─── record ───
   describe('record', () => {
-    it('상품이 존재하면 upsert 후 초과분을 정리해야 한다', async () => {
-      productRepo.findActiveProduct.mockResolvedValue({ id: BigInt(200) });
-      recentViewRepo.upsertView.mockResolvedValue(undefined);
-      recentViewRepo.deleteOldestOverLimit.mockResolvedValue(undefined);
+    it('활성 상품이면 view를 새로 기록한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const product = await createProduct(prisma, { is_active: true });
 
-      const result = await service.record(accountId, '200');
+      const result = await service.record(account.id, product.id.toString());
 
       expect(result).toBe(true);
-      expect(recentViewRepo.upsertView).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accountId,
-          productId: BigInt(200),
-        }),
-      );
-      expect(recentViewRepo.deleteOldestOverLimit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          accountId,
-          maxCount: 50,
-        }),
+      const row = await prisma.recentProductView.findUniqueOrThrow({
+        where: {
+          account_id_product_id: {
+            account_id: account.id,
+            product_id: product.id,
+          },
+        },
+      });
+      expect(row.deleted_at).toBeNull();
+    });
+
+    it('이미 기록된 view는 viewed_at을 갱신하고 soft-delete를 복원한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const product = await createProduct(prisma, { is_active: true });
+      await createRecentProductView(prisma, {
+        account_id: account.id,
+        product_id: product.id,
+        viewed_at: new Date('2025-01-01'),
+        deleted_at: new Date('2025-02-01'),
+      });
+
+      await service.record(account.id, product.id.toString());
+
+      const row = await prisma.recentProductView.findUniqueOrThrow({
+        where: {
+          account_id_product_id: {
+            account_id: account.id,
+            product_id: product.id,
+          },
+        },
+      });
+      expect(row.deleted_at).toBeNull();
+      expect(row.viewed_at.getTime()).toBeGreaterThan(
+        new Date('2025-01-01').getTime(),
       );
     });
 
-    it('상품이 존재하지 않으면 NotFoundException을 던져야 한다', async () => {
-      productRepo.findActiveProduct.mockResolvedValue(null);
-
-      await expect(service.record(accountId, '999')).rejects.toThrow(
+    it('상품이 존재하지 않으면 NotFoundException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await expect(service.record(account.id, '999999')).rejects.toThrow(
         NotFoundException,
       );
     });
 
-    it('유효하지 않은 productId이면 BadRequestException을 던져야 한다', async () => {
-      await expect(service.record(accountId, 'abc')).rejects.toThrow(
+    it('is_active=false 상품이면 NotFoundException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const inactive = await createProduct(prisma, { is_active: false });
+
+      await expect(
+        service.record(account.id, inactive.id.toString()),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('유효하지 않은 productId 문자열이면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await expect(service.record(account.id, 'not-a-number')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it(`계정당 ${MAX_RECENT_VIEWS}개 초과분은 오래된 순으로 soft-delete된다`, async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const store = await createStore(prisma);
+
+      // 먼저 50개 기록 (오래된 순)
+      const existingProductIds: bigint[] = [];
+      for (let i = 0; i < MAX_RECENT_VIEWS; i++) {
+        const p = await createProduct(prisma, { store_id: store.id });
+        existingProductIds.push(p.id);
+        await createRecentProductView(prisma, {
+          account_id: account.id,
+          product_id: p.id,
+          // 오름차순 시간: i=0이 가장 오래됨
+          viewed_at: new Date(2026, 0, 1, 0, i),
+        });
+      }
+
+      // 51번째 상품 기록 → oldest 1개가 soft-delete 되어야 함
+      const newProduct = await createProduct(prisma, { store_id: store.id });
+      await service.record(account.id, newProduct.id.toString());
+
+      const activeCount = await prisma.recentProductView.count({
+        where: { account_id: account.id, deleted_at: null },
+      });
+      expect(activeCount).toBe(MAX_RECENT_VIEWS);
+
+      // 가장 오래된 것(인덱스 0)이 soft-delete 되었는지 확인
+      const oldest = await prisma.recentProductView.findUniqueOrThrow({
+        where: {
+          account_id_product_id: {
+            account_id: account.id,
+            product_id: existingProductIds[0],
+          },
+        },
+      });
+      expect(oldest.deleted_at).not.toBeNull();
+    });
+  });
+
+  // ─── deleteOne ───
+  describe('deleteOne', () => {
+    it('기록이 있으면 soft-delete하고 true를 반환한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const product = await createProduct(prisma);
+      await createRecentProductView(prisma, {
+        account_id: account.id,
+        product_id: product.id,
+      });
+
+      const result = await service.deleteOne(account.id, product.id.toString());
+
+      expect(result).toBe(true);
+      const row = await prisma.recentProductView.findUniqueOrThrow({
+        where: {
+          account_id_product_id: {
+            account_id: account.id,
+            product_id: product.id,
+          },
+        },
+      });
+      expect(row.deleted_at).not.toBeNull();
+    });
+
+    it('존재하지 않는 (또는 이미 삭제된) 항목이면 false', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const result = await service.deleteOne(account.id, '999999');
+      expect(result).toBe(false);
+    });
+
+    it('유효하지 않은 productId 문자열이면 BadRequestException을 던진다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await expect(service.deleteOne(account.id, 'abc')).rejects.toThrow(
         BadRequestException,
       );
     });
   });
 
-  describe('deleteOne', () => {
-    it('삭제 성공 시 true를 반환해야 한다', async () => {
-      recentViewRepo.softDeleteByProduct.mockResolvedValue(true);
-
-      const result = await service.deleteOne(accountId, '200');
-
-      expect(result).toBe(true);
-    });
-
-    it('존재하지 않는 항목이면 false를 반환해야 한다', async () => {
-      recentViewRepo.softDeleteByProduct.mockResolvedValue(false);
-
-      const result = await service.deleteOne(accountId, '999');
-
-      expect(result).toBe(false);
-    });
-  });
-
+  // ─── clearAll ───
   describe('clearAll', () => {
-    it('전체 삭제 후 true를 반환해야 한다', async () => {
-      recentViewRepo.softDeleteAllByAccount.mockResolvedValue(5);
+    it('해당 계정의 모든 active view를 soft-delete한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      for (let i = 0; i < 3; i++) {
+        await createRecentProductView(prisma, { account_id: account.id });
+      }
 
-      const result = await service.clearAll(accountId);
+      const result = await service.clearAll(account.id);
 
+      expect(result).toBe(true);
+      const activeCount = await prisma.recentProductView.count({
+        where: { account_id: account.id, deleted_at: null },
+      });
+      expect(activeCount).toBe(0);
+    });
+
+    it('삭제할 항목이 없어도 true를 반환한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const result = await service.clearAll(account.id);
       expect(result).toBe(true);
     });
 
-    it('삭제할 항목이 없어도 true를 반환해야 한다', async () => {
-      recentViewRepo.softDeleteAllByAccount.mockResolvedValue(0);
+    it('다른 계정의 view는 영향을 받지 않는다', async () => {
+      const a1 = await createAccount(prisma, { account_type: 'USER' });
+      const a2 = await createAccount(prisma, { account_type: 'USER' });
+      await createRecentProductView(prisma, { account_id: a1.id });
+      await createRecentProductView(prisma, { account_id: a2.id });
 
-      const result = await service.clearAll(accountId);
+      await service.clearAll(a1.id);
 
-      expect(result).toBe(true);
+      const a2Remaining = await prisma.recentProductView.count({
+        where: { account_id: a2.id, deleted_at: null },
+      });
+      expect(a2Remaining).toBe(1);
     });
   });
 });

--- a/src/test/factories/index.ts
+++ b/src/test/factories/index.ts
@@ -2,6 +2,7 @@ export * from './account.factory';
 export * from './auth.factory';
 export * from './order.factory';
 export * from './product.factory';
+export * from './recent-product-view.factory';
 export * from './review.factory';
 export * from './seller.factory';
 export * from './sequence';

--- a/src/test/factories/recent-product-view.factory.ts
+++ b/src/test/factories/recent-product-view.factory.ts
@@ -1,0 +1,30 @@
+import type { PrismaClient, RecentProductView } from '@prisma/client';
+
+import { createAccount } from '@/test/factories/account.factory';
+import { createProduct } from '@/test/factories/product.factory';
+
+export interface RecentProductViewOverrides {
+  account_id?: bigint;
+  product_id?: bigint;
+  viewed_at?: Date;
+  deleted_at?: Date | null;
+}
+
+export async function createRecentProductView(
+  prisma: PrismaClient,
+  overrides: RecentProductViewOverrides = {},
+): Promise<RecentProductView> {
+  const accountId =
+    overrides.account_id ??
+    (await createAccount(prisma, { account_type: 'USER' })).id;
+  const productId = overrides.product_id ?? (await createProduct(prisma)).id;
+
+  return prisma.recentProductView.create({
+    data: {
+      account_id: accountId,
+      product_id: productId,
+      viewed_at: overrides.viewed_at ?? new Date(),
+      deleted_at: overrides.deleted_at ?? null,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
실DB 테스트 전면 도입 플랜의 **PR 4**.
user 도메인 중 profile / onboarding / recent-view 관련 서비스·리포지토리·리졸버의 mock 기반 테스트를 Testcontainers 실DB 테스트로 전환.

## 변경 범위
### 서비스 3개
- `user-base.service.spec.ts` — `requireActiveUser` 계열을 실DB 검증. 순수 함수(`normalize*`)는 DB 없이 직접 호출 (26 tests)
- `user-profile.service.spec.ts` — Prisma + UserRepository 실행. `S3Service`는 외부 I/O라 mock 유지 (22 tests)
- `user-recent-view.service.spec.ts` — Prisma + RecentProductViewRepository + ProductRepository 실행 (19 tests)

### 리졸버 통합 테스트 신설
- `user-profile.resolver.spec.ts` 신규 — resolver → service → DB 경로 검증 (6 tests)
- `user-recent-view.resolver.spec.ts` 신규 — 동일 패턴 (4 tests)
- `user.resolver.spec.ts`에서 profile/recent-view describe 블록 제거 (잔여 도메인은 PR 5에서 처리)

### 팩토리
- `src/test/factories/recent-product-view.factory.ts` 신규

### 커버리지 하한선 (플랜 §6 단계적 상향)
- `package.json` `coverageThreshold.global`: 70/58/58/70 → **80/73/73/80**

## 실측 커버리지
| 지표 | 실측 | 기준 | 여유 |
|---|---|---|---|
| Statements | 87.76% | 80% | +7.76 |
| Branches | 73.06% | 73% | +0.06 |
| Functions | 75.67% | 73% | +2.67 |
| Lines | 88.33% | 80% | +8.33 |

## 테스트 결과
- **705 tests / 56 suites 통과**
- `yarn lint` / `npx tsc --noEmit` 로컬 green

## 허용된 mock (플랜 §2.4)
- `S3Service.createUploadUrl` — 외부 I/O
- 그 외 내부 의존성(Repository, Service, Guard) **mock 금지** 원칙 준수

## Test plan
- [ ] CI (`check`, `pr-title`, `coverage-report`, `Analyze (javascript-typescript)`) green
- [ ] Codecov에 project summary + files Δ 상세 리포트 표시 확인 (PR #62 반영 효과)
- [ ] develop 머지 후 다음 PR 5 (user 2/2 — mypage/order/review/notification/search/engagement)로 이어서 진행