### PR TITLE
test: prisma / 인프라 레이어 spec 강화 (PR 8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,10 +126,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 88,
-        "branches": 78,
-        "functions": 85,
-        "lines": 88
+        "statements": 92,
+        "branches": 80,
+        "functions": 88,
+        "lines": 93
       }
     },
     "coverageDirectory": "../coverage",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 92,
-        "branches": 80,
+        "branches": 81,
         "functions": 88,
         "lines": 93
       }

--- a/src/features/seller/services/seller-content.service.spec.ts
+++ b/src/features/seller/services/seller-content.service.spec.ts
@@ -340,6 +340,92 @@ describe('SellerContentService (real DB)', () => {
       });
       expect(result.title).toBe('새 타이틀');
     });
+
+    it('linkType 변경: STORE → NONE이면 link_store_id 등 모든 link 필드가 null로 정리된다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const banner = await prisma.banner.create({
+        data: {
+          placement: 'STORE',
+          image_url: 'https://i.example/a.png',
+          link_type: 'STORE',
+          link_store_id: store.id,
+        },
+      });
+
+      await service.sellerUpdateBanner(account.id, {
+        bannerId: banner.id.toString(),
+        linkType: 'NONE',
+      });
+
+      const after = await prisma.banner.findUniqueOrThrow({
+        where: { id: banner.id },
+      });
+      expect(after.link_type).toBe('NONE');
+      expect(after.link_store_id).toBeNull();
+      expect(after.link_url).toBeNull();
+      expect(after.link_product_id).toBeNull();
+      expect(after.link_category_id).toBeNull();
+    });
+
+    it('linkType 변경: STORE → URL이면 link_url만 유지되고 나머지 null', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const banner = await prisma.banner.create({
+        data: {
+          placement: 'STORE',
+          image_url: 'https://i.example/a.png',
+          link_type: 'STORE',
+          link_store_id: store.id,
+        },
+      });
+
+      await service.sellerUpdateBanner(account.id, {
+        bannerId: banner.id.toString(),
+        linkType: 'URL',
+        linkUrl: 'https://external.example',
+      });
+
+      const after = await prisma.banner.findUniqueOrThrow({
+        where: { id: banner.id },
+      });
+      expect(after.link_type).toBe('URL');
+      expect(after.link_url).toBe('https://external.example');
+      expect(after.link_store_id).toBeNull();
+    });
+
+    it('linkType 미변경 + 비-link 필드만 업데이트 (else branch 커버)', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const banner = await prisma.banner.create({
+        data: {
+          placement: 'STORE',
+          image_url: 'https://i.example/a.png',
+          link_type: 'STORE',
+          link_store_id: store.id,
+        },
+      });
+
+      await service.sellerUpdateBanner(account.id, {
+        bannerId: banner.id.toString(),
+        placement: 'HOME_MAIN',
+        imageUrl: 'https://i.example/new.png',
+        sortOrder: 7,
+        isActive: false,
+        startsAt: '2026-05-01T00:00:00Z',
+        endsAt: '2026-05-31T23:59:59Z',
+      });
+
+      const after = await prisma.banner.findUniqueOrThrow({
+        where: { id: banner.id },
+      });
+      expect(after.placement).toBe('HOME_MAIN');
+      expect(after.image_url).toBe('https://i.example/new.png');
+      expect(after.sort_order).toBe(7);
+      expect(after.is_active).toBe(false);
+      expect(after.starts_at).not.toBeNull();
+      expect(after.ends_at).not.toBeNull();
+      // linkType이 변경되지 않았으므로 기존 STORE 링크는 그대로 유지
+      expect(after.link_type).toBe('STORE');
+      expect(after.link_store_id).toBe(store.id);
+    });
   });
 
   describe('sellerDeleteBanner', () => {

--- a/src/features/seller/services/seller-content.service.spec.ts
+++ b/src/features/seller/services/seller-content.service.spec.ts
@@ -426,6 +426,76 @@ describe('SellerContentService (real DB)', () => {
       expect(after.link_type).toBe('STORE');
       expect(after.link_store_id).toBe(store.id);
     });
+
+    it('linkType 미변경 + 4가지 inner link 필드(linkUrl/linkProductId/linkStoreId/linkCategoryId) 부분 업데이트', async () => {
+      // STORE 타입 banner로 ownership을 확보하면 validateBannerOwnership은 linkStoreId만
+      // 현재 store인지 확인하므로 나머지 linkUrl/linkProductId/linkCategoryId inner 분기를
+      // 자유롭게 검증할 수 있다.
+      const me = await setupSellerWithStore(prisma);
+      const product = await prisma.product.create({
+        data: { store_id: me.store.id, name: 'p', regular_price: 1000 },
+      });
+      const category = await prisma.category.create({
+        data: { name: '이벤트', category_type: 'EVENT' },
+      });
+      const banner = await prisma.banner.create({
+        data: {
+          placement: 'STORE',
+          image_url: 'https://i.example/a.png',
+          link_type: 'STORE',
+          link_store_id: me.store.id,
+          link_url: 'https://old.example',
+        },
+      });
+
+      await service.sellerUpdateBanner(me.account.id, {
+        bannerId: banner.id.toString(),
+        // linkType 미지정 → else branch
+        // 4개 inner 분기 모두 발동
+        linkUrl: 'https://new.example',
+        linkProductId: product.id.toString(),
+        linkStoreId: me.store.id.toString(),
+        linkCategoryId: category.id.toString(),
+      });
+
+      const after = await prisma.banner.findUniqueOrThrow({
+        where: { id: banner.id },
+      });
+      expect(after.link_type).toBe('STORE');
+      expect(after.link_url).toBe('https://new.example');
+      expect(after.link_product_id).toBe(product.id);
+      expect(after.link_store_id).toBe(me.store.id);
+      expect(after.link_category_id).toBe(category.id);
+    });
+
+    it('linkType 미변경 + linkProductId를 null로 (falsy 분기: parseId 미호출 경로)', async () => {
+      const me = await setupSellerWithStore(prisma);
+      const product = await prisma.product.create({
+        data: { store_id: me.store.id, name: 'p', regular_price: 1000 },
+      });
+      const banner = await prisma.banner.create({
+        data: {
+          placement: 'STORE',
+          image_url: 'https://i.example/a.png',
+          link_type: 'STORE',
+          link_store_id: me.store.id,
+          link_product_id: product.id,
+        },
+      });
+
+      await service.sellerUpdateBanner(me.account.id, {
+        bannerId: banner.id.toString(),
+        // linkProductId=null → inner 삼항의 falsy 측(→null) 경로
+        linkProductId: null,
+      });
+
+      const after = await prisma.banner.findUniqueOrThrow({
+        where: { id: banner.id },
+      });
+      expect(after.link_product_id).toBeNull();
+      // linkType 그대로
+      expect(after.link_type).toBe('STORE');
+    });
   });
 
   describe('sellerDeleteBanner', () => {

--- a/src/global/auth/decorators/current-user.decorator.spec.ts
+++ b/src/global/auth/decorators/current-user.decorator.spec.ts
@@ -1,0 +1,61 @@
+import type { ExecutionContext } from '@nestjs/common';
+
+import { currentUserFactory } from '@/global/auth/decorators/current-user.decorator';
+
+function makeExecutionContext(opts: {
+  gqlReqUser?: unknown;
+  httpReqUser?: unknown;
+  gqlContextType?: string;
+}): ExecutionContext {
+  const gqlReq = opts.gqlReqUser !== undefined ? { user: opts.gqlReqUser } : {};
+  const httpReq = { user: opts.httpReqUser };
+  // GraphQL resolver args는 (root, args, context, info) 4 요소.
+  // GqlExecutionContext.getContext()는 args[2]를 반환한다.
+  const gqlArgs = [null, null, { req: gqlReq }, null];
+
+  const ctx = {
+    getType: () => opts.gqlContextType ?? 'http',
+    getArgs: () => gqlArgs,
+    getArgByIndex: (idx: number) => gqlArgs[idx] ?? null,
+    switchToHttp: () => ({
+      getRequest: () => httpReq,
+      getResponse: () => ({}),
+      getNext: () => () => undefined,
+    }),
+    switchToRpc: () => ({}) as never,
+    switchToWs: () => ({}) as never,
+    getHandler: () => () => undefined,
+    getClass: () => class {},
+  } as unknown as ExecutionContext;
+  return ctx;
+}
+
+describe('currentUserFactory', () => {
+  it('GraphQL context에 req.user가 있으면 그 값을 반환한다', () => {
+    const user = { accountId: '42' };
+    const ctx = makeExecutionContext({
+      gqlReqUser: user,
+      gqlContextType: 'graphql',
+    });
+
+    const result = currentUserFactory(undefined, ctx);
+    expect(result).toEqual(user);
+  });
+
+  it('GraphQL context에 req.user가 없으면 HTTP request.user로 fallback', () => {
+    const user = { accountId: '100' };
+    const ctx = makeExecutionContext({
+      httpReqUser: user,
+      gqlContextType: 'http',
+    });
+
+    const result = currentUserFactory(undefined, ctx);
+    expect(result).toEqual(user);
+  });
+
+  it('어느 곳에도 user가 없으면 undefined 반환', () => {
+    const ctx = makeExecutionContext({});
+    const result = currentUserFactory(undefined, ctx);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/global/auth/decorators/current-user.decorator.ts
+++ b/src/global/auth/decorators/current-user.decorator.ts
@@ -27,17 +27,23 @@ import type { JwtUser } from '@/global/auth/types/jwt-payload.type';
  *   return this.userService.findOne(user.accountId);
  * }
  */
-export const CurrentUser = createParamDecorator(
-  (data: unknown, ctx: ExecutionContext): JwtUser | undefined => {
-    // GraphQL Context
-    const gqlContext = GqlExecutionContext.create(ctx);
-    const gqlReq = gqlContext.getContext<{ req?: Request }>()?.req;
-    if (gqlReq?.user) {
-      return gqlReq.user;
-    }
+/**
+ * createParamDecorator에 전달되는 factory. 테스트에서 직접 호출하기 위해 export.
+ */
+export function currentUserFactory(
+  _data: unknown,
+  ctx: ExecutionContext,
+): JwtUser | undefined {
+  // GraphQL Context
+  const gqlContext = GqlExecutionContext.create(ctx);
+  const gqlReq = gqlContext.getContext<{ req?: Request }>()?.req;
+  if (gqlReq?.user) {
+    return gqlReq.user;
+  }
 
-    // HTTP Context
-    const request = ctx.switchToHttp().getRequest<Request>();
-    return request.user;
-  },
-);
+  // HTTP Context
+  const request = ctx.switchToHttp().getRequest<Request>();
+  return request.user;
+}
+
+export const CurrentUser = createParamDecorator(currentUserFactory);

--- a/src/global/filters/global-exception.filter.spec.ts
+++ b/src/global/filters/global-exception.filter.spec.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, HttpStatus } from '@nestjs/common';
-import type { AbstractHttpAdapter } from '@nestjs/core';
+import { BaseExceptionFilter, type AbstractHttpAdapter } from '@nestjs/core';
 import type { Request, Response } from 'express';
 
 import { HttpExceptionFilter } from '@/global/filters/global-exception.filter';
@@ -149,26 +149,30 @@ describe('HttpExceptionFilter', () => {
     );
   });
 
-  it('GraphQL 컨텍스트(getType !== "http")에서는 BaseExceptionFilter.catch로 위임한다', () => {
-    // super.catch가 호출되는지만 검증 (HttpAdapter가 없어 BaseExceptionFilter 내부에서
-    // throw 가능 → catch해서 호출됐음만 확인)
-    const host = {
-      getType: () => 'graphql',
-      switchToHttp: () => ({
-        getRequest: () => ({}),
-        getResponse: () => ({}),
-      }),
-    } as never;
+  it('GraphQL 컨텍스트(getType !== "http")에서는 BaseExceptionFilter.catch로 위임하고 로깅을 스킵한다', () => {
+    const superCatch = jest
+      .spyOn(BaseExceptionFilter.prototype, 'catch')
+      .mockImplementation(() => undefined);
 
-    // super.catch는 HttpAdapter 필요 → 빈 adapter면 내부에서 throw.
-    // 단순히 super로 delegate됐음을 확인하기 위해 try/catch로 감싼다.
     try {
-      filter.catch(new Error('gql'), host);
-    } catch {
-      /* super.catch 경유 확인만 필요 */
+      const host = {
+        getType: () => 'graphql',
+        switchToHttp: () => ({
+          getRequest: () => ({}),
+          getResponse: () => ({}),
+        }),
+      } as never;
+      const exception = new Error('gql');
+
+      filter.catch(exception, host);
+
+      // 1) super.catch로 정확히 위임됐는지 — exception/host 원본 그대로 전달
+      expect(superCatch).toHaveBeenCalledTimes(1);
+      expect(superCatch).toHaveBeenCalledWith(exception, host);
+      // 2) HTTP 경로의 side effect가 일어나지 않았는지
+      expect(logger.txError).not.toHaveBeenCalled();
+    } finally {
+      superCatch.mockRestore();
     }
-    // res.status / res.json이 호출되지 않았음을 통해 http 경로로 가지 않았음을 확인
-    // (mockRes가 없으므로 간접 검증: logger.txError도 호출되지 않았어야 함)
-    expect(logger.txError).not.toHaveBeenCalled();
   });
 });

--- a/src/global/filters/global-exception.filter.spec.ts
+++ b/src/global/filters/global-exception.filter.spec.ts
@@ -113,4 +113,62 @@ describe('HttpExceptionFilter', () => {
       }),
     );
   });
+
+  it('BadRequestException의 message가 배열이지만 validation 형태가 아니면 기본 ERROR 응답', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const host = mockHost(req, res);
+
+    const exception = new BadRequestException({
+      // 배열이지만 validation 구조({property, constraints}) 아님
+      message: ['plain string', 'another'],
+    });
+
+    filter.catch(exception, host);
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    // ERROR 헬퍼로 직렬화 → data는 null
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 400, data: null }),
+    );
+  });
+
+  it('BadRequestException resp가 object이지만 message 속성이 없으면 기본 ERROR', () => {
+    const req = mockReq();
+    const res = mockRes();
+    const host = mockHost(req, res);
+
+    // BadRequestException에 message 없는 object
+    const exception = new BadRequestException({ statusCode: 400 } as never);
+
+    filter.catch(exception, host);
+
+    expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 400 }),
+    );
+  });
+
+  it('GraphQL 컨텍스트(getType !== "http")에서는 BaseExceptionFilter.catch로 위임한다', () => {
+    // super.catch가 호출되는지만 검증 (HttpAdapter가 없어 BaseExceptionFilter 내부에서
+    // throw 가능 → catch해서 호출됐음만 확인)
+    const host = {
+      getType: () => 'graphql',
+      switchToHttp: () => ({
+        getRequest: () => ({}),
+        getResponse: () => ({}),
+      }),
+    } as never;
+
+    // super.catch는 HttpAdapter 필요 → 빈 adapter면 내부에서 throw.
+    // 단순히 super로 delegate됐음을 확인하기 위해 try/catch로 감싼다.
+    try {
+      filter.catch(new Error('gql'), host);
+    } catch {
+      /* super.catch 경유 확인만 필요 */
+    }
+    // res.status / res.json이 호출되지 않았음을 통해 http 경로로 가지 않았음을 확인
+    // (mockRes가 없으므로 간접 검증: logger.txError도 호출되지 않았어야 함)
+    expect(logger.txError).not.toHaveBeenCalled();
+  });
 });

--- a/src/global/interceptors/gql-logging.interceptor.spec.ts
+++ b/src/global/interceptors/gql-logging.interceptor.spec.ts
@@ -129,4 +129,23 @@ describe('GqlLoggingInterceptor', () => {
       },
     });
   });
+
+  it('에러가 Error 인스턴스가 아니면 "Unknown error" + stack undefined로 로깅', (done) => {
+    const ctx = mockGqlContext('Query');
+    const notAnError = 'just a string thrown';
+    const handler = {
+      handle: () => throwError(() => notAnError),
+    } as CallHandler;
+
+    interceptor.intercept(ctx, handler).subscribe({
+      error: () => {
+        expect(logger.txError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            error: { message: 'Unknown error', stack: undefined },
+          }),
+        );
+        done();
+      },
+    });
+  });
 });

--- a/src/global/interceptors/http-logging.interceptor.spec.ts
+++ b/src/global/interceptors/http-logging.interceptor.spec.ts
@@ -115,4 +115,16 @@ describe('HttpLoggingInterceptor', () => {
       done();
     });
   });
+
+  it('statusCode가 falsy(0)이면 HttpStatus.OK(200)로 fallback', (done) => {
+    const { ctx } = mockHttpContext(0);
+    interceptor.intercept(ctx, mockHandler(null)).subscribe(() => {
+      expect(logger.tx).toHaveBeenCalledWith(
+        expect.objectContaining({
+          response: expect.objectContaining({ statusCode: 200 }),
+        }),
+      );
+      done();
+    });
+  });
 });

--- a/src/global/logger/custom-logger.service.spec.ts
+++ b/src/global/logger/custom-logger.service.spec.ts
@@ -80,6 +80,15 @@ describe('CustomLoggerService', () => {
         }),
       );
     });
+
+    it('optionalParams의 non-Error 값은 그대로 유지된다 (map 삼항 false branch)', () => {
+      service.log('x', 'plain string', 42, { k: 'v' });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          optionalParams: ['plain string', 42, { k: 'v' }],
+        }),
+      );
+    });
   });
 
   describe('트랜잭션 로그', () => {

--- a/src/global/logger/logger.spec.ts
+++ b/src/global/logger/logger.spec.ts
@@ -1,0 +1,80 @@
+describe('customLogger', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  function loadLogger() {
+    // 각 테스트마다 logger.ts의 top-level 초기화를 다시 타게 한다
+    return require('@/global/logger/logger').customLogger as {
+      info: (msg: unknown, meta?: Record<string, unknown>) => void;
+      error: (msg: unknown, meta?: Record<string, unknown>) => void;
+      level: string;
+    };
+  }
+
+  function withNodeEnv<T>(value: string | undefined, fn: () => T): T {
+    const original = process.env.NODE_ENV;
+    if (value === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = value;
+    try {
+      return fn();
+    } finally {
+      if (original === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = original;
+    }
+  }
+
+  it('dev 환경(NODE_ENV !== production)에서는 level=debug', () => {
+    withNodeEnv('development', () => {
+      jest.resetModules();
+      const logger = loadLogger();
+      expect(logger.level).toBe('debug');
+    });
+  });
+
+  it('production 환경에서는 level=info', () => {
+    withNodeEnv('production', () => {
+      jest.resetModules();
+      const logger = loadLogger();
+      expect(logger.level).toBe('info');
+    });
+  });
+
+  it('dev format: string message + meta 조합을 로깅해도 throw하지 않는다', () => {
+    withNodeEnv('development', () => {
+      jest.resetModules();
+      const logger = loadLogger();
+      expect(() =>
+        logger.info('hello', { foo: 'bar', count: 1 }),
+      ).not.toThrow();
+    });
+  });
+
+  it('dev format: string message 단독(meta 없음)도 로깅한다', () => {
+    withNodeEnv('development', () => {
+      jest.resetModules();
+      const logger = loadLogger();
+      expect(() => logger.info('single message')).not.toThrow();
+    });
+  });
+
+  it('dev format: message가 non-string(객체)여도 로깅한다', () => {
+    withNodeEnv('development', () => {
+      jest.resetModules();
+      const logger = loadLogger();
+      expect(() =>
+        logger.info({ eventType: 'LOGIN', userId: 7 } as unknown as string),
+      ).not.toThrow();
+    });
+  });
+
+  it('error level 로깅도 throw하지 않는다 (errors.stack 포맷 경로)', () => {
+    withNodeEnv('development', () => {
+      jest.resetModules();
+      const logger = loadLogger();
+      expect(() =>
+        logger.error('failed', { err: new Error('boom').message }),
+      ).not.toThrow();
+    });
+  });
+});

--- a/src/global/logger/logger.spec.ts
+++ b/src/global/logger/logger.spec.ts
@@ -1,15 +1,12 @@
-describe('customLogger', () => {
+import { formatDevLogLine } from '@/global/logger/logger';
+
+describe('customLogger 초기화 (NODE_ENV 분기)', () => {
   afterEach(() => {
     jest.resetModules();
   });
 
   function loadLogger() {
-    // 각 테스트마다 logger.ts의 top-level 초기화를 다시 타게 한다
-    return require('@/global/logger/logger').customLogger as {
-      info: (msg: unknown, meta?: Record<string, unknown>) => void;
-      error: (msg: unknown, meta?: Record<string, unknown>) => void;
-      level: string;
-    };
+    return require('@/global/logger/logger').customLogger as { level: string };
   }
 
   function withNodeEnv<T>(value: string | undefined, fn: () => T): T {
@@ -27,54 +24,69 @@ describe('customLogger', () => {
   it('dev 환경(NODE_ENV !== production)에서는 level=debug', () => {
     withNodeEnv('development', () => {
       jest.resetModules();
-      const logger = loadLogger();
-      expect(logger.level).toBe('debug');
+      expect(loadLogger().level).toBe('debug');
     });
   });
 
   it('production 환경에서는 level=info', () => {
     withNodeEnv('production', () => {
       jest.resetModules();
-      const logger = loadLogger();
-      expect(logger.level).toBe('info');
+      expect(loadLogger().level).toBe('info');
     });
   });
+});
 
-  it('dev format: string message + meta 조합을 로깅해도 throw하지 않는다', () => {
-    withNodeEnv('development', () => {
-      jest.resetModules();
-      const logger = loadLogger();
-      expect(() =>
-        logger.info('hello', { foo: 'bar', count: 1 }),
-      ).not.toThrow();
+describe('formatDevLogLine (printf 콜백)', () => {
+  it('string message + meta → "{ts} {level}: {message} {meta-json}" 형식', () => {
+    const line = formatDevLogLine({
+      level: 'info',
+      message: 'hello',
+      timestamp: '2026-04-22 10:00:00',
+      foo: 'bar',
+      count: 1,
     });
+    expect(line).toBe(
+      '2026-04-22 10:00:00 info: hello {"foo":"bar","count":1}',
+    );
   });
 
-  it('dev format: string message 단독(meta 없음)도 로깅한다', () => {
-    withNodeEnv('development', () => {
-      jest.resetModules();
-      const logger = loadLogger();
-      expect(() => logger.info('single message')).not.toThrow();
+  it('string message 단독(meta 없음) → 뒤에 meta JSON을 붙이지 않는다', () => {
+    const line = formatDevLogLine({
+      level: 'warn',
+      message: 'single message',
+      timestamp: '2026-04-22 10:00:00',
     });
+    expect(line).toBe('2026-04-22 10:00:00 warn: single message');
   });
 
-  it('dev format: message가 non-string(객체)여도 로깅한다', () => {
-    withNodeEnv('development', () => {
-      jest.resetModules();
-      const logger = loadLogger();
-      expect(() =>
-        logger.info({ eventType: 'LOGIN', userId: 7 } as unknown as string),
-      ).not.toThrow();
+  it('message가 non-string(객체)이면 meta 전체를 JSON.stringify로 직렬화한다', () => {
+    const line = formatDevLogLine({
+      level: 'info',
+      message: { eventType: 'LOGIN', userId: 7 } as never,
+      timestamp: '2026-04-22 10:00:00',
     });
+    // message가 non-string이므로 meta 자체가 출력 대상 (message는 rest에 포함 안됨)
+    expect(line).toBe('2026-04-22 10:00:00 info: {}');
   });
 
-  it('error level 로깅도 throw하지 않는다 (errors.stack 포맷 경로)', () => {
-    withNodeEnv('development', () => {
-      jest.resetModules();
-      const logger = loadLogger();
-      expect(() =>
-        logger.error('failed', { err: new Error('boom').message }),
-      ).not.toThrow();
+  it('timestamp 누락 시 현재 시각 ISO 문자열로 fallback', () => {
+    const line = formatDevLogLine({
+      level: 'debug',
+      message: 'no ts',
     });
+    // ISO 8601 패턴 (yyyy-mm-ddThh:mm:ss.sssZ)
+    expect(line).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z debug: no ts$/,
+    );
+  });
+
+  it('error level + meta (stack 포함)도 형식에 맞게 문자열화', () => {
+    const line = formatDevLogLine({
+      level: 'error',
+      message: 'failed',
+      timestamp: '2026-04-22 10:00:00',
+      err: 'boom',
+    });
+    expect(line).toBe('2026-04-22 10:00:00 error: failed {"err":"boom"}');
   });
 });

--- a/src/global/logger/logger.ts
+++ b/src/global/logger/logger.ts
@@ -4,23 +4,28 @@ import { createLogger, format, transports, type Logger } from 'winston';
 const isProduction = process.env.NODE_ENV === 'production';
 
 /**
+ * 개발 환경용 로그 포맷에 사용되는 pure printf 콜백. 테스트 가능하도록 export.
+ */
+export function formatDevLogLine(
+  info: TransformableInfo & { timestamp?: string },
+): string {
+  const ts = info.timestamp ?? new Date().toISOString();
+  const lvl = String(info.level);
+  const { level, timestamp, message, ...meta } = info as Record<
+    string,
+    unknown
+  >;
+  if (typeof message === 'string') {
+    const rest = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
+    return `${ts} ${lvl}: ${message}${rest}`;
+  }
+  return `${ts} ${lvl}: ${JSON.stringify(meta)}`;
+}
+
+/**
  * 개발 환경용 로그 포맷
  */
-const devFormat = format.printf(
-  (info: TransformableInfo & { timestamp?: string }) => {
-    const ts = info.timestamp ?? new Date().toISOString();
-    const lvl = String(info.level);
-    const { level, timestamp, message, ...meta } = info as Record<
-      string,
-      unknown
-    >;
-    if (typeof message === 'string') {
-      const rest = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
-      return `${ts} ${lvl}: ${message}${rest}`;
-    }
-    return `${ts} ${lvl}: ${JSON.stringify(meta)}`;
-  },
-);
+const devFormat = format.printf(formatDevLogLine);
 
 /**
  * 콘솔 출력용 트랜스포트 설정

--- a/src/global/storage/s3.service.spec.ts
+++ b/src/global/storage/s3.service.spec.ts
@@ -244,6 +244,39 @@ describe('S3Service', () => {
       });
     });
   });
+
+  describe('생성자의 credentials 분기', () => {
+    it('accessKeyId/secretAccessKey가 없으면 S3Client에 credentials 없이 초기화한다', async () => {
+      const { S3Client: MockS3Client } =
+        jest.requireMock<typeof import('@aws-sdk/client-s3')>(
+          '@aws-sdk/client-s3',
+        );
+      (MockS3Client as jest.Mock).mockClear();
+
+      const moduleRef: TestingModule = await Test.createTestingModule({
+        providers: [
+          S3Service,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn().mockReturnValue({
+                region: 'ap-northeast-2',
+                bucket: 'b',
+                presignExpiresSeconds: 300,
+                // accessKeyId, secretAccessKey 미지정
+              }),
+            },
+          },
+        ],
+      }).compile();
+
+      moduleRef.get<S3Service>(S3Service);
+      const lastCallArgs = (MockS3Client as jest.Mock).mock.calls.at(-1)?.[0];
+      expect(lastCallArgs).toEqual({ region: 'ap-northeast-2' });
+      // credentials 키 자체가 없어야 함 (ECS/EC2 IAM role 위임)
+      expect(lastCallArgs?.credentials).toBeUndefined();
+    });
+  });
 });
 
 // Jest 커스텀 매처

--- a/src/global/types/response.spec.ts
+++ b/src/global/types/response.spec.ts
@@ -58,5 +58,26 @@ describe('ApiResponseTemplate', () => {
       expect(res.code).toBe(400);
       expect(res.data).toEqual(errors);
     });
+
+    it('message/status 기본값: "error", 500', () => {
+      const res = ApiResponseTemplate.ERROR_WITH_DATA({ x: 1 });
+      expect(res.message).toBe('error');
+      expect(res.code).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+      expect(res.data).toEqual({ x: 1 });
+    });
+
+    it('message만 지정 + status 기본값', () => {
+      const res = ApiResponseTemplate.ERROR_WITH_DATA({ x: 1 }, 'custom error');
+      expect(res.message).toBe('custom error');
+      expect(res.code).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe('SUCCESS_WITH_DATA (default 파라미터 커버)', () => {
+    it('message만 지정 + status 기본값(200)', () => {
+      const res = ApiResponseTemplate.SUCCESS_WITH_DATA({ id: 1 }, 'created');
+      expect(res.message).toBe('created');
+      expect(res.code).toBe(HttpStatus.OK);
+    });
   });
 });

--- a/src/prisma/prisma.service.spec.ts
+++ b/src/prisma/prisma.service.spec.ts
@@ -1,0 +1,86 @@
+import { PrismaService } from '@/prisma/prisma.service';
+import {
+  disconnectTestPrismaClient,
+  getTestDatabaseUrl,
+  getTestPrismaClient,
+} from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+
+/**
+ * PrismaService는 기본 DATABASE_URL을 사용하는 Prisma 클라이언트.
+ * 테스트에서는 프로세스의 DATABASE_URL을 test container URL로 치환한 뒤 생성한다.
+ */
+describe('PrismaService (real DB)', () => {
+  let originalDatabaseUrl: string | undefined;
+
+  beforeAll(async () => {
+    // test container가 기동되도록 한 번 호출하여 URL 확보
+    await getTestPrismaClient();
+    originalDatabaseUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = getTestDatabaseUrl();
+  });
+
+  afterAll(async () => {
+    if (originalDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+    else process.env.DATABASE_URL = originalDatabaseUrl;
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('onModuleInit이 connect를 수행하고 쿼리 실행이 가능하다', async () => {
+    const service = new PrismaService();
+    await service.onModuleInit();
+    try {
+      // softDelete extension이 적용되어 있으면 Account 쿼리가 정상 작동
+      const count = await service.account.count();
+      expect(typeof count).toBe('number');
+    } finally {
+      await service.onModuleDestroy();
+    }
+  });
+
+  it('onModuleDestroy가 disconnect까지 수행한다 (연속 호출해도 throw 없음)', async () => {
+    const service = new PrismaService();
+    await service.onModuleInit();
+    await service.onModuleDestroy();
+    // 재호출이 no-op처럼 동작하는지 (Prisma는 idempotent disconnect)
+    await expect(service.onModuleDestroy()).resolves.not.toThrow();
+  });
+
+  it('생성된 인스턴스에 softDelete extension이 적용되어 있다 (deleted_at 자동 필터)', async () => {
+    const service = new PrismaService();
+    await service.onModuleInit();
+    try {
+      // soft-delete된 account를 생성하고 findFirst로는 안 나오는 것을 확인
+      const active = await service.account.create({
+        data: {
+          account_type: 'USER',
+          status: 'ACTIVE',
+          email: 'active@test.com',
+          name: 'A',
+        },
+      });
+      await service.account.create({
+        data: {
+          account_type: 'USER',
+          status: 'ACTIVE',
+          email: 'deleted@test.com',
+          name: 'D',
+          deleted_at: new Date(),
+        },
+      });
+
+      const found = await service.account.findMany({
+        where: { email: { in: ['active@test.com', 'deleted@test.com'] } },
+      });
+      // softDelete extension이 자동으로 deleted_at: null 필터를 붙이므로 active만 반환
+      expect(found.map((a) => a.id)).toEqual([active.id]);
+    } finally {
+      await service.onModuleDestroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Test DB 전면 도입 플랜의 **PR 8 (prisma + 잔여)** 작업. prisma/global 인프라 레이어에 누락된 spec 신규 추가 + 기존 spec의 low-branch 경로 보강.

## Scope

**신규 spec 3개**
- `prisma.service.spec.ts`: onModuleInit/Destroy 라이프사이클 + soft-delete extension 통합 동작을 실DB로 검증 (3 tests)
- `global/logger/logger.spec.ts`: NODE_ENV에 따른 level 선택, dev format printf의 string/non-string/meta 유무 분기 검증 (6 tests)
- `global/auth/decorators/current-user.decorator.spec.ts`: factory 함수를 별도 export하는 소폭 리팩터 + GraphQL req.user → HTTP fallback → undefined 세 경로 (3 tests)

**기존 spec branches 강화**
- `global-exception.filter`: GraphQL context 위임 경로, BadRequest message 비-validation/no-message 경로
- `response`: SUCCESS_WITH_DATA/ERROR_WITH_DATA 기본 파라미터 경로
- `s3.service`: accessKeyId/secretAccessKey 미지정 시 credentials 없이 초기화하는 분기
- `http-logging.interceptor`: statusCode=0 fallback
- `gql-logging.interceptor`: 에러가 Error 인스턴스가 아닐 때 "Unknown error" fallback
- `custom-logger.service`: optionalParams의 non-Error 값 identity 경로
- `seller-content.service`: sellerUpdateBanner의 linkType 변경(STORE→NONE/URL)으로 link 필드 정리, linkType 미변경 + 비-link 필드만 업데이트 else branch

## Coverage

**실측 전 / 후**: 92.36 / 77.29 / 87.68 / 92.98 → **93.76 / 80.19 / 88.46 / 94.32**

threshold 상향: 88/78/85/88 → **92/80/88/93**

PR 8 목표치(stmt 89 / br 88 / fn 88 / lines 89)
- statements/functions/lines: 달성
- branches 80.19는 88 미달. 인프라 레이어(seller.repository, auth.strategies, resolver의 optional arg 분기, defensive `?? null` 등)에 branches 장벽이 많아 현실적 한계.
- PR 9에서 mock 잔재 제거와 함께 추가 정리 예정

Test 총계: 72 suites / 712 tests → **75 suites / 737 tests** (+3 suites / +25 tests)

## Test plan
- [x] yarn test:cov 로컬 통과
- [ ] CI 통과 (check, pr-title, coverage-report, CodeQL)
- [ ] Codecov 리포트 확인