### PR TITLE
test: 나머지 feature(product/order/conversation/system) 실DB 전환

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,10 +126,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 85,
-        "branches": 76,
-        "functions": 80,
-        "lines": 85
+        "statements": 88,
+        "branches": 78,
+        "functions": 85,
+        "lines": 88
       }
     },
     "coverageDirectory": "../coverage",

--- a/src/features/conversation/repositories/conversation.repository.spec.ts
+++ b/src/features/conversation/repositories/conversation.repository.spec.ts
@@ -1,0 +1,152 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createAccount, createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('ConversationRepository (real DB)', () => {
+  let repo: ConversationRepository;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ConversationRepository],
+    });
+    repo = module.get(ConversationRepository);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  async function setupConversation() {
+    const customer = await createAccount(prisma, { account_type: 'USER' });
+    const store = await createStore(prisma);
+    const conv = await prisma.storeConversation.create({
+      data: { account_id: customer.id, store_id: store.id },
+    });
+    return { customer, store, conversation: conv };
+  }
+
+  describe('listConversationsByStore', () => {
+    it('특정 store의 conversation만 반환한다', async () => {
+      const a = await setupConversation();
+      const b = await setupConversation();
+
+      const rows = await repo.listConversationsByStore({
+        storeId: a.store.id,
+        limit: 10,
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].store_id).toBe(a.store.id);
+      expect(rows[0].id).not.toBe(b.conversation.id);
+    });
+
+    it('cursor보다 id가 작은 row만 반환 (내림차순 페이지네이션)', async () => {
+      const customer = await createAccount(prisma, { account_type: 'USER' });
+      const store = await createStore(prisma);
+      const c1 = await prisma.storeConversation.create({
+        data: { account_id: customer.id, store_id: store.id },
+      });
+      const customer2 = await createAccount(prisma, { account_type: 'USER' });
+      const c2 = await prisma.storeConversation.create({
+        data: { account_id: customer2.id, store_id: store.id },
+      });
+
+      const rows = await repo.listConversationsByStore({
+        storeId: store.id,
+        limit: 10,
+        cursor: c2.id,
+      });
+      expect(rows.map((r) => r.id)).toEqual([c1.id]);
+    });
+  });
+
+  describe('findConversationByIdAndStore', () => {
+    it('conversationId + storeId가 모두 맞으면 반환', async () => {
+      const { store, conversation } = await setupConversation();
+      const found = await repo.findConversationByIdAndStore({
+        conversationId: conversation.id,
+        storeId: store.id,
+      });
+      expect(found?.id).toBe(conversation.id);
+    });
+
+    it('다른 store면 null', async () => {
+      const { conversation } = await setupConversation();
+      const otherStore = await createStore(prisma);
+      const found = await repo.findConversationByIdAndStore({
+        conversationId: conversation.id,
+        storeId: otherStore.id,
+      });
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('listConversationMessages', () => {
+    it('conversation의 메시지를 id 내림차순으로 반환', async () => {
+      const { customer, conversation } = await setupConversation();
+      const m1 = await prisma.storeConversationMessage.create({
+        data: {
+          conversation_id: conversation.id,
+          sender_type: 'USER',
+          sender_account_id: customer.id,
+          body_format: 'TEXT',
+          body_text: '첫번째',
+        },
+      });
+      const m2 = await prisma.storeConversationMessage.create({
+        data: {
+          conversation_id: conversation.id,
+          sender_type: 'USER',
+          sender_account_id: customer.id,
+          body_format: 'TEXT',
+          body_text: '두번째',
+        },
+      });
+
+      const rows = await repo.listConversationMessages({
+        conversationId: conversation.id,
+        limit: 10,
+      });
+      expect(rows.map((r) => r.id)).toEqual([m2.id, m1.id]);
+    });
+  });
+
+  describe('createSellerConversationMessage', () => {
+    it('메시지 생성 시 conversation.last_message_at/updated_at을 트랜잭션 안에서 갱신한다', async () => {
+      const { store, conversation } = await setupConversation();
+      const seller = await createAccount(prisma, { account_type: 'SELLER' });
+      const now = new Date('2026-04-22T12:00:00Z');
+
+      const message = await repo.createSellerConversationMessage({
+        conversationId: conversation.id,
+        sellerAccountId: seller.id,
+        bodyFormat: 'TEXT',
+        bodyText: '판매자 응답',
+        bodyHtml: null,
+        now,
+      });
+
+      expect(message.sender_type).toBe('STORE');
+      expect(message.sender_account_id).toBe(seller.id);
+      expect(message.body_text).toBe('판매자 응답');
+
+      const updatedConv = await prisma.storeConversation.findUniqueOrThrow({
+        where: { id: conversation.id },
+      });
+      expect(updatedConv.last_message_at?.toISOString()).toBe(
+        now.toISOString(),
+      );
+      expect(updatedConv.store_id).toBe(store.id);
+    });
+  });
+});

--- a/src/features/order/policies/order-status-transition.policy.spec.ts
+++ b/src/features/order/policies/order-status-transition.policy.spec.ts
@@ -1,0 +1,102 @@
+import { BadRequestException } from '@nestjs/common';
+import { OrderStatus } from '@prisma/client';
+
+import { OrderStatusTransitionPolicy } from '@/features/order/policies/order-status-transition.policy';
+
+describe('OrderStatusTransitionPolicy', () => {
+  const policy = new OrderStatusTransitionPolicy();
+
+  describe('parse', () => {
+    it.each([
+      ['SUBMITTED', OrderStatus.SUBMITTED],
+      ['CONFIRMED', OrderStatus.CONFIRMED],
+      ['MADE', OrderStatus.MADE],
+      ['PICKED_UP', OrderStatus.PICKED_UP],
+      ['CANCELED', OrderStatus.CANCELED],
+    ])('"%s" → enum %s', (raw, expected) => {
+      expect(policy.parse(raw)).toBe(expected);
+    });
+
+    it('알 수 없는 문자열이면 BadRequestException', () => {
+      expect(() => policy.parse('INVALID')).toThrow(BadRequestException);
+    });
+  });
+
+  describe('assertSellerTransition', () => {
+    it('from === to면 BadRequestException', () => {
+      expect(() =>
+        policy.assertSellerTransition(
+          OrderStatus.SUBMITTED,
+          OrderStatus.SUBMITTED,
+        ),
+      ).toThrow(BadRequestException);
+    });
+
+    it('CONFIRMED는 SUBMITTED에서만 가능', () => {
+      expect(() =>
+        policy.assertSellerTransition(
+          OrderStatus.SUBMITTED,
+          OrderStatus.CONFIRMED,
+        ),
+      ).not.toThrow();
+      expect(() =>
+        policy.assertSellerTransition(OrderStatus.MADE, OrderStatus.CONFIRMED),
+      ).toThrow(BadRequestException);
+    });
+
+    it('MADE는 CONFIRMED에서만 가능', () => {
+      expect(() =>
+        policy.assertSellerTransition(OrderStatus.CONFIRMED, OrderStatus.MADE),
+      ).not.toThrow();
+      expect(() =>
+        policy.assertSellerTransition(OrderStatus.SUBMITTED, OrderStatus.MADE),
+      ).toThrow(BadRequestException);
+    });
+
+    it('PICKED_UP은 MADE에서만 가능', () => {
+      expect(() =>
+        policy.assertSellerTransition(OrderStatus.MADE, OrderStatus.PICKED_UP),
+      ).not.toThrow();
+      expect(() =>
+        policy.assertSellerTransition(
+          OrderStatus.CONFIRMED,
+          OrderStatus.PICKED_UP,
+        ),
+      ).toThrow(BadRequestException);
+    });
+
+    it('CANCELED는 SUBMITTED/CONFIRMED/MADE에서 가능, PICKED_UP에서는 불가', () => {
+      expect(() =>
+        policy.assertSellerTransition(
+          OrderStatus.SUBMITTED,
+          OrderStatus.CANCELED,
+        ),
+      ).not.toThrow();
+      expect(() =>
+        policy.assertSellerTransition(
+          OrderStatus.CONFIRMED,
+          OrderStatus.CANCELED,
+        ),
+      ).not.toThrow();
+      expect(() =>
+        policy.assertSellerTransition(OrderStatus.MADE, OrderStatus.CANCELED),
+      ).not.toThrow();
+      expect(() =>
+        policy.assertSellerTransition(
+          OrderStatus.PICKED_UP,
+          OrderStatus.CANCELED,
+        ),
+      ).toThrow(BadRequestException);
+    });
+  });
+
+  describe('requiresCancellationNote', () => {
+    it('CANCELED일 때만 true', () => {
+      expect(policy.requiresCancellationNote(OrderStatus.CANCELED)).toBe(true);
+      expect(policy.requiresCancellationNote(OrderStatus.CONFIRMED)).toBe(
+        false,
+      );
+      expect(policy.requiresCancellationNote(OrderStatus.MADE)).toBe(false);
+    });
+  });
+});

--- a/src/features/order/repositories/order.repository.spec.ts
+++ b/src/features/order/repositories/order.repository.spec.ts
@@ -471,7 +471,7 @@ describe('OrderRepository (real DB)', () => {
       expect(histories[0].note).toBe('재고 부족');
     });
 
-    it('PICKED_UP/MADE 각각 대응 시각 컬럼 갱신', async () => {
+    it('CONFIRMED→MADE→PICKED_UP 연속 전이 시 각 타임스탬프 컬럼이 누적 기록된다', async () => {
       const store = await createStore(prisma);
       const buyer = await setupBuyer();
       const seller = await createAccount(prisma, { account_type: 'SELLER' });
@@ -506,13 +506,32 @@ describe('OrderRepository (real DB)', () => {
         now: t3,
       });
 
+      expect(picked?.status).toBe('PICKED_UP');
+      expect(picked?.confirmed_at?.toISOString()).toBe(t1.toISOString());
       expect(picked?.made_at?.toISOString()).toBe(t2.toISOString());
       expect(picked?.picked_up_at?.toISOString()).toBe(t3.toISOString());
 
-      const pickedNotif = await prisma.notification.findFirst({
-        where: { order_id: order.id, event: 'ORDER_PICKED_UP' },
+      const histories = await prisma.orderStatusHistory.findMany({
+        where: { order_id: order.id },
+        orderBy: { changed_at: 'asc' },
       });
-      expect(pickedNotif).not.toBeNull();
+      expect(histories.map((h) => h.to_status)).toEqual([
+        'CONFIRMED',
+        'MADE',
+        'PICKED_UP',
+      ]);
+
+      const notifEvents = (
+        await prisma.notification.findMany({
+          where: { order_id: order.id },
+          orderBy: { id: 'asc' },
+        })
+      ).map((n) => n.event);
+      expect(notifEvents).toEqual([
+        'ORDER_CONFIRMED',
+        'ORDER_MADE',
+        'ORDER_PICKED_UP',
+      ]);
     });
   });
 });

--- a/src/features/order/repositories/order.repository.spec.ts
+++ b/src/features/order/repositories/order.repository.spec.ts
@@ -1,0 +1,518 @@
+import type { PrismaClient } from '@prisma/client';
+import { OrderStatus } from '@prisma/client';
+
+import { OrderRepository } from '@/features/order/repositories/order.repository';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createOrder,
+  createOrderItem,
+  createProduct,
+  createStore,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('OrderRepository (real DB)', () => {
+  let repo: OrderRepository;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [OrderRepository],
+    });
+    repo = module.get(OrderRepository);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  async function setupBuyer() {
+    return createAccount(prisma, { account_type: 'USER' });
+  }
+
+  describe('findOngoingOrdersByAccount', () => {
+    it('SUBMITTED/CONFIRMED/MADE 상태 주문만 since 이후로 반환하고 PICKED_UP/CANCELED 제외', async () => {
+      const buyer = await setupBuyer();
+      const since = new Date('2026-01-01');
+
+      const o1 = await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'SUBMITTED',
+      });
+      await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'PICKED_UP',
+      });
+      await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'CANCELED',
+      });
+      const o4 = await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'CONFIRMED',
+      });
+
+      const rows = await repo.findOngoingOrdersByAccount({
+        accountId: buyer.id,
+        since,
+        limit: 10,
+      });
+      expect(rows.map((r) => r.id).sort()).toEqual([o1.id, o4.id].sort());
+    });
+
+    it('since 이전에 생성된 주문은 제외한다', async () => {
+      const buyer = await setupBuyer();
+      const oldOrder = await prisma.order.create({
+        data: {
+          account_id: buyer.id,
+          order_number: 'OLD-1',
+          status: 'SUBMITTED',
+          pickup_at: new Date(),
+          buyer_name: 'x',
+          buyer_phone: '010-0000-0000',
+          subtotal_price: 0,
+          discount_price: 0,
+          total_price: 0,
+          created_at: new Date('2025-01-01'),
+        },
+      });
+      await createOrder(prisma, { account_id: buyer.id, status: 'SUBMITTED' });
+
+      const rows = await repo.findOngoingOrdersByAccount({
+        accountId: buyer.id,
+        since: new Date('2026-01-01'),
+        limit: 10,
+      });
+      expect(rows.map((r) => r.id)).not.toContain(oldOrder.id);
+    });
+
+    it('첫 item + 첫 image까지 포함하여 반환', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await prisma.productImage.create({
+        data: {
+          product_id: product.id,
+          image_url: 'https://i.example/1.png',
+          sort_order: 0,
+        },
+      });
+      const order = await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'SUBMITTED',
+      });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        product_id: product.id,
+        product_name_snapshot: '케이크',
+      });
+
+      const rows = await repo.findOngoingOrdersByAccount({
+        accountId: buyer.id,
+        since: new Date('2026-01-01'),
+        limit: 10,
+      });
+      expect(rows[0].items).toHaveLength(1);
+      expect(rows[0].items[0].product_name_snapshot).toBe('케이크');
+      expect(rows[0].items[0].product.images).toHaveLength(1);
+    });
+  });
+
+  describe('findOrdersByAccount / countOrdersByAccount', () => {
+    it('statuses 필터 + offset/limit + 내림차순', async () => {
+      const buyer = await setupBuyer();
+      for (let i = 0; i < 4; i++) {
+        await createOrder(prisma, {
+          account_id: buyer.id,
+          status: i % 2 === 0 ? 'SUBMITTED' : 'PICKED_UP',
+        });
+      }
+
+      const count = await repo.countOrdersByAccount({
+        accountId: buyer.id,
+        statuses: [OrderStatus.SUBMITTED],
+      });
+      expect(count).toBe(2);
+
+      const rows = await repo.findOrdersByAccount({
+        accountId: buyer.id,
+        statuses: [OrderStatus.SUBMITTED],
+        offset: 0,
+        limit: 10,
+      });
+      expect(rows).toHaveLength(2);
+      expect(rows.every((r) => r.status === 'SUBMITTED')).toBe(true);
+    });
+
+    it('statuses 없으면 전체 반환', async () => {
+      const buyer = await setupBuyer();
+      for (let i = 0; i < 3; i++)
+        await createOrder(prisma, { account_id: buyer.id });
+
+      const count = await repo.countOrdersByAccount({ accountId: buyer.id });
+      expect(count).toBe(3);
+    });
+
+    it('_count.items는 soft-deleted item을 제외한다', async () => {
+      const buyer = await setupBuyer();
+      const order = await createOrder(prisma, { account_id: buyer.id });
+      await createOrderItem(prisma, { order_id: order.id });
+      const deletedItem = await createOrderItem(prisma, { order_id: order.id });
+      await prisma.orderItem.update({
+        where: { id: deletedItem.id },
+        data: { deleted_at: new Date() },
+      });
+
+      const rows = await repo.findOrdersByAccount({
+        accountId: buyer.id,
+        offset: 0,
+        limit: 10,
+      });
+      expect(rows[0]._count.items).toBe(1);
+    });
+  });
+
+  describe('findOrderDetailByAccount', () => {
+    it('본인 주문이면 상세 반환 (status_histories 포함)', async () => {
+      const buyer = await setupBuyer();
+      const order = await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'CONFIRMED',
+      });
+      await prisma.orderStatusHistory.create({
+        data: {
+          order_id: order.id,
+          from_status: 'SUBMITTED',
+          to_status: 'CONFIRMED',
+          changed_at: new Date(),
+          note: '확정',
+        },
+      });
+
+      const detail = await repo.findOrderDetailByAccount({
+        orderId: order.id,
+        accountId: buyer.id,
+      });
+      expect(detail?.id).toBe(order.id);
+      expect(detail?.status_histories).toHaveLength(1);
+    });
+
+    it('다른 계정 주문은 null', async () => {
+      const me = await setupBuyer();
+      const other = await setupBuyer();
+      const othersOrder = await createOrder(prisma, { account_id: other.id });
+
+      const detail = await repo.findOrderDetailByAccount({
+        orderId: othersOrder.id,
+        accountId: me.id,
+      });
+      expect(detail).toBeNull();
+    });
+  });
+
+  describe('listOrdersByStore', () => {
+    it('해당 store item을 포함한 주문만 반환', async () => {
+      const storeA = await createStore(prisma);
+      const storeB = await createStore(prisma);
+      const buyer = await setupBuyer();
+
+      const orderA = await createOrder(prisma, { account_id: buyer.id });
+      await createOrderItem(prisma, {
+        order_id: orderA.id,
+        store_id: storeA.id,
+      });
+
+      const orderB = await createOrder(prisma, { account_id: buyer.id });
+      await createOrderItem(prisma, {
+        order_id: orderB.id,
+        store_id: storeB.id,
+      });
+
+      const rows = await repo.listOrdersByStore({
+        storeId: storeA.id,
+        limit: 10,
+      });
+      expect(rows.map((r) => r.id)).toEqual([orderA.id]);
+    });
+
+    it('search는 order_number/buyer_name/buyer_phone 에서 contains 매칭', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const o1 = await createOrder(prisma, {
+        account_id: buyer.id,
+        order_number: 'ORD-ABC-1',
+        buyer_name: '홍길동',
+      });
+      await createOrderItem(prisma, { order_id: o1.id, store_id: store.id });
+      const o2 = await createOrder(prisma, {
+        account_id: buyer.id,
+        order_number: 'ORD-XYZ-2',
+        buyer_name: '김철수',
+      });
+      await createOrderItem(prisma, { order_id: o2.id, store_id: store.id });
+
+      const rows = await repo.listOrdersByStore({
+        storeId: store.id,
+        limit: 10,
+        search: 'ABC',
+      });
+      expect(rows.map((r) => r.id)).toEqual([o1.id]);
+
+      const byBuyer = await repo.listOrdersByStore({
+        storeId: store.id,
+        limit: 10,
+        search: '김철수',
+      });
+      expect(byBuyer.map((r) => r.id)).toEqual([o2.id]);
+    });
+
+    it('fromCreatedAt/toCreatedAt/status 필터가 조합된다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const inside = await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'SUBMITTED',
+      });
+      await createOrderItem(prisma, {
+        order_id: inside.id,
+        store_id: store.id,
+      });
+
+      const outside = await prisma.order.create({
+        data: {
+          account_id: buyer.id,
+          order_number: 'OLD-1',
+          status: 'SUBMITTED',
+          pickup_at: new Date(),
+          buyer_name: 'x',
+          buyer_phone: '010-0000-0000',
+          subtotal_price: 0,
+          discount_price: 0,
+          total_price: 0,
+          created_at: new Date('2025-01-01'),
+        },
+      });
+      await createOrderItem(prisma, {
+        order_id: outside.id,
+        store_id: store.id,
+      });
+
+      const rows = await repo.listOrdersByStore({
+        storeId: store.id,
+        limit: 10,
+        status: OrderStatus.SUBMITTED,
+        fromCreatedAt: new Date('2026-01-01'),
+      });
+      expect(rows.map((r) => r.id)).toEqual([inside.id]);
+    });
+
+    it('cursor 기반 페이지네이션 (id < cursor)', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const o1 = await createOrder(prisma, { account_id: buyer.id });
+      await createOrderItem(prisma, { order_id: o1.id, store_id: store.id });
+      const o2 = await createOrder(prisma, { account_id: buyer.id });
+      await createOrderItem(prisma, { order_id: o2.id, store_id: store.id });
+
+      const rows = await repo.listOrdersByStore({
+        storeId: store.id,
+        limit: 10,
+        cursor: o2.id,
+      });
+      expect(rows.map((r) => r.id)).toEqual([o1.id]);
+    });
+  });
+
+  describe('findOrderDetailByStore', () => {
+    it('해당 store item만 items로 포함 (다른 store item 제외)', async () => {
+      const storeA = await createStore(prisma);
+      const storeB = await createStore(prisma);
+      const buyer = await setupBuyer();
+      const order = await createOrder(prisma, { account_id: buyer.id });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        store_id: storeA.id,
+      });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        store_id: storeB.id,
+      });
+
+      const detail = await repo.findOrderDetailByStore({
+        orderId: order.id,
+        storeId: storeA.id,
+      });
+      expect(detail?.items).toHaveLength(1);
+      expect(detail?.items[0].store_id).toBe(storeA.id);
+    });
+
+    it('해당 store item이 없는 주문이면 null', async () => {
+      const storeA = await createStore(prisma);
+      const storeB = await createStore(prisma);
+      const buyer = await setupBuyer();
+      const order = await createOrder(prisma, { account_id: buyer.id });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        store_id: storeB.id,
+      });
+
+      const detail = await repo.findOrderDetailByStore({
+        orderId: order.id,
+        storeId: storeA.id,
+      });
+      expect(detail).toBeNull();
+    });
+  });
+
+  describe('updateOrderStatusBySeller', () => {
+    async function setupOrderForStore(storeId: bigint, buyerId: bigint) {
+      const order = await createOrder(prisma, {
+        account_id: buyerId,
+        status: 'SUBMITTED',
+      });
+      await createOrderItem(prisma, { order_id: order.id, store_id: storeId });
+      return order;
+    }
+
+    it('다른 store의 주문이면 null 반환 (update 미수행)', async () => {
+      const storeA = await createStore(prisma);
+      const storeB = await createStore(prisma);
+      const buyer = await setupBuyer();
+      const order = await setupOrderForStore(storeA.id, buyer.id);
+      const seller = await createAccount(prisma, { account_type: 'SELLER' });
+
+      const result = await repo.updateOrderStatusBySeller({
+        orderId: order.id,
+        storeId: storeB.id,
+        actorAccountId: seller.id,
+        toStatus: OrderStatus.CONFIRMED,
+        note: null,
+        now: new Date(),
+      });
+      expect(result).toBeNull();
+    });
+
+    it('CONFIRMED 전환: status + confirmed_at 갱신 + status_history + notification + auditLog 생성', async () => {
+      const store = await createStore(prisma);
+      const buyer = await setupBuyer();
+      const order = await setupOrderForStore(store.id, buyer.id);
+      const seller = await createAccount(prisma, { account_type: 'SELLER' });
+      const now = new Date('2026-04-22T10:00:00Z');
+
+      const updated = await repo.updateOrderStatusBySeller({
+        orderId: order.id,
+        storeId: store.id,
+        actorAccountId: seller.id,
+        toStatus: OrderStatus.CONFIRMED,
+        note: null,
+        now,
+      });
+
+      expect(updated?.status).toBe('CONFIRMED');
+      expect(updated?.confirmed_at?.toISOString()).toBe(now.toISOString());
+
+      const histories = await prisma.orderStatusHistory.findMany({
+        where: { order_id: order.id },
+      });
+      expect(histories).toHaveLength(1);
+      expect(histories[0].from_status).toBe('SUBMITTED');
+      expect(histories[0].to_status).toBe('CONFIRMED');
+
+      const notifications = await prisma.notification.findMany({
+        where: { order_id: order.id },
+      });
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0].event).toBe('ORDER_CONFIRMED');
+      expect(notifications[0].account_id).toBe(buyer.id);
+
+      const auditLogs = await prisma.auditLog.findMany({
+        where: { target_id: order.id, target_type: 'ORDER' },
+      });
+      expect(auditLogs).toHaveLength(1);
+      expect(auditLogs[0].action).toBe('STATUS_CHANGE');
+    });
+
+    it('CANCELED 전환: canceled_at 갱신되고 notification은 생성 안됨', async () => {
+      const store = await createStore(prisma);
+      const buyer = await setupBuyer();
+      const order = await setupOrderForStore(store.id, buyer.id);
+      const seller = await createAccount(prisma, { account_type: 'SELLER' });
+      const now = new Date('2026-04-22T10:00:00Z');
+
+      const updated = await repo.updateOrderStatusBySeller({
+        orderId: order.id,
+        storeId: store.id,
+        actorAccountId: seller.id,
+        toStatus: OrderStatus.CANCELED,
+        note: '재고 부족',
+        now,
+      });
+
+      expect(updated?.status).toBe('CANCELED');
+      expect(updated?.canceled_at?.toISOString()).toBe(now.toISOString());
+
+      // CANCELED는 notification 매핑 없음
+      const notifications = await prisma.notification.findMany({
+        where: { order_id: order.id },
+      });
+      expect(notifications).toHaveLength(0);
+
+      const histories = await prisma.orderStatusHistory.findMany({
+        where: { order_id: order.id },
+      });
+      expect(histories[0].note).toBe('재고 부족');
+    });
+
+    it('PICKED_UP/MADE 각각 대응 시각 컬럼 갱신', async () => {
+      const store = await createStore(prisma);
+      const buyer = await setupBuyer();
+      const seller = await createAccount(prisma, { account_type: 'SELLER' });
+
+      const order = await setupOrderForStore(store.id, buyer.id);
+      const t1 = new Date('2026-04-22T10:00:00Z');
+      const t2 = new Date('2026-04-22T11:00:00Z');
+      const t3 = new Date('2026-04-22T12:00:00Z');
+
+      await repo.updateOrderStatusBySeller({
+        orderId: order.id,
+        storeId: store.id,
+        actorAccountId: seller.id,
+        toStatus: OrderStatus.CONFIRMED,
+        note: null,
+        now: t1,
+      });
+      await repo.updateOrderStatusBySeller({
+        orderId: order.id,
+        storeId: store.id,
+        actorAccountId: seller.id,
+        toStatus: OrderStatus.MADE,
+        note: null,
+        now: t2,
+      });
+      const picked = await repo.updateOrderStatusBySeller({
+        orderId: order.id,
+        storeId: store.id,
+        actorAccountId: seller.id,
+        toStatus: OrderStatus.PICKED_UP,
+        note: null,
+        now: t3,
+      });
+
+      expect(picked?.made_at?.toISOString()).toBe(t2.toISOString());
+      expect(picked?.picked_up_at?.toISOString()).toBe(t3.toISOString());
+
+      const pickedNotif = await prisma.notification.findFirst({
+        where: { order_id: order.id, event: 'ORDER_PICKED_UP' },
+      });
+      expect(pickedNotif).not.toBeNull();
+    });
+  });
+});

--- a/src/features/order/services/order-domain.service.spec.ts
+++ b/src/features/order/services/order-domain.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { OrderStatus } from '@prisma/client';
 
 import { OrderStatusTransitionPolicy } from '@/features/order/policies/order-status-transition.policy';
@@ -11,10 +12,10 @@ describe('OrderDomainService', () => {
     expect(service.parseStatus('CONFIRMED')).toBe(OrderStatus.CONFIRMED);
   });
 
-  it('assertSellerTransition은 policy에 위임하여 예외를 전파한다', () => {
+  it('assertSellerTransition은 policy에 위임하여 BadRequestException을 전파한다', () => {
     expect(() =>
       service.assertSellerTransition(OrderStatus.SUBMITTED, OrderStatus.MADE),
-    ).toThrow();
+    ).toThrow(BadRequestException);
   });
 
   it('requiresCancellationNote는 policy 결과를 그대로 반환한다', () => {

--- a/src/features/order/services/order-domain.service.spec.ts
+++ b/src/features/order/services/order-domain.service.spec.ts
@@ -1,0 +1,24 @@
+import { OrderStatus } from '@prisma/client';
+
+import { OrderStatusTransitionPolicy } from '@/features/order/policies/order-status-transition.policy';
+import { OrderDomainService } from '@/features/order/services/order-domain.service';
+
+describe('OrderDomainService', () => {
+  const policy = new OrderStatusTransitionPolicy();
+  const service = new OrderDomainService(policy);
+
+  it('parseStatus는 policy.parse에 위임한다', () => {
+    expect(service.parseStatus('CONFIRMED')).toBe(OrderStatus.CONFIRMED);
+  });
+
+  it('assertSellerTransition은 policy에 위임하여 예외를 전파한다', () => {
+    expect(() =>
+      service.assertSellerTransition(OrderStatus.SUBMITTED, OrderStatus.MADE),
+    ).toThrow();
+  });
+
+  it('requiresCancellationNote는 policy 결과를 그대로 반환한다', () => {
+    expect(service.requiresCancellationNote(OrderStatus.CANCELED)).toBe(true);
+    expect(service.requiresCancellationNote(OrderStatus.SUBMITTED)).toBe(false);
+  });
+});

--- a/src/features/product/repositories/product.repository.spec.ts
+++ b/src/features/product/repositories/product.repository.spec.ts
@@ -1,0 +1,645 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createProduct, createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('ProductRepository (real DB)', () => {
+  let repo: ProductRepository;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ProductRepository],
+    });
+    repo = module.get(ProductRepository);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  async function createCategory(name = '생일') {
+    return prisma.category.create({
+      data: { name, category_type: 'EVENT' },
+    });
+  }
+
+  async function createTag(name = '레터링') {
+    return prisma.tag.create({ data: { name } });
+  }
+
+  async function createOptionGroup(productId: bigint, sortOrder = 0) {
+    return prisma.productOptionGroup.create({
+      data: { product_id: productId, name: '사이즈', sort_order: sortOrder },
+    });
+  }
+
+  async function createOptionItem(optionGroupId: bigint, sortOrder = 0) {
+    return prisma.productOptionItem.create({
+      data: {
+        option_group_id: optionGroupId,
+        title: 'T',
+        sort_order: sortOrder,
+      },
+    });
+  }
+
+  async function createTemplate(productId: bigint) {
+    return prisma.productCustomTemplate.create({
+      data: {
+        product_id: productId,
+        base_image_url: 'https://i.example/base.png',
+      },
+    });
+  }
+
+  // ─── Product list/fetch ──
+  describe('listProductsByStore', () => {
+    it('store_id 필터 + cursor 페이지네이션', async () => {
+      const storeA = await createStore(prisma);
+      const storeB = await createStore(prisma);
+      const p1 = await createProduct(prisma, { store_id: storeA.id });
+      const p2 = await createProduct(prisma, { store_id: storeA.id });
+      await createProduct(prisma, { store_id: storeB.id });
+
+      const rows = await repo.listProductsByStore({
+        storeId: storeA.id,
+        limit: 10,
+      });
+      expect(rows.map((r) => r.id).sort()).toEqual([p1.id, p2.id].sort());
+
+      const page2 = await repo.listProductsByStore({
+        storeId: storeA.id,
+        limit: 10,
+        cursor: p2.id,
+      });
+      expect(page2.map((r) => r.id)).toEqual([p1.id]);
+    });
+
+    it('isActive 필터', async () => {
+      const store = await createStore(prisma);
+      await createProduct(prisma, { store_id: store.id, is_active: true });
+      await createProduct(prisma, { store_id: store.id, is_active: false });
+
+      const active = await repo.listProductsByStore({
+        storeId: store.id,
+        limit: 10,
+        isActive: true,
+      });
+      expect(active).toHaveLength(1);
+      expect(active[0].is_active).toBe(true);
+    });
+
+    it('categoryId 필터: product_categories join', async () => {
+      const store = await createStore(prisma);
+      const cat = await createCategory();
+      const pInCat = await createProduct(prisma, { store_id: store.id });
+      await createProduct(prisma, { store_id: store.id });
+      await prisma.productCategory.create({
+        data: { product_id: pInCat.id, category_id: cat.id },
+      });
+
+      const rows = await repo.listProductsByStore({
+        storeId: store.id,
+        limit: 10,
+        categoryId: cat.id,
+      });
+      expect(rows.map((r) => r.id)).toEqual([pInCat.id]);
+    });
+
+    it('search: 이름 또는 태그 이름 contains 매칭', async () => {
+      const store = await createStore(prisma);
+      const pByName = await createProduct(prisma, {
+        store_id: store.id,
+        name: '바닐라 케이크',
+      });
+      const pByTag = await createProduct(prisma, {
+        store_id: store.id,
+        name: '다른 이름',
+      });
+      const tag = await createTag('레터링');
+      await prisma.productTag.create({
+        data: { product_id: pByTag.id, tag_id: tag.id },
+      });
+
+      const byName = await repo.listProductsByStore({
+        storeId: store.id,
+        limit: 10,
+        search: '바닐라',
+      });
+      expect(byName.map((r) => r.id)).toEqual([pByName.id]);
+
+      const byTag = await repo.listProductsByStore({
+        storeId: store.id,
+        limit: 10,
+        search: '레터링',
+      });
+      expect(byTag.map((r) => r.id)).toEqual([pByTag.id]);
+    });
+
+    it('include는 images/categories/tags/option_groups(items)/custom_template(text_tokens)까지 로딩', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await prisma.productImage.create({
+        data: {
+          product_id: product.id,
+          image_url: 'https://i.example/1.png',
+          sort_order: 0,
+        },
+      });
+      const cat = await createCategory();
+      await prisma.productCategory.create({
+        data: { product_id: product.id, category_id: cat.id },
+      });
+      const tag = await createTag();
+      await prisma.productTag.create({
+        data: { product_id: product.id, tag_id: tag.id },
+      });
+      const group = await createOptionGroup(product.id);
+      await createOptionItem(group.id);
+      const tpl = await createTemplate(product.id);
+      await prisma.productCustomTextToken.create({
+        data: { template_id: tpl.id, token_key: 'K', default_text: 'V' },
+      });
+
+      const rows = await repo.listProductsByStore({
+        storeId: store.id,
+        limit: 10,
+      });
+      const row = rows[0];
+      expect(row.images).toHaveLength(1);
+      expect(row.product_categories[0].category.name).toBe('생일');
+      expect(row.product_tags[0].tag.name).toBe('레터링');
+      expect(row.option_groups[0].option_items).toHaveLength(1);
+      expect(row.custom_template?.text_tokens).toHaveLength(1);
+    });
+  });
+
+  describe('findProductById (active만)', () => {
+    it('is_active: false면 반환 안함', async () => {
+      const store = await createStore(prisma);
+      const inactive = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: false,
+      });
+      const result = await repo.findProductById({
+        productId: inactive.id,
+        storeId: store.id,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('store_id 불일치면 null', async () => {
+      const storeA = await createStore(prisma);
+      const storeB = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: storeA.id });
+
+      const result = await repo.findProductById({
+        productId: product.id,
+        storeId: storeB.id,
+      });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findProductByIdIncludingInactive', () => {
+    it('inactive 상품도 반환', async () => {
+      const store = await createStore(prisma);
+      const inactive = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: false,
+      });
+      const result = await repo.findProductByIdIncludingInactive({
+        productId: inactive.id,
+        storeId: store.id,
+      });
+      expect(result?.id).toBe(inactive.id);
+    });
+  });
+
+  // ─── Product CRUD ──
+  describe('createProduct / updateProduct / softDeleteProduct', () => {
+    it('createProduct는 store_id를 결합하여 생성', async () => {
+      const store = await createStore(prisma);
+      const result = await repo.createProduct({
+        storeId: store.id,
+        data: {
+          name: '신상',
+          regular_price: 10000,
+          currency: 'KRW',
+          is_active: true,
+        },
+      });
+      expect(result.store_id).toBe(store.id);
+      expect(result.name).toBe('신상');
+    });
+
+    it('updateProduct는 주어진 필드만 갱신', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, {
+        store_id: store.id,
+        name: '구',
+      });
+      const result = await repo.updateProduct({
+        productId: product.id,
+        data: { name: '신' },
+      });
+      expect(result.name).toBe('신');
+    });
+
+    it('softDeleteProduct는 deleted_at + is_active:false', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await repo.softDeleteProduct(product.id);
+
+      const after = await prisma.product.findUnique({
+        where: { id: product.id },
+      });
+      expect(after?.deleted_at).not.toBeNull();
+      expect(after?.is_active).toBe(false);
+    });
+  });
+
+  // ─── Images ──
+  describe('Product images', () => {
+    it('countProductImages + addProductImage + listProductImages', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+
+      expect(await repo.countProductImages(product.id)).toBe(0);
+      await repo.addProductImage({
+        productId: product.id,
+        imageUrl: 'https://i.example/1.png',
+        sortOrder: 0,
+      });
+      expect(await repo.countProductImages(product.id)).toBe(1);
+
+      const list = await repo.listProductImages(product.id);
+      expect(list).toHaveLength(1);
+    });
+
+    it('findProductImageById + softDeleteProductImage', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const image = await prisma.productImage.create({
+        data: {
+          product_id: product.id,
+          image_url: 'https://i.example/a.png',
+          sort_order: 0,
+        },
+      });
+
+      const found = await repo.findProductImageById(image.id);
+      expect(found?.product.store_id).toBe(store.id);
+
+      await repo.softDeleteProductImage(image.id);
+      const after = await prisma.productImage.findUnique({
+        where: { id: image.id },
+      });
+      expect(after?.deleted_at).not.toBeNull();
+    });
+
+    it('reorderProductImages: sort_order 재할당 (트랜잭션)', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const img1 = await prisma.productImage.create({
+        data: { product_id: product.id, image_url: 'a', sort_order: 0 },
+      });
+      const img2 = await prisma.productImage.create({
+        data: { product_id: product.id, image_url: 'b', sort_order: 1 },
+      });
+      const img3 = await prisma.productImage.create({
+        data: { product_id: product.id, image_url: 'c', sort_order: 2 },
+      });
+
+      const result = await repo.reorderProductImages({
+        productId: product.id,
+        imageIds: [img3.id, img1.id, img2.id],
+      });
+      expect(result.map((r) => r.id)).toEqual([img3.id, img1.id, img2.id]);
+    });
+  });
+
+  // ─── Category / Tag ──
+  describe('findCategoryIds / findTagIds / replaceProduct*', () => {
+    it('findCategoryIds는 존재하는 id만 반환', async () => {
+      const cat = await createCategory();
+      const result = await repo.findCategoryIds([cat.id, BigInt(999999)]);
+      expect(result.map((r) => r.id)).toEqual([cat.id]);
+    });
+
+    it('findTagIds는 존재하는 id만 반환', async () => {
+      const tag = await createTag();
+      const result = await repo.findTagIds([tag.id, BigInt(999999)]);
+      expect(result.map((r) => r.id)).toEqual([tag.id]);
+    });
+
+    it('replaceProductCategories: 기존 관계 제거 후 신규 생성', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const cat1 = await createCategory('A');
+      const cat2 = await createCategory('B');
+
+      await repo.replaceProductCategories({
+        productId: product.id,
+        categoryIds: [cat1.id],
+      });
+      let rows = await prisma.productCategory.findMany({
+        where: { product_id: product.id },
+      });
+      expect(rows.map((r) => r.category_id)).toEqual([cat1.id]);
+
+      // 교체
+      await repo.replaceProductCategories({
+        productId: product.id,
+        categoryIds: [cat2.id],
+      });
+      rows = await prisma.productCategory.findMany({
+        where: { product_id: product.id },
+      });
+      expect(rows.map((r) => r.category_id)).toEqual([cat2.id]);
+
+      // 빈 배열: 전부 제거
+      await repo.replaceProductCategories({
+        productId: product.id,
+        categoryIds: [],
+      });
+      rows = await prisma.productCategory.findMany({
+        where: { product_id: product.id },
+      });
+      expect(rows).toHaveLength(0);
+    });
+
+    it('replaceProductTags: 교체 동작', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const t1 = await createTag('A');
+      const t2 = await createTag('B');
+
+      await repo.replaceProductTags({
+        productId: product.id,
+        tagIds: [t1.id, t2.id],
+      });
+      const rows = await prisma.productTag.findMany({
+        where: { product_id: product.id },
+      });
+      expect(rows).toHaveLength(2);
+    });
+  });
+
+  // ─── OptionGroup / OptionItem ──
+  describe('Option group/item', () => {
+    it('createOptionGroup + findOptionGroupById(product.store_id 포함)', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+
+      const group = await repo.createOptionGroup({
+        productId: product.id,
+        data: { name: '사이즈' },
+      });
+
+      const found = await repo.findOptionGroupById(group.id);
+      expect(found?.product.store_id).toBe(store.id);
+    });
+
+    it('updateOptionGroup은 option_items include 포함', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const group = await createOptionGroup(product.id);
+      await createOptionItem(group.id);
+
+      const result = await repo.updateOptionGroup({
+        optionGroupId: group.id,
+        data: { name: '새 이름' },
+      });
+      expect(result.name).toBe('새 이름');
+      expect(result.option_items).toHaveLength(1);
+    });
+
+    it('softDeleteOptionGroup: deleted_at + is_active:false', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const group = await createOptionGroup(product.id);
+
+      await repo.softDeleteOptionGroup(group.id);
+      const after = await prisma.productOptionGroup.findUnique({
+        where: { id: group.id },
+      });
+      expect(after?.deleted_at).not.toBeNull();
+      expect(after?.is_active).toBe(false);
+    });
+
+    it('listOptionGroupsByProduct: sort_order 오름차순', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const g2 = await prisma.productOptionGroup.create({
+        data: { product_id: product.id, name: 'B', sort_order: 1 },
+      });
+      const g1 = await prisma.productOptionGroup.create({
+        data: { product_id: product.id, name: 'A', sort_order: 0 },
+      });
+
+      const rows = await repo.listOptionGroupsByProduct(product.id);
+      expect(rows.map((r) => r.id)).toEqual([g1.id, g2.id]);
+    });
+
+    it('reorderOptionGroups (트랜잭션): sort_order 재할당', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const g1 = await createOptionGroup(product.id, 0);
+      const g2 = await createOptionGroup(product.id, 1);
+
+      const rows = await repo.reorderOptionGroups({
+        productId: product.id,
+        optionGroupIds: [g2.id, g1.id],
+      });
+      expect(rows.map((r) => r.id)).toEqual([g2.id, g1.id]);
+    });
+
+    it('OptionItem CRUD + findOptionItemById(store_id 경유) + softDelete + reorder', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const group = await createOptionGroup(product.id);
+
+      const item = await repo.createOptionItem({
+        optionGroupId: group.id,
+        data: { title: 'L' },
+      });
+
+      const found = await repo.findOptionItemById(item.id);
+      expect(found?.option_group.product.store_id).toBe(store.id);
+
+      const updated = await repo.updateOptionItem({
+        optionItemId: item.id,
+        data: { title: 'XL' },
+      });
+      expect(updated.title).toBe('XL');
+
+      const item2 = await createOptionItem(group.id, 1);
+      const reordered = await repo.reorderOptionItems({
+        optionGroupId: group.id,
+        optionItemIds: [item2.id, item.id],
+      });
+      expect(reordered.map((r) => r.id)).toEqual([item2.id, item.id]);
+
+      await repo.softDeleteOptionItem(item.id);
+      const after = await prisma.productOptionItem.findUnique({
+        where: { id: item.id },
+      });
+      expect(after?.deleted_at).not.toBeNull();
+      expect(after?.is_active).toBe(false);
+    });
+  });
+
+  // ─── Custom Template / Text Token ──
+  describe('Custom template / text token', () => {
+    it('upsertProductCustomTemplate: 동일 product_id 재호출 시 같은 row 갱신', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+
+      const first = await repo.upsertProductCustomTemplate({
+        productId: product.id,
+        baseImageUrl: 'https://i.example/a.png',
+        isActive: true,
+      });
+      const second = await repo.upsertProductCustomTemplate({
+        productId: product.id,
+        baseImageUrl: 'https://i.example/b.png',
+        isActive: false,
+      });
+      expect(second.id).toBe(first.id);
+      expect(second.base_image_url).toBe('https://i.example/b.png');
+      expect(second.is_active).toBe(false);
+    });
+
+    it('findCustomTemplateById + setCustomTemplateActive', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const tpl = await createTemplate(product.id);
+
+      const found = await repo.findCustomTemplateById(tpl.id);
+      expect(found?.product.store_id).toBe(store.id);
+
+      const toggled = await repo.setCustomTemplateActive(tpl.id, false);
+      expect(toggled.is_active).toBe(false);
+    });
+
+    it('upsertCustomTextToken: tokenId 없으면 create, 있으면 update', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const tpl = await createTemplate(product.id);
+
+      const created = await repo.upsertCustomTextToken({
+        templateId: tpl.id,
+        tokenKey: 'NAME',
+        defaultText: '가',
+        maxLength: 30,
+        sortOrder: 0,
+        isRequired: true,
+        posX: 10,
+        posY: 20,
+        width: 100,
+        height: 50,
+      });
+      expect(created.token_key).toBe('NAME');
+
+      const updated = await repo.upsertCustomTextToken({
+        tokenId: created.id,
+        templateId: tpl.id,
+        tokenKey: 'NAME2',
+        defaultText: '나',
+        maxLength: 40,
+        sortOrder: 0,
+        isRequired: false,
+        posX: null,
+        posY: null,
+        width: null,
+        height: null,
+      });
+      expect(updated.id).toBe(created.id);
+      expect(updated.token_key).toBe('NAME2');
+    });
+
+    it('findCustomTextTokenById (template 경유 store_id 확인용 include)', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const tpl = await createTemplate(product.id);
+      const token = await prisma.productCustomTextToken.create({
+        data: { template_id: tpl.id, token_key: 'K', default_text: 'V' },
+      });
+
+      const found = await repo.findCustomTextTokenById(token.id);
+      expect(found?.template.product.store_id).toBe(store.id);
+    });
+
+    it('softDeleteCustomTextToken + listCustomTextTokens + reorder', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const tpl = await createTemplate(product.id);
+      const t1 = await prisma.productCustomTextToken.create({
+        data: { template_id: tpl.id, token_key: 'A', default_text: 'a' },
+      });
+      const t2 = await prisma.productCustomTextToken.create({
+        data: { template_id: tpl.id, token_key: 'B', default_text: 'b' },
+      });
+
+      const reordered = await repo.reorderCustomTextTokens({
+        templateId: tpl.id,
+        tokenIds: [t2.id, t1.id],
+      });
+      expect(reordered.map((r) => r.id)).toEqual([t2.id, t1.id]);
+
+      await repo.softDeleteCustomTextToken(t1.id);
+      const after = await prisma.productCustomTextToken.findUnique({
+        where: { id: t1.id },
+      });
+      expect(after?.deleted_at).not.toBeNull();
+    });
+  });
+
+  // ─── Misc ownership ──
+  describe('findActiveProduct / findProductOwnership', () => {
+    it('findActiveProduct는 is_active:true만 반환', async () => {
+      const store = await createStore(prisma);
+      const active = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: true,
+      });
+      const inactive = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: false,
+      });
+
+      expect(await repo.findActiveProduct(active.id)).not.toBeNull();
+      expect(await repo.findActiveProduct(inactive.id)).toBeNull();
+    });
+
+    it('findProductOwnership: productId+storeId 조합 확인', async () => {
+      const storeA = await createStore(prisma);
+      const storeB = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: storeA.id });
+
+      expect(
+        await repo.findProductOwnership({
+          productId: product.id,
+          storeId: storeA.id,
+        }),
+      ).not.toBeNull();
+      expect(
+        await repo.findProductOwnership({
+          productId: product.id,
+          storeId: storeB.id,
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/features/product/repositories/product.repository.spec.ts
+++ b/src/features/product/repositories/product.repository.spec.ts
@@ -243,17 +243,22 @@ describe('ProductRepository (real DB)', () => {
       expect(result.name).toBe('신상');
     });
 
-    it('updateProduct는 주어진 필드만 갱신', async () => {
+    it('updateProduct는 주어진 필드만 갱신하고 나머지는 유지한다', async () => {
       const store = await createStore(prisma);
       const product = await createProduct(prisma, {
         store_id: store.id,
         name: '구',
+        regular_price: 15000,
+        is_active: true,
       });
       const result = await repo.updateProduct({
         productId: product.id,
         data: { name: '신' },
       });
       expect(result.name).toBe('신');
+      expect(result.regular_price).toBe(15000);
+      expect(result.is_active).toBe(true);
+      expect(result.store_id).toBe(store.id);
     });
 
     it('softDeleteProduct는 deleted_at + is_active:false', async () => {
@@ -326,6 +331,17 @@ describe('ProductRepository (real DB)', () => {
         imageIds: [img3.id, img1.id, img2.id],
       });
       expect(result.map((r) => r.id)).toEqual([img3.id, img1.id, img2.id]);
+      // 정렬 결과뿐 아니라 sort_order 값 자체가 0,1,2로 재할당됐는지 확인
+      const sortOrderByImage = new Map(
+        (
+          await prisma.productImage.findMany({
+            where: { product_id: product.id },
+          })
+        ).map((r) => [r.id, r.sort_order]),
+      );
+      expect(sortOrderByImage.get(img3.id)).toBe(0);
+      expect(sortOrderByImage.get(img1.id)).toBe(1);
+      expect(sortOrderByImage.get(img2.id)).toBe(2);
     });
   });
 
@@ -463,6 +479,16 @@ describe('ProductRepository (real DB)', () => {
         optionGroupIds: [g2.id, g1.id],
       });
       expect(rows.map((r) => r.id)).toEqual([g2.id, g1.id]);
+
+      const sortOrderByGroup = new Map(
+        (
+          await prisma.productOptionGroup.findMany({
+            where: { product_id: product.id },
+          })
+        ).map((r) => [r.id, r.sort_order]),
+      );
+      expect(sortOrderByGroup.get(g2.id)).toBe(0);
+      expect(sortOrderByGroup.get(g1.id)).toBe(1);
     });
 
     it('OptionItem CRUD + findOptionItemById(store_id 경유) + softDelete + reorder', async () => {
@@ -490,6 +516,16 @@ describe('ProductRepository (real DB)', () => {
         optionItemIds: [item2.id, item.id],
       });
       expect(reordered.map((r) => r.id)).toEqual([item2.id, item.id]);
+
+      const sortOrderByItem = new Map(
+        (
+          await prisma.productOptionItem.findMany({
+            where: { option_group_id: group.id },
+          })
+        ).map((r) => [r.id, r.sort_order]),
+      );
+      expect(sortOrderByItem.get(item2.id)).toBe(0);
+      expect(sortOrderByItem.get(item.id)).toBe(1);
 
       await repo.softDeleteOptionItem(item.id);
       const after = await prisma.productOptionItem.findUnique({
@@ -581,23 +617,48 @@ describe('ProductRepository (real DB)', () => {
       expect(found?.template.product.store_id).toBe(store.id);
     });
 
-    it('softDeleteCustomTextToken + listCustomTextTokens + reorder', async () => {
+    it('listCustomTextTokens + reorderCustomTextTokens(sort_order 재할당) + softDelete', async () => {
       const store = await createStore(prisma);
       const product = await createProduct(prisma, { store_id: store.id });
       const tpl = await createTemplate(product.id);
       const t1 = await prisma.productCustomTextToken.create({
-        data: { template_id: tpl.id, token_key: 'A', default_text: 'a' },
+        data: {
+          template_id: tpl.id,
+          token_key: 'A',
+          default_text: 'a',
+          sort_order: 0,
+        },
       });
       const t2 = await prisma.productCustomTextToken.create({
-        data: { template_id: tpl.id, token_key: 'B', default_text: 'b' },
+        data: {
+          template_id: tpl.id,
+          token_key: 'B',
+          default_text: 'b',
+          sort_order: 1,
+        },
       });
 
+      // list: 기본 sort_order 오름차순
+      const listed = await repo.listCustomTextTokens(tpl.id);
+      expect(listed.map((r) => r.id)).toEqual([t1.id, t2.id]);
+
+      // reorder: 순서가 뒤집히고 sort_order 값이 0, 1로 재할당됨
       const reordered = await repo.reorderCustomTextTokens({
         templateId: tpl.id,
         tokenIds: [t2.id, t1.id],
       });
       expect(reordered.map((r) => r.id)).toEqual([t2.id, t1.id]);
+      const sortOrderByToken = new Map(
+        (
+          await prisma.productCustomTextToken.findMany({
+            where: { template_id: tpl.id },
+          })
+        ).map((r) => [r.id, r.sort_order]),
+      );
+      expect(sortOrderByToken.get(t2.id)).toBe(0);
+      expect(sortOrderByToken.get(t1.id)).toBe(1);
 
+      // soft-delete
       await repo.softDeleteCustomTextToken(t1.id);
       const after = await prisma.productCustomTextToken.findUnique({
         where: { id: t1.id },

--- a/src/features/system/health.controller.spec.ts
+++ b/src/features/system/health.controller.spec.ts
@@ -17,25 +17,29 @@ describe('HealthController', () => {
     process.env.PROFILE = 'test-profile';
     process.env.PORT = '3001';
 
-    const result = controller.getProfiles();
-    expect(result).toEqual({
-      status: 'ok',
-      profile: 'test-profile',
-      port: '3001',
-    });
-
-    if (originalProfile === undefined) delete process.env.PROFILE;
-    else process.env.PROFILE = originalProfile;
-    if (originalPort === undefined) delete process.env.PORT;
-    else process.env.PORT = originalPort;
+    try {
+      const result = controller.getProfiles();
+      expect(result).toEqual({
+        status: 'ok',
+        profile: 'test-profile',
+        port: '3001',
+      });
+    } finally {
+      if (originalProfile === undefined) delete process.env.PROFILE;
+      else process.env.PROFILE = originalProfile;
+      if (originalPort === undefined) delete process.env.PORT;
+      else process.env.PORT = originalPort;
+    }
   });
 
   it('getProfiles: PROFILE 미설정이면 unknown 폴백', () => {
     const original = process.env.PROFILE;
     delete process.env.PROFILE;
 
-    expect(controller.getProfiles().profile).toBe('unknown');
-
-    if (original !== undefined) process.env.PROFILE = original;
+    try {
+      expect(controller.getProfiles().profile).toBe('unknown');
+    } finally {
+      if (original !== undefined) process.env.PROFILE = original;
+    }
   });
 });

--- a/src/features/system/health.controller.spec.ts
+++ b/src/features/system/health.controller.spec.ts
@@ -1,0 +1,41 @@
+import { HealthController } from '@/features/system/health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(() => {
+    controller = new HealthController();
+  });
+
+  it('getHealth: status:ok를 반환한다', () => {
+    expect(controller.getHealth()).toEqual({ status: 'ok' });
+  });
+
+  it('getProfiles: PROFILE/PORT 환경변수를 응답에 포함한다', () => {
+    const originalProfile = process.env.PROFILE;
+    const originalPort = process.env.PORT;
+    process.env.PROFILE = 'test-profile';
+    process.env.PORT = '3001';
+
+    const result = controller.getProfiles();
+    expect(result).toEqual({
+      status: 'ok',
+      profile: 'test-profile',
+      port: '3001',
+    });
+
+    if (originalProfile === undefined) delete process.env.PROFILE;
+    else process.env.PROFILE = originalProfile;
+    if (originalPort === undefined) delete process.env.PORT;
+    else process.env.PORT = originalPort;
+  });
+
+  it('getProfiles: PROFILE 미설정이면 unknown 폴백', () => {
+    const original = process.env.PROFILE;
+    delete process.env.PROFILE;
+
+    expect(controller.getProfiles().profile).toBe('unknown');
+
+    if (original !== undefined) process.env.PROFILE = original;
+  });
+});

--- a/src/features/system/resolvers/ping.resolver.spec.ts
+++ b/src/features/system/resolvers/ping.resolver.spec.ts
@@ -1,0 +1,8 @@
+import { PingResolver } from '@/features/system/resolvers/ping.resolver';
+
+describe('PingResolver', () => {
+  it('ping Query는 pong을 반환한다', () => {
+    const resolver = new PingResolver();
+    expect(resolver.ping()).toBe('pong');
+  });
+});

--- a/src/test/db/prisma-test-client.ts
+++ b/src/test/db/prisma-test-client.ts
@@ -58,6 +58,35 @@ function buildTestDbUrl(state: TestDbState, dbName: string): string {
  * - worker별 격리된 DB 생성(없으면 CREATE)
  * - `prisma migrate deploy`로 스키마 적용 (worker당 1회)
  */
+/**
+ * MySQL admin 연결을 재시도와 함께 연다.
+ * Testcontainers의 mysqladmin ping healthcheck가 통과해도 실제 외부 연결을 받을
+ * 준비가 안 된 구간이 CI에서 관측됨 ("Connection lost: The server closed the
+ * connection"). 500ms → 1s → 2s → 4s → 8s 백오프로 최대 5회 재시도.
+ */
+async function connectAdminWithRetry(
+  state: TestDbState,
+): Promise<mysql.Connection> {
+  const maxAttempts = 5;
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await mysql.createConnection({
+        host: state.host,
+        port: state.port,
+        user: state.rootUser,
+        password: state.rootPassword,
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts - 1) break;
+      const backoffMs = 500 * 2 ** attempt;
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+  }
+  throw lastError;
+}
+
 async function ensureSchema(
   state: TestDbState,
   dbName: string,
@@ -65,12 +94,7 @@ async function ensureSchema(
 ): Promise<void> {
   if (isSchemaApplied(dbName)) return;
 
-  const admin = await mysql.createConnection({
-    host: state.host,
-    port: state.port,
-    user: state.rootUser,
-    password: state.rootPassword,
-  });
+  const admin = await connectAdminWithRetry(state);
   try {
     await admin.query(
       `CREATE DATABASE IF NOT EXISTS \`${dbName}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`,
@@ -127,6 +151,6 @@ export async function disconnectTestPrismaClient(): Promise<void> {
     await cachedClient.$disconnect();
     cachedClient = null;
   }
-  // schemaApplied 플래그는 globalThis에 있으므로 건드리지 않는다.
+  // schema marker는 파일 시스템에 있으므로 건드리지 않는다.
   // worker 프로세스가 살아있는 동안 migrate를 다시 돌리지 않는다.
 }

--- a/src/test/db/prisma-test-client.ts
+++ b/src/test/db/prisma-test-client.ts
@@ -18,7 +18,29 @@ interface TestDbState {
 
 let cachedClient: PrismaClient | null = null;
 let cachedDbUrl: string | null = null;
-let schemaApplied = false;
+
+/**
+ * schemaApplied는 worker 프로세스 전역으로 유지한다.
+ * Jest는 test file마다 module registry를 새로 만들기 때문에 module-scope 변수로는
+ * suite 간 공유되지 않는다. 이 경우 매 suite마다 ensureSchema()가 호출되며
+ * `mysql.createConnection`과 `npx prisma migrate deploy`가 반복되는데, CI의
+ * MySQL 연결이 flaky하면 "Connection lost" 오류가 발생한다 (PR 7 CI).
+ * globalThis에 저장해 한 worker가 살아있는 동안 1회만 실행되도록 한다.
+ */
+interface TestDbGlobal {
+  __TEST_SCHEMA_APPLIED__?: Record<string, boolean>;
+}
+
+function isSchemaApplied(dbName: string): boolean {
+  const g = globalThis as unknown as TestDbGlobal;
+  return g.__TEST_SCHEMA_APPLIED__?.[dbName] === true;
+}
+
+function markSchemaApplied(dbName: string): void {
+  const g = globalThis as unknown as TestDbGlobal;
+  if (!g.__TEST_SCHEMA_APPLIED__) g.__TEST_SCHEMA_APPLIED__ = {};
+  g.__TEST_SCHEMA_APPLIED__[dbName] = true;
+}
 
 function loadState(): TestDbState {
   const raw = readFileSync(STATE_FILE, 'utf8');
@@ -44,7 +66,7 @@ async function ensureSchema(
   dbName: string,
   dbUrl: string,
 ): Promise<void> {
-  if (schemaApplied) return;
+  if (isSchemaApplied(dbName)) return;
 
   const admin = await mysql.createConnection({
     host: state.host,
@@ -68,7 +90,7 @@ async function ensureSchema(
     stdio: 'pipe',
   });
 
-  schemaApplied = true;
+  markSchemaApplied(dbName);
 }
 
 /**
@@ -108,7 +130,6 @@ export async function disconnectTestPrismaClient(): Promise<void> {
     await cachedClient.$disconnect();
     cachedClient = null;
   }
-  // schemaApplied는 유지한다. 같은 worker 프로세스 내에서 DB는 동일하므로
-  // migrate를 다시 돌릴 필요가 없고, 재실행 시 mysql admin 연결이 flaky해
-  // "Connection lost" 오류를 유발할 수 있다 (PR 7 CI에서 관측됨).
+  // schemaApplied 플래그는 globalThis에 있으므로 건드리지 않는다.
+  // worker 프로세스가 살아있는 동안 migrate를 다시 돌리지 않는다.
 }

--- a/src/test/db/prisma-test-client.ts
+++ b/src/test/db/prisma-test-client.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { PrismaClient } from '@prisma/client';
@@ -20,26 +20,23 @@ let cachedClient: PrismaClient | null = null;
 let cachedDbUrl: string | null = null;
 
 /**
- * schemaApplied는 worker 프로세스 전역으로 유지한다.
- * Jest는 test file마다 module registry를 새로 만들기 때문에 module-scope 변수로는
- * suite 간 공유되지 않는다. 이 경우 매 suite마다 ensureSchema()가 호출되며
- * `mysql.createConnection`과 `npx prisma migrate deploy`가 반복되는데, CI의
- * MySQL 연결이 flaky하면 "Connection lost" 오류가 발생한다 (PR 7 CI).
- * globalThis에 저장해 한 worker가 살아있는 동안 1회만 실행되도록 한다.
+ * schemaApplied 플래그는 파일 시스템에 저장한다.
+ * Jest는 test file마다 독립된 VM context를 만들므로 module-scope 변수나 globalThis도
+ * 공유되지 않는다 → 매 suite마다 ensureSchema()가 재호출되며 mysql admin 연결이
+ * 반복 오픈되어 CI flaky 연결에서 "Connection lost"가 발생한다 (PR 7 CI).
+ * 파일 시스템은 VM sandboxing과 무관하게 유지되므로 marker file로 해결한다.
+ * worker별 DB가 다르므로 파일 경쟁 조건은 없다 (globalTeardown에서 정리).
  */
-interface TestDbGlobal {
-  __TEST_SCHEMA_APPLIED__?: Record<string, boolean>;
+function getSchemaMarkerPath(dbName: string): string {
+  return join(process.cwd(), '.tmp', `schema-applied-${dbName}.marker`);
 }
 
 function isSchemaApplied(dbName: string): boolean {
-  const g = globalThis as unknown as TestDbGlobal;
-  return g.__TEST_SCHEMA_APPLIED__?.[dbName] === true;
+  return existsSync(getSchemaMarkerPath(dbName));
 }
 
 function markSchemaApplied(dbName: string): void {
-  const g = globalThis as unknown as TestDbGlobal;
-  if (!g.__TEST_SCHEMA_APPLIED__) g.__TEST_SCHEMA_APPLIED__ = {};
-  g.__TEST_SCHEMA_APPLIED__[dbName] = true;
+  writeFileSync(getSchemaMarkerPath(dbName), 'ok', 'utf8');
 }
 
 function loadState(): TestDbState {

--- a/src/test/db/prisma-test-client.ts
+++ b/src/test/db/prisma-test-client.ts
@@ -107,6 +107,8 @@ export async function disconnectTestPrismaClient(): Promise<void> {
   if (cachedClient) {
     await cachedClient.$disconnect();
     cachedClient = null;
-    schemaApplied = false;
   }
+  // schemaApplied는 유지한다. 같은 worker 프로세스 내에서 DB는 동일하므로
+  // migrate를 다시 돌릴 필요가 없고, 재실행 시 mysql admin 연결이 flaky해
+  // "Connection lost" 오류를 유발할 수 있다 (PR 7 CI에서 관측됨).
 }

--- a/src/test/db/truncate.ts
+++ b/src/test/db/truncate.ts
@@ -3,10 +3,12 @@ import mysql from 'mysql2/promise';
 import { getTestDatabaseUrl } from '@/test/db/prisma-test-client';
 
 let cachedConn: mysql.Connection | null = null;
+let cachedTableNames: string[] | null = null;
 
 /**
  * Worker별로 캐싱된 mysql2 연결을 반환한다.
  * 연결이 끊겼으면 재생성한다.
+ * truncateAll을 단일 round-trip으로 수행하기 위해 multipleStatements를 활성화.
  */
 async function getConnection(): Promise<mysql.Connection> {
   if (cachedConn) {
@@ -17,21 +19,18 @@ async function getConnection(): Promise<mysql.Connection> {
       cachedConn = null;
     }
   }
-  cachedConn = await mysql.createConnection(getTestDatabaseUrl());
+  cachedConn = await mysql.createConnection({
+    uri: getTestDatabaseUrl(),
+    multipleStatements: true,
+  });
   return cachedConn;
 }
 
 /**
- * 테스트 DB의 모든 테이블을 TRUNCATE한다.
- *
- * Prisma 커넥션 풀을 우회하여 단일 mysql2 연결에서 실행.
- * → SET FOREIGN_KEY_CHECKS=0 과 TRUNCATE가 동일 세션에서 보장됨.
- *
- * - `_prisma_migrations`는 제외 (스키마 이력 유지)
+ * worker 프로세스 동안 테이블 목록은 변하지 않으므로 1회만 조회해 재사용한다.
  */
-export async function truncateAll(): Promise<void> {
-  const conn = await getConnection();
-
+async function loadTableNames(conn: mysql.Connection): Promise<string[]> {
+  if (cachedTableNames) return cachedTableNames;
   const [rows] = await conn.query<mysql.RowDataPacket[]>(`
     SELECT TABLE_NAME AS table_name
     FROM information_schema.tables
@@ -39,17 +38,36 @@ export async function truncateAll(): Promise<void> {
       AND table_type = 'BASE TABLE'
       AND TABLE_NAME <> '_prisma_migrations'
   `);
+  cachedTableNames = rows.map((r) => r.table_name as string);
+  return cachedTableNames;
+}
 
-  if (rows.length === 0) return;
+/**
+ * 테스트 DB의 모든 테이블 데이터를 초기화한다.
+ *
+ * TRUNCATE 대신 DELETE를 사용한다: MySQL에서 TRUNCATE는 빈 테이블이어도 .ibd 파일을
+ * drop & recreate하므로 per-statement 비용이 크지만, DELETE는 빈 테이블에서 거의
+ * 즉시 리턴한다. 테스트 대부분이 소수 테이블만 건드리고 나머지는 비어있으므로
+ * 실측상 DELETE가 훨씬 빠르다.
+ *
+ * 트레이드오프: AUTO_INCREMENT 값이 리셋되지 않는다. 우리 테스트는 factory가 반환한
+ * id를 들고 사용하지 상수 id에 의존하지 않으므로 무해하다.
+ *
+ * - multi-statement 배치로 1회 round-trip
+ * - SET FOREIGN_KEY_CHECKS=0 으로 FK 순서 무시
+ * - `_prisma_migrations`는 제외 (스키마 이력 유지)
+ */
+export async function truncateAll(): Promise<void> {
+  const conn = await getConnection();
+  const tables = await loadTableNames(conn);
+  if (tables.length === 0) return;
 
-  await conn.query('SET FOREIGN_KEY_CHECKS = 0');
-  try {
-    for (const row of rows) {
-      await conn.query(`TRUNCATE TABLE \`${row.table_name}\``);
-    }
-  } finally {
-    await conn.query('SET FOREIGN_KEY_CHECKS = 1');
-  }
+  const deleteStatements = tables
+    .map((name) => `DELETE FROM \`${name}\`;`)
+    .join('\n');
+  const sql = `SET FOREIGN_KEY_CHECKS = 0;\n${deleteStatements}\nSET FOREIGN_KEY_CHECKS = 1;`;
+
+  await conn.query(sql);
 }
 
 /**
@@ -60,4 +78,5 @@ export async function closeTruncateConnection(): Promise<void> {
     await cachedConn.end();
     cachedConn = null;
   }
+  cachedTableNames = null;
 }

--- a/src/test/jest.global-setup.ts
+++ b/src/test/jest.global-setup.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 
 import {
@@ -7,7 +13,8 @@ import {
   type StartedTestContainer,
 } from 'testcontainers';
 
-const STATE_FILE = join(process.cwd(), '.tmp', 'test-db-state.json');
+const TMP_DIR = join(process.cwd(), '.tmp');
+const STATE_FILE = join(TMP_DIR, 'test-db-state.json');
 
 /**
  * Jest globalSetup.
@@ -17,6 +24,17 @@ const STATE_FILE = join(process.cwd(), '.tmp', 'test-db-state.json');
  * 3) worker들이 state 파일로부터 접속 정보를 읽어 worker별 DB를 구성
  */
 export default async function globalSetup(): Promise<void> {
+  // 이전 실행이 Ctrl+C 등으로 중단되어 globalTeardown이 실행되지 않았다면
+  // .tmp/schema-applied-*.marker가 stale 상태로 남는다. 새 MySQL 컨테이너를
+  // 기동하는 시점이므로 무조건 정리한다 (Codex 리뷰 반영).
+  if (existsSync(TMP_DIR)) {
+    for (const name of readdirSync(TMP_DIR)) {
+      if (name.startsWith('schema-applied-') && name.endsWith('.marker')) {
+        unlinkSync(join(TMP_DIR, name));
+      }
+    }
+  }
+
   console.log('[test] starting MySQL container...');
 
   const container: StartedTestContainer = await new GenericContainer(

--- a/src/test/jest.global-teardown.ts
+++ b/src/test/jest.global-teardown.ts
@@ -1,9 +1,10 @@
-import { existsSync, unlinkSync } from 'node:fs';
+import { existsSync, readdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { StartedTestContainer } from 'testcontainers';
 
-const STATE_FILE = join(process.cwd(), '.tmp', 'test-db-state.json');
+const TMP_DIR = join(process.cwd(), '.tmp');
+const STATE_FILE = join(TMP_DIR, 'test-db-state.json');
 
 export default async function globalTeardown(): Promise<void> {
   const container = (
@@ -16,9 +17,14 @@ export default async function globalTeardown(): Promise<void> {
       await container.stop({ timeout: 5000 });
     }
   } finally {
-    // 컨테이너 stop 실패와 무관하게 state 파일은 반드시 정리
-    if (existsSync(STATE_FILE)) {
-      unlinkSync(STATE_FILE);
+    // 컨테이너 stop 실패와 무관하게 state 파일 + schema marker 정리
+    if (existsSync(STATE_FILE)) unlinkSync(STATE_FILE);
+    if (existsSync(TMP_DIR)) {
+      for (const name of readdirSync(TMP_DIR)) {
+        if (name.startsWith('schema-applied-') && name.endsWith('.marker')) {
+          unlinkSync(join(TMP_DIR, name));
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Test DB 전면 도입 플랜의 **PR 7 (product/order/conversation/system/core)** 작업. 기존에 spec이 없던 도메인들에 대해 실DB/unit 테스트를 신규로 작성했다.

## Scope

**Unit specs (pure, DB 불필요)**
- order-status-transition.policy.spec.ts: parse/assertSellerTransition/requiresCancellationNote 전체 경로. SUBMITTED→CONFIRMED→MADE→PICKED_UP 선형 전이, CANCELED는 PICKED_UP 제외 가능
- order-domain.service.spec.ts: policy 위임 검증
- health.controller.spec.ts: getHealth + getProfiles (PROFILE 환경변수 분기)
- ping.resolver.spec.ts: pong 반환

**Real-DB specs (Testcontainers)**
- conversation.repository.spec.ts (6 tests): 5개 메서드 + \$transaction으로 메시지 생성 + conversation.last_message_at 동시 갱신 검증
- order.repository.spec.ts (18 tests): 7개 메서드. 특히 updateOrderStatusBySeller의 \$transaction에서 status/타임스탬프 갱신, statusHistory/Notification/AuditLog 동시 생성. CONFIRMED/MADE/PICKED_UP → Notification 생성, CANCELED는 알림 없음.
- product.repository.spec.ts (31 tests): 30+ 메서드 전수. list 필터 조합, include 구조(images/categories/tags/optionGroups/customTemplate), CRUD, reorder 트랜잭션, upsert 동일 product_id 단일 row 유지

core/는 GraphQL SDL만 있어서 작업 없음.

## Coverage

**전체 실측**: 92.74 / 78.27 / 87.67 / 93.28 (statements/branches/functions/lines)

threshold 상향: 85/76/80/85 → **88/78/85/88**
- statements/functions/lines: PR 7 목표치(stmt 88 / fn 85 / lines 88) 달성
- branches: 실측 78.27 기준 -0.27pt 버퍼 (PR 7 목표 85 미달)
  - 사유: 전역 필터/인터셉터/미들웨어/S3 서비스 등 side-path가 많은 인프라 레이어에 아직 직접 테스트 없음 (PR 8 스코프). feature 도메인 repo/service 내부 branches는 대부분 85%+

Test 총계: 72 suites, 712 tests (이전 65 suites, 638 → +7/+74)

## Test plan
- [x] yarn test:cov 통과
- [ ] CI 통과 (check, pr-title, coverage-report, CodeQL)
- [ ] Codecov 리포트 확인