### PR TITLE
test: 커버리지 하한선 상향 + 핫스팟 분기 보강

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,10 +126,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 92,
-        "branches": 81,
-        "functions": 88,
-        "lines": 93
+        "statements": 96,
+        "branches": 86,
+        "functions": 92,
+        "lines": 96
       }
     },
     "coverageDirectory": "../coverage",

--- a/src/common/utils/request-context.spec.ts
+++ b/src/common/utils/request-context.spec.ts
@@ -1,6 +1,8 @@
 import type { Request, Response } from 'express';
+import type { GraphQLResolveInfo } from 'graphql';
 
 import {
+  buildGraphqlRequestMeta,
   buildHttpRequestMeta,
   calculateDuration,
   ensureRequestTracking,
@@ -129,6 +131,80 @@ describe('request-context', () => {
 
     it('유효하지 않은 문자열이면 null을 반환한다', () => {
       expect(resolveUserId(mockReq({ user: { id: 'abc' } }))).toBeNull();
+    });
+  });
+
+  describe('readSingleHeader (배열 헤더 분기)', () => {
+    it('배열 헤더에서 첫 유효 값만 사용해 requestId로 반영한다', () => {
+      const req = mockReq({
+        headers: { [REQUEST_ID_HEADER]: ['', '  ', 'array-id', 'second-id'] },
+      });
+      const { requestId } = ensureRequestTracking(req);
+      expect(requestId).toBe('array-id');
+    });
+
+    it('배열 헤더가 모두 공백/빈값이면 새 UUID를 생성한다', () => {
+      const req = mockReq({
+        headers: { [REQUEST_ID_HEADER]: ['', '   '] },
+      });
+      const { requestId } = ensureRequestTracking(req);
+      expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+    });
+  });
+
+  describe('buildHttpRequestMeta 엣지 분기', () => {
+    it('originalUrl이 없고 path만 있으면 path를 사용한다', () => {
+      const req = mockReq({ originalUrl: undefined, path: '/only-path' });
+      const meta = buildHttpRequestMeta(req);
+      expect(meta.path).toBe('/only-path');
+    });
+
+    it('originalUrl/path가 모두 없으면 빈 문자열로 반환한다', () => {
+      const req = mockReq({ originalUrl: undefined, path: undefined });
+      const meta = buildHttpRequestMeta(req);
+      expect(meta.path).toBe('');
+    });
+  });
+
+  describe('buildGraphqlRequestMeta path.key 분기', () => {
+    function mockInfo(
+      overrides: Partial<GraphQLResolveInfo>,
+    ): GraphQLResolveInfo {
+      return {
+        fieldName: 'testField',
+        operation: { name: { value: 'TestOp' } },
+        parentType: { toString: () => 'Query' },
+        path: { key: 'testField' },
+        ...overrides,
+      } as unknown as GraphQLResolveInfo;
+    }
+
+    it('path.key가 문자열이면 그대로 사용한다', () => {
+      const req = mockReq();
+      const meta = buildGraphqlRequestMeta(mockInfo({}), req);
+      expect(meta.path).toBe('testField');
+      expect(meta.operationName).toBe('TestOp');
+      expect(meta.parentType).toBe('Query');
+    });
+
+    it('path.key가 숫자이면 문자열화한다', () => {
+      const req = mockReq();
+      const info = mockInfo({
+        path: { key: 3, prev: undefined, typename: undefined },
+      } as unknown as GraphQLResolveInfo);
+      const meta = buildGraphqlRequestMeta(info, req);
+      expect(meta.path).toBe('3');
+    });
+
+    it('path.key가 잘못된 타입이면 fieldName으로 fallback', () => {
+      const req = mockReq();
+      const info = mockInfo({
+        path: {
+          key: undefined as unknown as string,
+        } as GraphQLResolveInfo['path'],
+      });
+      const meta = buildGraphqlRequestMeta(info, req);
+      expect(meta.path).toBe('testField');
     });
   });
 });

--- a/src/features/auth/auth.service.spec.ts
+++ b/src/features/auth/auth.service.spec.ts
@@ -450,5 +450,63 @@ describe('AuthService', () => {
         'Account not found.',
       );
     });
+
+    it('user_profile이 아예 null이면 모든 프로필 필드가 null + needsProfile=true', async () => {
+      mockRepo.findAccountForMe.mockResolvedValue({
+        id: BigInt(1),
+        email: null,
+        name: null,
+        user_profile: null,
+      } as never);
+
+      const result = await service.me(BigInt(1));
+
+      expect(result.nickname).toBeNull();
+      expect(result.profileImageUrl).toBeNull();
+      expect(result.birthDate).toBeNull();
+      expect(result.phoneNumber).toBeNull();
+      expect(result.needsProfile).toBe(true);
+    });
+  });
+
+  describe('startOidcLogin returnTo 분기 (빈 값/공백)', () => {
+    it('returnTo가 undefined이면 기본 프론트 URL을 사용한다', async () => {
+      const mockRes = { cookie: jest.fn() } as unknown as Response;
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'FRONTEND_BASE_URL') return 'http://front.example';
+        return undefined;
+      });
+      mockOidc.buildAuthorizationUrl.mockResolvedValue({
+        authorizationUrl: 'https://a',
+        state: 's',
+        nonce: 'n',
+        codeVerifier: 'v',
+      });
+
+      await service.startOidcLogin('google', undefined, mockRes);
+
+      const returnToCookie = (mockRes.cookie as jest.Mock).mock.calls.find(
+        (c) => c[0] === 'caquick_oidc_return_to',
+      );
+      expect(returnToCookie![1]).toBe('http://front.example');
+    });
+
+    it('FRONTEND_BASE_URL이 미설정이면 http://localhost:3000으로 fallback', async () => {
+      const mockRes = { cookie: jest.fn() } as unknown as Response;
+      mockConfig.get.mockImplementation(() => undefined);
+      mockOidc.buildAuthorizationUrl.mockResolvedValue({
+        authorizationUrl: 'https://a',
+        state: 's',
+        nonce: 'n',
+        codeVerifier: 'v',
+      });
+
+      await service.startOidcLogin('google', '   ', mockRes);
+
+      const returnToCookie = (mockRes.cookie as jest.Mock).mock.calls.find(
+        (c) => c[0] === 'caquick_oidc_return_to',
+      );
+      expect(returnToCookie![1]).toBe('http://localhost:3000');
+    });
   });
 });

--- a/src/features/auth/controllers/auth.controller.spec.ts
+++ b/src/features/auth/controllers/auth.controller.spec.ts
@@ -1,8 +1,18 @@
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Request, Response } from 'express';
 
 import { AuthService } from '@/features/auth/auth.service';
 import { AuthController } from '@/features/auth/controllers/auth.controller';
+
+function mockRes(): Response {
+  return {
+    redirect: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+}
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -12,6 +22,12 @@ describe('AuthController', () => {
     auth = {
       startOidcLogin: jest.fn(),
       handleOidcCallback: jest.fn(),
+      refresh: jest.fn(),
+      logout: jest.fn(),
+      sellerLogin: jest.fn(),
+      refreshSeller: jest.fn(),
+      logoutSeller: jest.fn(),
+      changeSellerPassword: jest.fn(),
     } as unknown as jest.Mocked<AuthService>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -64,5 +80,126 @@ describe('AuthController', () => {
 
     expect(auth.handleOidcCallback).toHaveBeenCalledWith('google', req, res);
     expect(res.redirect).toHaveBeenCalledWith('https://caquick.site/mypage');
+  });
+
+  it('refresh는 200 + accessToken JSON으로 응답한다', async () => {
+    const res = mockRes();
+    const req = {} as Request;
+    auth.refresh.mockResolvedValue({
+      accessToken: 'new-access',
+    });
+
+    await controller.refresh(req, res);
+
+    expect(auth.refresh).toHaveBeenCalledWith(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      accessToken: 'new-access',
+      tokenType: 'Bearer',
+    });
+  });
+
+  it('logout은 204 + empty body로 응답한다', async () => {
+    const res = mockRes();
+    const req = {} as Request;
+
+    await controller.logout(req, res);
+
+    expect(auth.logout).toHaveBeenCalledWith(req, res);
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it('sellerLogin은 accessToken + accountStatus를 응답한다', async () => {
+    const res = mockRes();
+    const req = {} as Request;
+    auth.sellerLogin.mockResolvedValue({
+      accessToken: 'seller-access',
+      accountStatus: 'ACTIVE',
+    });
+
+    await controller.sellerLogin(
+      { username: 'seller', password: 'pw1234!A' },
+      req,
+      res,
+    );
+
+    expect(auth.sellerLogin).toHaveBeenCalledWith({
+      username: 'seller',
+      password: 'pw1234!A',
+      req,
+      res,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      accessToken: 'seller-access',
+      tokenType: 'Bearer',
+      accountStatus: 'ACTIVE',
+    });
+  });
+
+  it('sellerRefresh는 accessToken + accountStatus를 응답한다', async () => {
+    const res = mockRes();
+    const req = {} as Request;
+    auth.refreshSeller.mockResolvedValue({
+      accessToken: 'rotated',
+      accountStatus: 'ACTIVE',
+    });
+
+    await controller.sellerRefresh(req, res);
+
+    expect(auth.refreshSeller).toHaveBeenCalledWith(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      accessToken: 'rotated',
+      tokenType: 'Bearer',
+      accountStatus: 'ACTIVE',
+    });
+  });
+
+  it('sellerLogout은 204로 응답한다', async () => {
+    const res = mockRes();
+    const req = {} as Request;
+
+    await controller.sellerLogout(req, res);
+
+    expect(auth.logoutSeller).toHaveBeenCalledWith(req, res);
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it('sellerChangePassword는 parseAccountId 후 {ok:true}를 반환한다', async () => {
+    const res = mockRes();
+    const req = {} as Request;
+
+    await controller.sellerChangePassword(
+      { accountId: '42' },
+      { currentPassword: 'old!Pass1', newPassword: 'New!Pass1' },
+      req,
+      res,
+    );
+
+    expect(auth.changeSellerPassword).toHaveBeenCalledWith({
+      accountId: BigInt(42),
+      currentPassword: 'old!Pass1',
+      newPassword: 'New!Pass1',
+      req,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('sellerChangePassword는 accountId가 BigInt로 파싱 불가하면 BadRequestException', async () => {
+    const res = mockRes();
+    const req = {} as Request;
+
+    await expect(
+      controller.sellerChangePassword(
+        { accountId: 'not-a-number' },
+        { currentPassword: 'old', newPassword: 'new' },
+        req,
+        res,
+      ),
+    ).rejects.toThrow(BadRequestException);
   });
 });

--- a/src/features/auth/controllers/auth.controller.spec.ts
+++ b/src/features/auth/controllers/auth.controller.spec.ts
@@ -4,6 +4,7 @@ import type { Request, Response } from 'express';
 
 import { AuthService } from '@/features/auth/auth.service';
 import { AuthController } from '@/features/auth/controllers/auth.controller';
+import type { JwtUser } from '@/global/auth';
 
 function mockRes(): Response {
   return {
@@ -172,8 +173,9 @@ describe('AuthController', () => {
     const res = mockRes();
     const req = {} as Request;
 
+    const user: JwtUser = { accountId: '42', accountType: 'SELLER' };
     await controller.sellerChangePassword(
-      { accountId: '42' },
+      user,
       { currentPassword: 'old!Pass1', newPassword: 'New!Pass1' },
       req,
       res,
@@ -193,9 +195,13 @@ describe('AuthController', () => {
     const res = mockRes();
     const req = {} as Request;
 
+    const badUser: JwtUser = {
+      accountId: 'not-a-number',
+      accountType: 'SELLER',
+    };
     await expect(
       controller.sellerChangePassword(
-        { accountId: 'not-a-number' },
+        badUser,
         { currentPassword: 'old', newPassword: 'new' },
         req,
         res,

--- a/src/features/auth/repositories/auth.repository.spec.ts
+++ b/src/features/auth/repositories/auth.repository.spec.ts
@@ -153,6 +153,45 @@ describe('AuthRepository (real DB)', () => {
 
       expect(result.account!.user_profile!.nickname).toBe('john');
     });
+
+    it('displayName/email 모두 없으면 nickname이 "user"로 생성된다', async () => {
+      const result = await repo.upsertUserByOidcIdentity({
+        provider: IdentityProvider.KAKAO,
+        providerSubject: 'anonymous-sub',
+        emailVerified: false,
+      });
+
+      expect(result.account!.user_profile!.nickname).toBe('user');
+    });
+
+    it('기존 Identity + account email이 null + user_profile 없는 경우: profile 신규 생성 + email 주입', async () => {
+      // account는 있지만 email/profile이 비어있는 초기 상태 재현
+      const account = await prisma.account.create({
+        data: {
+          account_type: 'USER',
+          email: null,
+          name: null,
+          status: 'ACTIVE',
+        },
+      });
+      await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'GOOGLE',
+        provider_subject: 'partial-sub',
+      });
+
+      const result = await repo.upsertUserByOidcIdentity({
+        provider: IdentityProvider.GOOGLE,
+        providerSubject: 'partial-sub',
+        providerEmail: 'new-profile@example.com',
+        emailVerified: true,
+        providerDisplayName: 'New Name',
+      });
+
+      expect(result.account!.email).toBe('new-profile@example.com');
+      expect(result.account!.name).toBe('New Name');
+      expect(result.account!.user_profile).not.toBeNull();
+    });
   });
 
   // ─── Refresh Session ───
@@ -416,6 +455,42 @@ describe('AuthRepository (real DB)', () => {
       });
       expect(logs).toHaveLength(1);
       expect(logs[0].action).toBe(AuditActionType.UPDATE);
+    });
+
+    it('storeId/ipAddress/userAgent/beforeJson 모두 생략해도 기본 null 처리로 생성된다', async () => {
+      const account = await createAccount(prisma);
+
+      await repo.createAuditLog({
+        actorAccountId: account.id,
+        targetType: AuditTargetType.STORE,
+        targetId: account.id,
+        action: AuditActionType.UPDATE,
+      });
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].store_id).toBeNull();
+      expect(logs[0].ip_address).toBeNull();
+      expect(logs[0].user_agent).toBeNull();
+      expect(logs[0].before_json).toBeNull();
+      expect(logs[0].after_json).toBeNull();
+    });
+  });
+
+  describe('createRefreshSession (userAgent/ipAddress 미지정 분기)', () => {
+    it('userAgent/ipAddress 미지정 시 null로 저장된다', async () => {
+      const account = await createAccount(prisma);
+
+      const session = await repo.createRefreshSession({
+        accountId: account.id,
+        tokenHash: 'b'.repeat(64),
+        expiresAt: new Date(Date.now() + 3600_000),
+      });
+
+      expect(session.user_agent).toBeNull();
+      expect(session.ip_address).toBeNull();
     });
   });
 });

--- a/src/features/auth/strategies/jwt-bearer.strategy.spec.ts
+++ b/src/features/auth/strategies/jwt-bearer.strategy.spec.ts
@@ -119,4 +119,28 @@ describe('JwtBearerStrategy (real DB)', () => {
       ).rejects.toThrow(UnauthorizedException);
     });
   });
+
+  describe('constructor 분기', () => {
+    /**
+     * 생성자에서 JWT_ACCESS_SECRET 필수 검증을 fail-fast 한다.
+     * - 미설정/공백만 있는 경우 모두 throw 되어야 한다.
+     * - passport-jwt Strategy 생성자는 secret 없을 때 내부적으로 throw하므로,
+     *   config에 빈 문자열이면 커스텀 throw가 먼저 발생함을 확인한다.
+     */
+    it('JWT_ACCESS_SECRET 미설정이면 Error', () => {
+      const config = { get: () => undefined } as never;
+      const repo = {} as never;
+      expect(() => new JwtBearerStrategy(config, repo)).toThrow(
+        'Missing JWT_ACCESS_SECRET',
+      );
+    });
+
+    it('JWT_ACCESS_SECRET이 공백 문자열이면 Error', () => {
+      const config = { get: () => '   ' } as never;
+      const repo = {} as never;
+      expect(() => new JwtBearerStrategy(config, repo)).toThrow(
+        'Missing JWT_ACCESS_SECRET',
+      );
+    });
+  });
 });

--- a/src/features/order/repositories/order.repository.spec.ts
+++ b/src/features/order/repositories/order.repository.spec.ts
@@ -314,6 +314,66 @@ describe('OrderRepository (real DB)', () => {
       expect(rows.map((r) => r.id)).toEqual([inside.id]);
     });
 
+    it('toCreatedAt / fromPickupAt / toPickupAt 필터가 각각 동작한다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+
+      const oldOrder = await prisma.order.create({
+        data: {
+          account_id: buyer.id,
+          order_number: 'OLD-2',
+          status: 'SUBMITTED',
+          pickup_at: new Date('2026-01-15'),
+          buyer_name: 'x',
+          buyer_phone: '010-0000-0000',
+          subtotal_price: 0,
+          discount_price: 0,
+          total_price: 0,
+          created_at: new Date('2025-06-01'),
+        },
+      });
+      await createOrderItem(prisma, {
+        order_id: oldOrder.id,
+        store_id: store.id,
+      });
+
+      const newOrder = await prisma.order.create({
+        data: {
+          account_id: buyer.id,
+          order_number: 'NEW-2',
+          status: 'SUBMITTED',
+          pickup_at: new Date('2026-06-15'),
+          buyer_name: 'y',
+          buyer_phone: '010-1111-1111',
+          subtotal_price: 0,
+          discount_price: 0,
+          total_price: 0,
+          created_at: new Date('2026-05-01'),
+        },
+      });
+      await createOrderItem(prisma, {
+        order_id: newOrder.id,
+        store_id: store.id,
+      });
+
+      // toCreatedAt 단독: 2025-06 만 통과
+      const byTo = await repo.listOrdersByStore({
+        storeId: store.id,
+        limit: 10,
+        toCreatedAt: new Date('2026-01-01'),
+      });
+      expect(byTo.map((r) => r.id)).toEqual([oldOrder.id]);
+
+      // fromPickupAt/toPickupAt 조합: 2026-03 ~ 2026-08 (newOrder만)
+      const byPickup = await repo.listOrdersByStore({
+        storeId: store.id,
+        limit: 10,
+        fromPickupAt: new Date('2026-03-01'),
+        toPickupAt: new Date('2026-08-01'),
+      });
+      expect(byPickup.map((r) => r.id)).toEqual([newOrder.id]);
+    });
+
     it('cursor 기반 페이지네이션 (id < cursor)', async () => {
       const buyer = await setupBuyer();
       const store = await createStore(prisma);

--- a/src/features/seller/resolvers/seller-product.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-product.resolver.spec.ts
@@ -8,6 +8,25 @@ import { SellerProductQueryResolver } from '@/features/seller/resolvers/seller-p
 import { SellerCustomTemplateService } from '@/features/seller/services/seller-custom-template.service';
 import { SellerOptionService } from '@/features/seller/services/seller-option.service';
 import { SellerProductCrudService } from '@/features/seller/services/seller-product-crud.service';
+import type {
+  SellerAddProductImageInput,
+  SellerCreateOptionGroupInput,
+  SellerCreateOptionItemInput,
+  SellerCreateProductInput,
+  SellerReorderOptionGroupsInput,
+  SellerReorderOptionItemsInput,
+  SellerReorderProductCustomTextTokensInput,
+  SellerReorderProductImagesInput,
+  SellerSetProductActiveInput,
+  SellerSetProductCategoriesInput,
+  SellerSetProductCustomTemplateActiveInput,
+  SellerSetProductTagsInput,
+  SellerUpdateOptionGroupInput,
+  SellerUpdateOptionItemInput,
+  SellerUpdateProductInput,
+  SellerUpsertProductCustomTemplateInput,
+  SellerUpsertProductCustomTextTokenInput,
+} from '@/features/seller/types/seller-input.type';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
 import { createProduct, setupSellerWithStore } from '@/test/factories';
@@ -47,13 +66,14 @@ describe('Seller Product Resolvers (real DB)', () => {
   it('Mutation.sellerCreateProduct + Query.sellerProducts: DB 왕복 반영', async () => {
     const { account } = await setupSellerWithStore(prisma);
 
+    const createInput: SellerCreateProductInput = {
+      name: '신상',
+      regularPrice: 10000,
+      initialImageUrl: 'https://i.example/a.png',
+    };
     const created = await mutationResolver.sellerCreateProduct(
       { accountId: account.id.toString() },
-      {
-        name: '신상',
-        regularPrice: 10000,
-        initialImageUrl: 'https://i.example/a.png',
-      } as never,
+      createInput,
     );
     expect(created.name).toBe('신상');
 
@@ -82,15 +102,16 @@ describe('Seller Product Resolvers (real DB)', () => {
     const { account, store } = await setupSellerWithStore(prisma);
     const product = await createProduct(prisma, { store_id: store.id });
 
+    const badInput: SellerCreateOptionGroupInput = {
+      productId: product.id.toString(),
+      name: 'X',
+      minSelect: 3,
+      maxSelect: 1,
+    };
     await expect(
       mutationResolver.sellerCreateOptionGroup(
         { accountId: account.id.toString() },
-        {
-          productId: product.id.toString(),
-          name: 'X',
-          minSelect: 3,
-          maxSelect: 1,
-        } as never,
+        badInput,
       ),
     ).rejects.toThrow(BadRequestException);
   });
@@ -110,11 +131,15 @@ describe('Seller Product Resolvers (real DB)', () => {
     async function setupProductForMutationWiring() {
       const { account, store } = await setupSellerWithStore(prisma);
       const auth = { accountId: account.id.toString() };
-      const created = await mutationResolver.sellerCreateProduct(auth, {
+      const createInput: SellerCreateProductInput = {
         name: '원본',
         regularPrice: 10000,
         initialImageUrl: 'https://i.example/init.png',
-      } as never);
+      };
+      const created = await mutationResolver.sellerCreateProduct(
+        auth,
+        createInput,
+      );
       return { account, store, auth, productId: created.id };
     }
 
@@ -122,35 +147,48 @@ describe('Seller Product Resolvers (real DB)', () => {
       const { auth, productId } = await setupProductForMutationWiring();
 
       // update / setActive
-      const updated = await mutationResolver.sellerUpdateProduct(auth, {
+      const updateInput: SellerUpdateProductInput = {
         productId,
         name: '수정됨',
-      } as never);
+      };
+      const updated = await mutationResolver.sellerUpdateProduct(
+        auth,
+        updateInput,
+      );
       expect(updated.name).toBe('수정됨');
 
-      const toggled = await mutationResolver.sellerSetProductActive(auth, {
+      const setActiveInput: SellerSetProductActiveInput = {
         productId,
         isActive: false,
-      } as never);
+      };
+      const toggled = await mutationResolver.sellerSetProductActive(
+        auth,
+        setActiveInput,
+      );
       expect(toggled.isActive).toBe(false);
 
       // image add / reorder / delete
-      const addedImage = await mutationResolver.sellerAddProductImage(auth, {
+      const addImageInput: SellerAddProductImageInput = {
         productId,
         imageUrl: 'https://i.example/b.png',
-      } as never);
+      };
+      const addedImage = await mutationResolver.sellerAddProductImage(
+        auth,
+        addImageInput,
+      );
       const initialImage = await prisma.productImage.findFirstOrThrow({
         where: {
           product_id: BigInt(productId),
           id: { not: BigInt(addedImage.id) },
         },
       });
+      const reorderImagesInput: SellerReorderProductImagesInput = {
+        productId,
+        imageIds: [addedImage.id, initialImage.id.toString()],
+      };
       const reordered = await mutationResolver.sellerReorderProductImages(
         auth,
-        {
-          productId,
-          imageIds: [addedImage.id, initialImage.id.toString()],
-        } as never,
+        reorderImagesInput,
       );
       expect(reordered.map((r) => r.id)).toEqual([
         addedImage.id,
@@ -164,20 +202,25 @@ describe('Seller Product Resolvers (real DB)', () => {
       const category = await prisma.category.create({
         data: { name: '생일', category_type: 'EVENT' },
       });
+      const setCategoriesInput: SellerSetProductCategoriesInput = {
+        productId,
+        categoryIds: [category.id.toString()],
+      };
       const withCategory = await mutationResolver.sellerSetProductCategories(
         auth,
-        {
-          productId,
-          categoryIds: [category.id.toString()],
-        } as never,
+        setCategoriesInput,
       );
       expect(withCategory.categories.map((c) => c.name)).toContain('생일');
 
       const tag = await prisma.tag.create({ data: { name: '레터링' } });
-      const withTag = await mutationResolver.sellerSetProductTags(auth, {
+      const setTagsInput: SellerSetProductTagsInput = {
         productId,
         tagIds: [tag.id.toString()],
-      } as never);
+      };
+      const withTag = await mutationResolver.sellerSetProductTags(
+        auth,
+        setTagsInput,
+      );
       expect(withTag.tags.map((t) => t.name)).toContain('레터링');
 
       // 본인 product delete
@@ -189,31 +232,44 @@ describe('Seller Product Resolvers (real DB)', () => {
     it('option group lifecycle(create/update/reorder/delete) 배선', async () => {
       const { auth, productId } = await setupProductForMutationWiring();
 
-      const group1 = await mutationResolver.sellerCreateOptionGroup(auth, {
+      const createGroup1: SellerCreateOptionGroupInput = {
         productId,
         name: '사이즈',
         minSelect: 1,
         maxSelect: 1,
-      } as never);
-      const group2 = await mutationResolver.sellerCreateOptionGroup(auth, {
+      };
+      const group1 = await mutationResolver.sellerCreateOptionGroup(
+        auth,
+        createGroup1,
+      );
+      const createGroup2: SellerCreateOptionGroupInput = {
         productId,
         name: '토핑',
         minSelect: 0,
         maxSelect: 3,
-      } as never);
+      };
+      const group2 = await mutationResolver.sellerCreateOptionGroup(
+        auth,
+        createGroup2,
+      );
 
+      const updateGroupInput: SellerUpdateOptionGroupInput = {
+        optionGroupId: group1.id,
+        name: '사이즈(수정)',
+      };
       const groupUpdated = await mutationResolver.sellerUpdateOptionGroup(
         auth,
-        { optionGroupId: group1.id, name: '사이즈(수정)' } as never,
+        updateGroupInput,
       );
       expect(groupUpdated.name).toBe('사이즈(수정)');
 
+      const reorderGroupsInput: SellerReorderOptionGroupsInput = {
+        productId,
+        optionGroupIds: [group2.id, group1.id],
+      };
       const reorderedGroups = await mutationResolver.sellerReorderOptionGroups(
         auth,
-        {
-          productId,
-          optionGroupIds: [group2.id, group1.id],
-        } as never,
+        reorderGroupsInput,
       );
       expect(reorderedGroups.map((g) => g.id)).toEqual([group2.id, group1.id]);
 
@@ -224,36 +280,53 @@ describe('Seller Product Resolvers (real DB)', () => {
 
     it('option item lifecycle(create/update/reorder/delete) 배선', async () => {
       const { auth, productId } = await setupProductForMutationWiring();
-      const group = await mutationResolver.sellerCreateOptionGroup(auth, {
+      const createGroupInput: SellerCreateOptionGroupInput = {
         productId,
         name: '사이즈',
         minSelect: 0,
         maxSelect: 3,
-      } as never);
+      };
+      const group = await mutationResolver.sellerCreateOptionGroup(
+        auth,
+        createGroupInput,
+      );
 
-      const item1 = await mutationResolver.sellerCreateOptionItem(auth, {
+      const createItem1: SellerCreateOptionItemInput = {
         optionGroupId: group.id,
         title: 'S',
         priceDelta: 0,
-      } as never);
-      const item2 = await mutationResolver.sellerCreateOptionItem(auth, {
+      };
+      const item1 = await mutationResolver.sellerCreateOptionItem(
+        auth,
+        createItem1,
+      );
+      const createItem2: SellerCreateOptionItemInput = {
         optionGroupId: group.id,
         title: 'M',
         priceDelta: 1000,
-      } as never);
+      };
+      const item2 = await mutationResolver.sellerCreateOptionItem(
+        auth,
+        createItem2,
+      );
 
-      const itemUpdated = await mutationResolver.sellerUpdateOptionItem(auth, {
+      const updateItemInput: SellerUpdateOptionItemInput = {
         optionItemId: item1.id,
         title: 'Small',
-      } as never);
+      };
+      const itemUpdated = await mutationResolver.sellerUpdateOptionItem(
+        auth,
+        updateItemInput,
+      );
       expect(itemUpdated.title).toBe('Small');
 
+      const reorderItemsInput: SellerReorderOptionItemsInput = {
+        optionGroupId: group.id,
+        optionItemIds: [item2.id, item1.id],
+      };
       const reorderedItems = await mutationResolver.sellerReorderOptionItems(
         auth,
-        {
-          optionGroupId: group.id,
-          optionItemIds: [item2.id, item1.id],
-        } as never,
+        reorderItemsInput,
       );
       expect(reorderedItems.map((i) => i.id)).toEqual([item2.id, item1.id]);
 
@@ -265,43 +338,55 @@ describe('Seller Product Resolvers (real DB)', () => {
     it('custom template + text token lifecycle 배선', async () => {
       const { auth, productId } = await setupProductForMutationWiring();
 
+      const upsertTemplateInput: SellerUpsertProductCustomTemplateInput = {
+        productId,
+        baseImageUrl: 'https://i.example/tpl.png',
+        isActive: true,
+      };
       const template = await mutationResolver.sellerUpsertProductCustomTemplate(
         auth,
-        {
-          productId,
-          baseImageUrl: 'https://i.example/tpl.png',
-          isActive: true,
-        } as never,
+        upsertTemplateInput,
       );
-      const templateActive =
-        await mutationResolver.sellerSetProductCustomTemplateActive(auth, {
+      const setTemplateActiveInput: SellerSetProductCustomTemplateActiveInput =
+        {
           templateId: template.id,
           isActive: false,
-        } as never);
+        };
+      const templateActive =
+        await mutationResolver.sellerSetProductCustomTemplateActive(
+          auth,
+          setTemplateActiveInput,
+        );
       expect(templateActive.isActive).toBe(false);
 
+      const upsertToken1: SellerUpsertProductCustomTextTokenInput = {
+        templateId: template.id,
+        tokenKey: 'name',
+        defaultText: '기본',
+      };
       const token1 = await mutationResolver.sellerUpsertProductCustomTextToken(
         auth,
-        {
-          templateId: template.id,
-          tokenKey: 'name',
-          defaultText: '기본',
-        } as never,
+        upsertToken1,
       );
+      const upsertToken2: SellerUpsertProductCustomTextTokenInput = {
+        templateId: template.id,
+        tokenKey: 'age',
+        defaultText: '10',
+      };
       const token2 = await mutationResolver.sellerUpsertProductCustomTextToken(
         auth,
-        {
-          templateId: template.id,
-          tokenKey: 'age',
-          defaultText: '10',
-        } as never,
+        upsertToken2,
       );
 
+      const reorderTokensInput: SellerReorderProductCustomTextTokensInput = {
+        templateId: template.id,
+        tokenIds: [token2.id, token1.id],
+      };
       const reorderedTokens =
-        await mutationResolver.sellerReorderProductCustomTextTokens(auth, {
-          templateId: template.id,
-          tokenIds: [token2.id, token1.id],
-        } as never);
+        await mutationResolver.sellerReorderProductCustomTextTokens(
+          auth,
+          reorderTokensInput,
+        );
       expect(reorderedTokens.map((t) => t.id)).toEqual([token2.id, token1.id]);
 
       expect(

--- a/src/features/seller/resolvers/seller-product.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-product.resolver.spec.ts
@@ -96,38 +96,45 @@ describe('Seller Product Resolvers (real DB)', () => {
   });
 
   /**
-   * 모든 seller-product-mutation resolver 메서드를 한 번씩 경유하는 배선 통합 테스트.
-   * 상세 분기/예외는 service.spec에서 담당하며, 이 블록은
-   * resolver → service → repository 어댑터 계층이 정상 배선되었는지만 확인한다.
+   * 모든 seller-product-mutation resolver 메서드를 도메인 단위로 묶어 배선만 검증하는 통합 테스트.
+   * 상세 분기/예외는 service.spec에서 담당하며, 여기는 resolver → service → repository 어댑터
+   * 계층이 정상 배선되었는지만 확인한다.
+   *
+   * truncateAll이 beforeEach에서 동작하므로, 각 it은 자체 setup(seller + product)으로 시작한다.
    */
   describe('전체 Mutation 메서드 배선 커버리지', () => {
-    it('product/option/template/token 주요 mutation을 순차 호출하여 DB 반영까지 확인', async () => {
+    /**
+     * 본 describe의 공통 setup. account/store + 1개 product를 만들고 auth/productId/auth+resolver 호출에
+     * 필요한 최소 입력을 반환한다.
+     */
+    async function setupProductForMutationWiring() {
       const { account, store } = await setupSellerWithStore(prisma);
       const auth = { accountId: account.id.toString() };
-
-      // 1) sellerCreateProduct
       const created = await mutationResolver.sellerCreateProduct(auth, {
         name: '원본',
         regularPrice: 10000,
         initialImageUrl: 'https://i.example/init.png',
       } as never);
-      const productId = created.id;
+      return { account, store, auth, productId: created.id };
+    }
 
-      // 2) sellerUpdateProduct
+    it('product CRUD + image + category + tag mutation 배선', async () => {
+      const { auth, productId } = await setupProductForMutationWiring();
+
+      // update / setActive
       const updated = await mutationResolver.sellerUpdateProduct(auth, {
         productId,
         name: '수정됨',
       } as never);
       expect(updated.name).toBe('수정됨');
 
-      // 3) sellerSetProductActive
       const toggled = await mutationResolver.sellerSetProductActive(auth, {
         productId,
         isActive: false,
       } as never);
       expect(toggled.isActive).toBe(false);
 
-      // 4) sellerAddProductImage + 5) sellerReorderProductImages + 6) sellerDeleteProductImage
+      // image add / reorder / delete
       const addedImage = await mutationResolver.sellerAddProductImage(auth, {
         productId,
         imageUrl: 'https://i.example/b.png',
@@ -149,13 +156,11 @@ describe('Seller Product Resolvers (real DB)', () => {
         addedImage.id,
         initialImage.id.toString(),
       ]);
-      const deleteOk = await mutationResolver.sellerDeleteProductImage(
-        auth,
-        addedImage.id,
-      );
-      expect(deleteOk).toBe(true);
+      expect(
+        await mutationResolver.sellerDeleteProductImage(auth, addedImage.id),
+      ).toBe(true);
 
-      // 7) sellerSetProductCategories
+      // category / tag
       const category = await prisma.category.create({
         data: { name: '생일', category_type: 'EVENT' },
       });
@@ -168,7 +173,6 @@ describe('Seller Product Resolvers (real DB)', () => {
       );
       expect(withCategory.categories.map((c) => c.name)).toContain('생일');
 
-      // 8) sellerSetProductTags
       const tag = await prisma.tag.create({ data: { name: '레터링' } });
       const withTag = await mutationResolver.sellerSetProductTags(auth, {
         productId,
@@ -176,7 +180,15 @@ describe('Seller Product Resolvers (real DB)', () => {
       } as never);
       expect(withTag.tags.map((t) => t.name)).toContain('레터링');
 
-      // 9~12) option group: create/update/reorder/delete
+      // 본인 product delete
+      expect(await mutationResolver.sellerDeleteProduct(auth, productId)).toBe(
+        true,
+      );
+    });
+
+    it('option group lifecycle(create/update/reorder/delete) 배선', async () => {
+      const { auth, productId } = await setupProductForMutationWiring();
+
       const group1 = await mutationResolver.sellerCreateOptionGroup(auth, {
         productId,
         name: '사이즈',
@@ -189,11 +201,13 @@ describe('Seller Product Resolvers (real DB)', () => {
         minSelect: 0,
         maxSelect: 3,
       } as never);
+
       const groupUpdated = await mutationResolver.sellerUpdateOptionGroup(
         auth,
         { optionGroupId: group1.id, name: '사이즈(수정)' } as never,
       );
       expect(groupUpdated.name).toBe('사이즈(수정)');
+
       const reorderedGroups = await mutationResolver.sellerReorderOptionGroups(
         auth,
         {
@@ -202,35 +216,55 @@ describe('Seller Product Resolvers (real DB)', () => {
         } as never,
       );
       expect(reorderedGroups.map((g) => g.id)).toEqual([group2.id, group1.id]);
-      await mutationResolver.sellerDeleteOptionGroup(auth, group2.id);
 
-      // 13~16) option item: create/update/reorder/delete
+      expect(
+        await mutationResolver.sellerDeleteOptionGroup(auth, group2.id),
+      ).toBe(true);
+    });
+
+    it('option item lifecycle(create/update/reorder/delete) 배선', async () => {
+      const { auth, productId } = await setupProductForMutationWiring();
+      const group = await mutationResolver.sellerCreateOptionGroup(auth, {
+        productId,
+        name: '사이즈',
+        minSelect: 0,
+        maxSelect: 3,
+      } as never);
+
       const item1 = await mutationResolver.sellerCreateOptionItem(auth, {
-        optionGroupId: group1.id,
+        optionGroupId: group.id,
         title: 'S',
         priceDelta: 0,
       } as never);
       const item2 = await mutationResolver.sellerCreateOptionItem(auth, {
-        optionGroupId: group1.id,
+        optionGroupId: group.id,
         title: 'M',
         priceDelta: 1000,
       } as never);
+
       const itemUpdated = await mutationResolver.sellerUpdateOptionItem(auth, {
         optionItemId: item1.id,
         title: 'Small',
       } as never);
       expect(itemUpdated.title).toBe('Small');
+
       const reorderedItems = await mutationResolver.sellerReorderOptionItems(
         auth,
         {
-          optionGroupId: group1.id,
+          optionGroupId: group.id,
           optionItemIds: [item2.id, item1.id],
         } as never,
       );
       expect(reorderedItems.map((i) => i.id)).toEqual([item2.id, item1.id]);
-      await mutationResolver.sellerDeleteOptionItem(auth, item2.id);
 
-      // 17~18) custom template: upsert + setActive
+      expect(
+        await mutationResolver.sellerDeleteOptionItem(auth, item2.id),
+      ).toBe(true);
+    });
+
+    it('custom template + text token lifecycle 배선', async () => {
+      const { auth, productId } = await setupProductForMutationWiring();
+
       const template = await mutationResolver.sellerUpsertProductCustomTemplate(
         auth,
         {
@@ -246,7 +280,6 @@ describe('Seller Product Resolvers (real DB)', () => {
         } as never);
       expect(templateActive.isActive).toBe(false);
 
-      // 19~21) custom text token: upsert/reorder/delete
       const token1 = await mutationResolver.sellerUpsertProductCustomTextToken(
         auth,
         {
@@ -263,23 +296,20 @@ describe('Seller Product Resolvers (real DB)', () => {
           defaultText: '10',
         } as never,
       );
+
       const reorderedTokens =
         await mutationResolver.sellerReorderProductCustomTextTokens(auth, {
           templateId: template.id,
           tokenIds: [token2.id, token1.id],
         } as never);
       expect(reorderedTokens.map((t) => t.id)).toEqual([token2.id, token1.id]);
-      await mutationResolver.sellerDeleteProductCustomTextToken(
-        auth,
-        token1.id,
-      );
 
-      // 22) sellerDeleteProduct (이미 위에서 sellerDeleteProduct 타 store 테스트 존재, 여기선 본인 삭제)
-      const deleted = await mutationResolver.sellerDeleteProduct(
-        auth,
-        productId,
-      );
-      expect(deleted).toBe(true);
+      expect(
+        await mutationResolver.sellerDeleteProductCustomTextToken(
+          auth,
+          token1.id,
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/src/features/seller/resolvers/seller-product.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-product.resolver.spec.ts
@@ -94,4 +94,192 @@ describe('Seller Product Resolvers (real DB)', () => {
       ),
     ).rejects.toThrow(BadRequestException);
   });
+
+  /**
+   * 모든 seller-product-mutation resolver 메서드를 한 번씩 경유하는 배선 통합 테스트.
+   * 상세 분기/예외는 service.spec에서 담당하며, 이 블록은
+   * resolver → service → repository 어댑터 계층이 정상 배선되었는지만 확인한다.
+   */
+  describe('전체 Mutation 메서드 배선 커버리지', () => {
+    it('product/option/template/token 주요 mutation을 순차 호출하여 DB 반영까지 확인', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const auth = { accountId: account.id.toString() };
+
+      // 1) sellerCreateProduct
+      const created = await mutationResolver.sellerCreateProduct(auth, {
+        name: '원본',
+        regularPrice: 10000,
+        initialImageUrl: 'https://i.example/init.png',
+      } as never);
+      const productId = created.id;
+
+      // 2) sellerUpdateProduct
+      const updated = await mutationResolver.sellerUpdateProduct(auth, {
+        productId,
+        name: '수정됨',
+      } as never);
+      expect(updated.name).toBe('수정됨');
+
+      // 3) sellerSetProductActive
+      const toggled = await mutationResolver.sellerSetProductActive(auth, {
+        productId,
+        isActive: false,
+      } as never);
+      expect(toggled.isActive).toBe(false);
+
+      // 4) sellerAddProductImage + 5) sellerReorderProductImages + 6) sellerDeleteProductImage
+      const addedImage = await mutationResolver.sellerAddProductImage(auth, {
+        productId,
+        imageUrl: 'https://i.example/b.png',
+      } as never);
+      const initialImage = await prisma.productImage.findFirstOrThrow({
+        where: {
+          product_id: BigInt(productId),
+          id: { not: BigInt(addedImage.id) },
+        },
+      });
+      const reordered = await mutationResolver.sellerReorderProductImages(
+        auth,
+        {
+          productId,
+          imageIds: [addedImage.id, initialImage.id.toString()],
+        } as never,
+      );
+      expect(reordered.map((r) => r.id)).toEqual([
+        addedImage.id,
+        initialImage.id.toString(),
+      ]);
+      const deleteOk = await mutationResolver.sellerDeleteProductImage(
+        auth,
+        addedImage.id,
+      );
+      expect(deleteOk).toBe(true);
+
+      // 7) sellerSetProductCategories
+      const category = await prisma.category.create({
+        data: { name: '생일', category_type: 'EVENT' },
+      });
+      const withCategory = await mutationResolver.sellerSetProductCategories(
+        auth,
+        {
+          productId,
+          categoryIds: [category.id.toString()],
+        } as never,
+      );
+      expect(withCategory.categories.map((c) => c.name)).toContain('생일');
+
+      // 8) sellerSetProductTags
+      const tag = await prisma.tag.create({ data: { name: '레터링' } });
+      const withTag = await mutationResolver.sellerSetProductTags(auth, {
+        productId,
+        tagIds: [tag.id.toString()],
+      } as never);
+      expect(withTag.tags.map((t) => t.name)).toContain('레터링');
+
+      // 9~12) option group: create/update/reorder/delete
+      const group1 = await mutationResolver.sellerCreateOptionGroup(auth, {
+        productId,
+        name: '사이즈',
+        minSelect: 1,
+        maxSelect: 1,
+      } as never);
+      const group2 = await mutationResolver.sellerCreateOptionGroup(auth, {
+        productId,
+        name: '토핑',
+        minSelect: 0,
+        maxSelect: 3,
+      } as never);
+      const groupUpdated = await mutationResolver.sellerUpdateOptionGroup(
+        auth,
+        { optionGroupId: group1.id, name: '사이즈(수정)' } as never,
+      );
+      expect(groupUpdated.name).toBe('사이즈(수정)');
+      const reorderedGroups = await mutationResolver.sellerReorderOptionGroups(
+        auth,
+        {
+          productId,
+          optionGroupIds: [group2.id, group1.id],
+        } as never,
+      );
+      expect(reorderedGroups.map((g) => g.id)).toEqual([group2.id, group1.id]);
+      await mutationResolver.sellerDeleteOptionGroup(auth, group2.id);
+
+      // 13~16) option item: create/update/reorder/delete
+      const item1 = await mutationResolver.sellerCreateOptionItem(auth, {
+        optionGroupId: group1.id,
+        title: 'S',
+        priceDelta: 0,
+      } as never);
+      const item2 = await mutationResolver.sellerCreateOptionItem(auth, {
+        optionGroupId: group1.id,
+        title: 'M',
+        priceDelta: 1000,
+      } as never);
+      const itemUpdated = await mutationResolver.sellerUpdateOptionItem(auth, {
+        optionItemId: item1.id,
+        title: 'Small',
+      } as never);
+      expect(itemUpdated.title).toBe('Small');
+      const reorderedItems = await mutationResolver.sellerReorderOptionItems(
+        auth,
+        {
+          optionGroupId: group1.id,
+          optionItemIds: [item2.id, item1.id],
+        } as never,
+      );
+      expect(reorderedItems.map((i) => i.id)).toEqual([item2.id, item1.id]);
+      await mutationResolver.sellerDeleteOptionItem(auth, item2.id);
+
+      // 17~18) custom template: upsert + setActive
+      const template = await mutationResolver.sellerUpsertProductCustomTemplate(
+        auth,
+        {
+          productId,
+          baseImageUrl: 'https://i.example/tpl.png',
+          isActive: true,
+        } as never,
+      );
+      const templateActive =
+        await mutationResolver.sellerSetProductCustomTemplateActive(auth, {
+          templateId: template.id,
+          isActive: false,
+        } as never);
+      expect(templateActive.isActive).toBe(false);
+
+      // 19~21) custom text token: upsert/reorder/delete
+      const token1 = await mutationResolver.sellerUpsertProductCustomTextToken(
+        auth,
+        {
+          templateId: template.id,
+          tokenKey: 'name',
+          defaultText: '기본',
+        } as never,
+      );
+      const token2 = await mutationResolver.sellerUpsertProductCustomTextToken(
+        auth,
+        {
+          templateId: template.id,
+          tokenKey: 'age',
+          defaultText: '10',
+        } as never,
+      );
+      const reorderedTokens =
+        await mutationResolver.sellerReorderProductCustomTextTokens(auth, {
+          templateId: template.id,
+          tokenIds: [token2.id, token1.id],
+        } as never);
+      expect(reorderedTokens.map((t) => t.id)).toEqual([token2.id, token1.id]);
+      await mutationResolver.sellerDeleteProductCustomTextToken(
+        auth,
+        token1.id,
+      );
+
+      // 22) sellerDeleteProduct (이미 위에서 sellerDeleteProduct 타 store 테스트 존재, 여기선 본인 삭제)
+      const deleted = await mutationResolver.sellerDeleteProduct(
+        auth,
+        productId,
+      );
+      expect(deleted).toBe(true);
+    });
+  });
 });

--- a/src/features/seller/services/seller-content.service.spec.ts
+++ b/src/features/seller/services/seller-content.service.spec.ts
@@ -737,11 +737,35 @@ describe('SellerContentService (real DB)', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('audit targetType ORDER/CONVERSATION/CHANGE_PASSWORD도 해석된다', async () => {
-      const { account } = await setupSellerWithStore(prisma);
-      for (const t of ['ORDER', 'CONVERSATION', 'CHANGE_PASSWORD'] as const) {
+    it('audit targetType ORDER/CONVERSATION/CHANGE_PASSWORD가 enum으로 정확히 매핑되어 필터된다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+
+      // 각 targetType별로 식별 가능한 audit log를 미리 생성한다.
+      // (전체 5종 중 위 3종을 검증; STORE/PRODUCT는 다른 분기에서 이미 사용)
+      const types = ['ORDER', 'CONVERSATION', 'CHANGE_PASSWORD'] as const;
+      const created = new Map<string, bigint>();
+      for (const t of types) {
+        const row = await prisma.auditLog.create({
+          data: {
+            actor_account_id: account.id,
+            store_id: store.id,
+            target_type: t,
+            target_id: store.id,
+            action: 'UPDATE',
+          },
+        });
+        created.set(t, row.id);
+      }
+
+      for (const t of types) {
         const r = await service.sellerAuditLogs(account.id, { targetType: t });
-        expect(Array.isArray(r.items)).toBe(true);
+        // 1) 해당 타입의 row만 반환되는지 (다른 타입 섞이지 않음)
+        expect(r.items.length).toBeGreaterThan(0);
+        expect(r.items.every((it) => it.targetType === t)).toBe(true);
+        // 2) 미리 만든 row가 실제로 결과에 포함되는지 (매핑이 정확함을 확인)
+        expect(r.items.some((it) => it.id === created.get(t)!.toString())).toBe(
+          true,
+        );
       }
     });
   });
@@ -749,7 +773,7 @@ describe('SellerContentService (real DB)', () => {
   describe('toAuditLogOutput 비어있는 json 필드 분기', () => {
     it('before/after json이 null인 audit log도 정상 직렬화된다', async () => {
       const { account, store } = await setupSellerWithStore(prisma);
-      await prisma.auditLog.create({
+      const created = await prisma.auditLog.create({
         data: {
           actor_account_id: account.id,
           store_id: store.id,
@@ -762,9 +786,11 @@ describe('SellerContentService (real DB)', () => {
       });
 
       const result = await service.sellerAuditLogs(account.id);
-      expect(result.items.length).toBeGreaterThan(0);
-      expect(result.items[0].beforeJson).toBeNull();
-      expect(result.items[0].afterJson).toBeNull();
+      // 정렬/다른 자동 생성 audit 영향 없이 방금 만든 row 자체를 검증
+      const target = result.items.find((it) => it.id === created.id.toString());
+      expect(target).toBeDefined();
+      expect(target!.beforeJson).toBeNull();
+      expect(target!.afterJson).toBeNull();
     });
   });
 });

--- a/src/features/seller/services/seller-content.service.spec.ts
+++ b/src/features/seller/services/seller-content.service.spec.ts
@@ -3,7 +3,7 @@ import {
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
-import type { PrismaClient } from '@prisma/client';
+import { Prisma, type PrismaClient } from '@prisma/client';
 
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
@@ -562,6 +562,209 @@ describe('SellerContentService (real DB)', () => {
           targetType: 'INVALID' as never,
         }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('cursor 기반 페이지네이션으로 두 번째 페이지를 반환한다', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      for (let i = 0; i < 3; i++) {
+        await service.sellerCreateFaqTopic(account.id, {
+          title: `F${i}`,
+          answerHtml: `<p>${i}</p>`,
+        });
+      }
+
+      const first = await service.sellerAuditLogs(account.id, { limit: 2 });
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).not.toBeNull();
+
+      const second = await service.sellerAuditLogs(account.id, {
+        limit: 2,
+        cursor: first.nextCursor as string,
+      });
+      expect(second.items.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('sellerUpdateFaqTopic 전 필드 분기', () => {
+    it('title/answerHtml/sortOrder/isActive 모든 필드 포함 수정', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      const created = await service.sellerCreateFaqTopic(account.id, {
+        title: '원본',
+        answerHtml: '<p>원본</p>',
+      });
+
+      const result = await service.sellerUpdateFaqTopic(account.id, {
+        topicId: created.id,
+        title: '수정됨',
+        answerHtml: '<p>수정됨</p>',
+        sortOrder: 9,
+        isActive: false,
+      });
+
+      expect(result.title).toBe('수정됨');
+      expect(result.answerHtml).toBe('<p>수정됨</p>');
+      expect(result.sortOrder).toBe(9);
+      expect(result.isActive).toBe(false);
+    });
+  });
+
+  describe('sellerBanners cursor 분기', () => {
+    it('cursor를 포함한 페이지네이션이 정상 동작한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      for (let i = 0; i < 3; i++) {
+        await service.sellerCreateBanner(account.id, {
+          placement: 'STORE',
+          imageUrl: `https://i.example/${i}.png`,
+          linkType: 'STORE',
+          linkStoreId: store.id.toString(),
+        });
+      }
+
+      const first = await service.sellerBanners(account.id, { limit: 2 });
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).not.toBeNull();
+
+      const second = await service.sellerBanners(account.id, {
+        limit: 2,
+        cursor: first.nextCursor as string,
+      });
+      expect(second.items.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('sellerCreateBanner 다양한 linkType 분기', () => {
+    it('linkType=PRODUCT + 본인 매장 product로 생성 성공', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+
+      const result = await service.sellerCreateBanner(account.id, {
+        placement: 'HOME_MAIN',
+        imageUrl: 'https://i.example/p.png',
+        linkType: 'PRODUCT',
+        linkProductId: product.id.toString(),
+      });
+      expect(result.linkType).toBe('PRODUCT');
+      expect(result.linkProductId).toBe(product.id.toString());
+    });
+
+    it('linkType=STORE + 본인 storeId로 생성 성공', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const result = await service.sellerCreateBanner(account.id, {
+        placement: 'HOME_SUB',
+        imageUrl: 'https://i.example/s.png',
+        linkType: 'STORE',
+        linkStoreId: store.id.toString(),
+      });
+      expect(result.linkType).toBe('STORE');
+      expect(result.linkStoreId).toBe(store.id.toString());
+    });
+
+    it('linkType=CATEGORY + category 지정 시 생성 성공', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      const category = await prisma.category.create({
+        data: { name: '시즌', category_type: 'EVENT' },
+      });
+      const result = await service.sellerCreateBanner(account.id, {
+        placement: 'CATEGORY',
+        imageUrl: 'https://i.example/c.png',
+        linkType: 'CATEGORY',
+        linkCategoryId: category.id.toString(),
+      });
+      expect(result.linkType).toBe('CATEGORY');
+      expect(result.linkCategoryId).toBe(category.id.toString());
+    });
+  });
+
+  describe('validateBannerOwnership 추가 분기', () => {
+    it('linkType=STORE + linkStoreId 누락이면 BadRequestException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerCreateBanner(account.id, {
+          placement: 'HOME_MAIN',
+          imageUrl: 'https://i.example/x.png',
+          linkType: 'STORE',
+          linkStoreId: null,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('linkType=STORE + 타 store 지정이면 ForbiddenException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      const otherStore = await createStore(prisma);
+      await expect(
+        service.sellerCreateBanner(account.id, {
+          placement: 'HOME_MAIN',
+          imageUrl: 'https://i.example/x.png',
+          linkType: 'STORE',
+          linkStoreId: otherStore.id.toString(),
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('linkType=CATEGORY + linkCategoryId 누락이면 BadRequestException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerCreateBanner(account.id, {
+          placement: 'CATEGORY',
+          imageUrl: 'https://i.example/x.png',
+          linkType: 'CATEGORY',
+          linkCategoryId: null,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('toBannerPlacement/toBannerLinkType/toAuditTargetType 오류 분기', () => {
+    it('placement가 알 수 없는 값이면 BadRequestException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerCreateBanner(account.id, {
+          placement: 'UNKNOWN' as never,
+          imageUrl: 'https://i.example/x.png',
+          linkType: 'NONE',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('linkType이 알 수 없는 값이면 BadRequestException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerCreateBanner(account.id, {
+          placement: 'HOME_MAIN',
+          imageUrl: 'https://i.example/x.png',
+          linkType: 'INVALID' as never,
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('audit targetType ORDER/CONVERSATION/CHANGE_PASSWORD도 해석된다', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      for (const t of ['ORDER', 'CONVERSATION', 'CHANGE_PASSWORD'] as const) {
+        const r = await service.sellerAuditLogs(account.id, { targetType: t });
+        expect(Array.isArray(r.items)).toBe(true);
+      }
+    });
+  });
+
+  describe('toAuditLogOutput 비어있는 json 필드 분기', () => {
+    it('before/after json이 null인 audit log도 정상 직렬화된다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      await prisma.auditLog.create({
+        data: {
+          actor_account_id: account.id,
+          store_id: store.id,
+          target_type: 'STORE',
+          target_id: store.id,
+          action: 'UPDATE',
+          before_json: Prisma.JsonNull,
+          after_json: Prisma.JsonNull,
+        },
+      });
+
+      const result = await service.sellerAuditLogs(account.id);
+      expect(result.items.length).toBeGreaterThan(0);
+      expect(result.items[0].beforeJson).toBeNull();
+      expect(result.items[0].afterJson).toBeNull();
     });
   });
 });

--- a/src/features/seller/services/seller-conversation.service.spec.ts
+++ b/src/features/seller/services/seller-conversation.service.spec.ts
@@ -183,4 +183,75 @@ describe('SellerConversationService (real DB)', () => {
       expect(auditLogs).toHaveLength(1);
     });
   });
+
+  describe('sellerConversations / sellerConversationMessages cursor 분기', () => {
+    it('sellerConversations: cursor 기반 두 번째 페이지를 반환한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      for (let i = 0; i < 3; i++) await setupConversation(store.id);
+
+      const first = await service.sellerConversations(account.id, { limit: 2 });
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).not.toBeNull();
+
+      const second = await service.sellerConversations(account.id, {
+        limit: 2,
+        cursor: first.nextCursor as string,
+      });
+      expect(second.items.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('sellerConversationMessages: cursor 기반 두 번째 페이지를 반환한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const conv = await setupConversation(store.id);
+      for (let i = 0; i < 3; i++) {
+        await prisma.storeConversationMessage.create({
+          data: {
+            conversation_id: conv.id,
+            sender_type: 'STORE',
+            sender_account_id: account.id,
+            body_format: 'TEXT',
+            body_text: `msg ${i}`,
+          },
+        });
+      }
+      const first = await service.sellerConversationMessages(
+        account.id,
+        conv.id,
+        { limit: 2 },
+      );
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).not.toBeNull();
+
+      const second = await service.sellerConversationMessages(
+        account.id,
+        conv.id,
+        { limit: 2, cursor: first.nextCursor as string },
+      );
+      expect(second.items.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('toConversationMessageOutput senderAccountId null 분기', () => {
+    it('SYSTEM 메시지처럼 sender_account_id가 null이면 출력도 null', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const conv = await setupConversation(store.id);
+      await prisma.storeConversationMessage.create({
+        data: {
+          conversation_id: conv.id,
+          sender_type: 'SYSTEM',
+          sender_account_id: null,
+          body_format: 'TEXT',
+          body_text: '시스템 알림',
+        },
+      });
+
+      const result = await service.sellerConversationMessages(
+        account.id,
+        conv.id,
+      );
+      const systemMsg = result.items.find((m) => m.senderType === 'SYSTEM');
+      expect(systemMsg).toBeDefined();
+      expect(systemMsg!.senderAccountId).toBeNull();
+    });
+  });
 });

--- a/src/features/seller/services/seller-option.service.spec.ts
+++ b/src/features/seller/services/seller-option.service.spec.ts
@@ -396,7 +396,9 @@ describe('SellerOptionService (real DB)', () => {
 
     it('매장 그룹 집합에 없는 id가 섞이면 BadRequestException(invalidIds)', async () => {
       const { accountId, product } = await setupProductForSeller();
-      const g1 = await createOptionGroup(product.id);
+      // 길이 일치 분기(idsMismatchError) 대신 invalidIds 분기를 타도록
+      // 본인 product에 그룹 1개를 미리 만들어 둔다.
+      await createOptionGroup(product.id);
       const otherProduct = await createProduct(prisma, {
         store_id: product.store_id,
         name: 'other',
@@ -409,8 +411,6 @@ describe('SellerOptionService (real DB)', () => {
           optionGroupIds: [otherGroup.id.toString()],
         }),
       ).rejects.toThrow(BadRequestException);
-      // g1은 실제 정합성 확인용 (존재 기준치)
-      expect(g1.id).toBeDefined();
     });
   });
 

--- a/src/features/seller/services/seller-option.service.spec.ts
+++ b/src/features/seller/services/seller-option.service.spec.ts
@@ -319,4 +319,164 @@ describe('SellerOptionService (real DB)', () => {
       expect(result[0].id).toBe(i2.id.toString());
     });
   });
+
+  describe('sellerUpdateOptionGroup 모든 선택 필드 분기', () => {
+    it('name/isRequired/minSelect/maxSelect/sortOrder/isActive/optionRequires* 전체 포함 수정', async () => {
+      const { accountId, product } = await setupProductForSeller();
+      const group = await prisma.productOptionGroup.create({
+        data: {
+          product_id: product.id,
+          name: '사이즈',
+          is_required: true,
+          min_select: 1,
+          max_select: 2,
+        },
+      });
+
+      const result = await service.sellerUpdateOptionGroup(accountId, {
+        optionGroupId: group.id.toString(),
+        name: '사이즈(수정)',
+        isRequired: false,
+        minSelect: 0,
+        maxSelect: 3,
+        sortOrder: 5,
+        isActive: false,
+        optionRequiresDescription: true,
+        optionRequiresImage: true,
+      });
+
+      expect(result.name).toBe('사이즈(수정)');
+      expect(result.isRequired).toBe(false);
+      expect(result.minSelect).toBe(0);
+      expect(result.maxSelect).toBe(3);
+      expect(result.sortOrder).toBe(5);
+      expect(result.isActive).toBe(false);
+      expect(result.optionRequiresDescription).toBe(true);
+      expect(result.optionRequiresImage).toBe(true);
+    });
+  });
+
+  describe('sellerUpdateOptionItem 모든 선택 필드 분기', () => {
+    it('title/description/imageUrl/priceDelta/sortOrder/isActive 전체 포함 수정', async () => {
+      const { accountId, product } = await setupProductForSeller();
+      const group = await createOptionGroup(product.id);
+      const item = await prisma.productOptionItem.create({
+        data: { option_group_id: group.id, title: 'S' },
+      });
+
+      const result = await service.sellerUpdateOptionItem(accountId, {
+        optionItemId: item.id.toString(),
+        title: 'L',
+        description: '대사이즈',
+        imageUrl: 'https://i.example/l.png',
+        priceDelta: 2000,
+        sortOrder: 3,
+        isActive: false,
+      });
+
+      expect(result.title).toBe('L');
+      expect(result.description).toBe('대사이즈');
+      expect(result.imageUrl).toBe('https://i.example/l.png');
+      expect(result.priceDelta).toBe(2000);
+      expect(result.sortOrder).toBe(3);
+      expect(result.isActive).toBe(false);
+    });
+  });
+
+  describe('sellerReorderOptionGroups 추가 예외', () => {
+    it('존재하지 않는 productId면 NotFoundException', async () => {
+      const { accountId } = await setupProductForSeller();
+      await expect(
+        service.sellerReorderOptionGroups(accountId, {
+          productId: '999999',
+          optionGroupIds: [],
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('매장 그룹 집합에 없는 id가 섞이면 BadRequestException(invalidIds)', async () => {
+      const { accountId, product } = await setupProductForSeller();
+      const g1 = await createOptionGroup(product.id);
+      const otherProduct = await createProduct(prisma, {
+        store_id: product.store_id,
+        name: 'other',
+      });
+      const otherGroup = await createOptionGroup(otherProduct.id);
+
+      await expect(
+        service.sellerReorderOptionGroups(accountId, {
+          productId: product.id.toString(),
+          optionGroupIds: [otherGroup.id.toString()],
+        }),
+      ).rejects.toThrow(BadRequestException);
+      // g1은 실제 정합성 확인용 (존재 기준치)
+      expect(g1.id).toBeDefined();
+    });
+  });
+
+  describe('sellerCreateOptionItem 타 매장 그룹 접근', () => {
+    it('다른 매장의 group이면 NotFoundException', async () => {
+      const me = await setupProductForSeller();
+      const other = await setupProductForSeller();
+      const othersGroup = await createOptionGroup(other.product.id);
+
+      await expect(
+        service.sellerCreateOptionItem(me.accountId, {
+          optionGroupId: othersGroup.id.toString(),
+          title: 'X',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('sellerDeleteOptionItem 타 매장 접근', () => {
+    it('다른 매장의 item이면 NotFoundException', async () => {
+      const me = await setupProductForSeller();
+      const other = await setupProductForSeller();
+      const othersGroup = await createOptionGroup(other.product.id);
+      const othersItem = await prisma.productOptionItem.create({
+        data: { option_group_id: othersGroup.id, title: 'T' },
+      });
+
+      await expect(
+        service.sellerDeleteOptionItem(me.accountId, othersItem.id),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('sellerReorderOptionItems 추가 예외', () => {
+    it('없는 optionGroupId면 NotFoundException', async () => {
+      const { accountId } = await setupProductForSeller();
+      await expect(
+        service.sellerReorderOptionItems(accountId, {
+          optionGroupId: '999999',
+          optionItemIds: [],
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('매장 item 집합에 없는 id가 섞이면 BadRequestException(invalidIds)', async () => {
+      const { accountId, product } = await setupProductForSeller();
+      const group = await createOptionGroup(product.id);
+      const otherProduct = await createProduct(prisma, {
+        store_id: product.store_id,
+        name: 'o',
+      });
+      const otherGroup = await createOptionGroup(otherProduct.id);
+      const foreignItem = await prisma.productOptionItem.create({
+        data: { option_group_id: otherGroup.id, title: 'F' },
+      });
+      // 내 group에 item 하나 생성하여 length는 맞추고, 섞인 id만 foreign
+      await prisma.productOptionItem.create({
+        data: { option_group_id: group.id, title: 'Mine' },
+      });
+
+      await expect(
+        service.sellerReorderOptionItems(accountId, {
+          optionGroupId: group.id.toString(),
+          optionItemIds: [foreignItem.id.toString()],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
 });

--- a/src/features/seller/services/seller-product-crud.service.spec.ts
+++ b/src/features/seller/services/seller-product-crud.service.spec.ts
@@ -400,6 +400,169 @@ describe('SellerProductCrudService (real DB)', () => {
     });
   });
 
+  describe('sellerProducts (필터/커서 분기)', () => {
+    it('cursor와 categoryId를 넘기면 필터 파라미터가 정상 해석된다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const category = await prisma.category.create({
+        data: { name: '행사', category_type: 'EVENT' },
+      });
+      const products: bigint[] = [];
+      for (let i = 0; i < 3; i++) {
+        const p = await createSellerProduct(store.id, { name: `P${i}` });
+        await prisma.productCategory.create({
+          data: { product_id: p.id, category_id: category.id },
+        });
+        products.push(p.id);
+      }
+
+      // 첫 페이지
+      const first = await service.sellerProducts(account.id, {
+        limit: 2,
+        categoryId: category.id.toString(),
+      });
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).not.toBeNull();
+
+      // 두 번째 페이지: cursor path 활성화
+      const second = await service.sellerProducts(account.id, {
+        limit: 2,
+        cursor: first.nextCursor as string,
+        categoryId: category.id.toString(),
+      });
+      expect(second.items.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('search 필터(공백 trim 후 non-empty) 분기도 호출된다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      await createSellerProduct(store.id, { name: '바나나' });
+      await createSellerProduct(store.id, { name: '사과' });
+
+      const result = await service.sellerProducts(account.id, {
+        search: '  바나나  ',
+      });
+      expect(result.items.map((i) => i.name)).toContain('바나나');
+    });
+  });
+
+  describe('sellerUpdateProduct (buildProductUpdateData 전 필드 분기)', () => {
+    it('description/purchaseNotice/currency/baseDesignImageUrl/preparationTimeMinutes 포함 수정', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const product = await createSellerProduct(store.id, { name: '초기' });
+
+      const result = await service.sellerUpdateProduct(account.id, {
+        productId: product.id.toString(),
+        description: '설명',
+        purchaseNotice: '주의사항',
+        currency: 'KRW',
+        baseDesignImageUrl: 'https://i.example/base.png',
+        preparationTimeMinutes: 60,
+        regularPrice: 12000,
+        salePrice: 9000,
+      });
+
+      expect(result.description).toBe('설명');
+      expect(result.purchaseNotice).toBe('주의사항');
+      expect(result.currency).toBe('KRW');
+      expect(result.baseDesignImageUrl).toBe('https://i.example/base.png');
+      expect(result.preparationTimeMinutes).toBe(60);
+      expect(result.regularPrice).toBe(12000);
+      expect(result.salePrice).toBe(9000);
+    });
+
+    it('salePrice만 넘긴 경우 기존 regularPrice 기준 검증을 통과한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const product = await createSellerProduct(store.id);
+
+      const result = await service.sellerUpdateProduct(account.id, {
+        productId: product.id.toString(),
+        salePrice: 8000,
+      });
+      expect(result.salePrice).toBe(8000);
+    });
+  });
+
+  describe('sellerSetProductCategories/Tags 존재 검증 실패 분기', () => {
+    it('setProductCategories: 존재하지 않는 productId면 NotFoundException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerSetProductCategories(account.id, {
+          productId: '999999',
+          categoryIds: [],
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('setProductTags: 존재하지 않는 productId면 NotFoundException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerSetProductTags(account.id, {
+          productId: '999999',
+          tagIds: [],
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('sellerAddProductImage / sellerDeleteProductImage / sellerReorderProductImages 추가 예외', () => {
+    it('addProductImage: 존재하지 않는 productId면 NotFoundException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerAddProductImage(account.id, {
+          productId: '999999',
+          imageUrl: 'https://i.example/x.png',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('reorderProductImages: 존재하지 않는 productId면 NotFoundException', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerReorderProductImages(account.id, {
+          productId: '999999',
+          imageIds: ['1'],
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('reorderProductImages: 매장 imageId 집합과 입력 배열이 안 맞으면 BadRequestException(invalidIds)', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const product = await createSellerProduct(store.id);
+      const otherProduct = await createSellerProduct(store.id);
+      const otherImage = await prisma.productImage.findFirstOrThrow({
+        where: { product_id: otherProduct.id },
+      });
+
+      await expect(
+        service.sellerReorderProductImages(account.id, {
+          productId: product.id.toString(),
+          imageIds: [otherImage.id.toString()],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('toProductOutput custom_template 포함 분기', () => {
+    it('custom_template이 존재하는 product 조회 시 customTemplate 필드가 채워진다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const product = await createSellerProduct(store.id, {
+        name: '템플릿 상품',
+      });
+      await prisma.productCustomTemplate.create({
+        data: {
+          product_id: product.id,
+          base_image_url: 'https://i.example/tpl.png',
+          is_active: true,
+        },
+      });
+
+      const result = await service.sellerProduct(account.id, product.id);
+      expect(result.customTemplate).not.toBeNull();
+      expect(result.customTemplate?.baseImageUrl).toBe(
+        'https://i.example/tpl.png',
+      );
+    });
+  });
+
   describe('sellerSetProductTags', () => {
     it('존재하지 않는 tagId가 있으면 BadRequestException', async () => {
       const { account, store } = await setupSellerWithStore(prisma);

--- a/src/features/seller/services/seller-store.service.spec.ts
+++ b/src/features/seller/services/seller-store.service.spec.ts
@@ -491,4 +491,132 @@ describe('SellerStoreService (real DB)', () => {
       expect(auditLogs[0].before_json).not.toBeNull();
     });
   });
+
+  describe('sellerMyStore / sellerUpdateStoreBasicInfo / sellerUpdatePickupPolicy 존재 실패 분기', () => {
+    /**
+     * SellerContext(SellerProfile + Account SELLER type)는 존재하지만,
+     * 해당 seller의 Store row가 없는 상황을 재현해 `findStoreBySellerAccountId`가
+     * null을 반환하는 분기를 타게 한다.
+     */
+    async function setupSellerWithoutStore() {
+      const account = await prisma.account.create({
+        data: {
+          account_type: 'SELLER',
+          email: `no-store-${Date.now()}-${Math.random()}@example.com`,
+          name: 'no-store-seller',
+        },
+      });
+      await prisma.sellerProfile.create({
+        data: {
+          account_id: account.id,
+          business_name: 'no-store',
+          business_phone: '02-0000-9999',
+        },
+      });
+      return account;
+    }
+
+    it('sellerMyStore: store가 없으면 NotFoundException', async () => {
+      const account = await setupSellerWithoutStore();
+      await expect(service.sellerMyStore(account.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('sellerUpdateStoreBasicInfo: store가 없으면 NotFoundException', async () => {
+      const account = await setupSellerWithoutStore();
+      await expect(
+        service.sellerUpdateStoreBasicInfo(account.id, {
+          storeName: '이름',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('sellerUpdatePickupPolicy: store가 없으면 NotFoundException', async () => {
+      const account = await setupSellerWithoutStore();
+      await expect(
+        service.sellerUpdatePickupPolicy(account.id, {
+          pickupSlotIntervalMinutes: 30,
+          minLeadTimeMinutes: 60,
+          maxDaysAhead: 7,
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('buildStoreBasicInfoUpdateData 전 필드 분기', () => {
+    it('모든 선택 필드(주소/좌표/지도/웹사이트/영업시간 텍스트)를 포함한 수정', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+
+      const result = await service.sellerUpdateStoreBasicInfo(account.id, {
+        storeName: '매장',
+        storePhone: '02-0000-0000',
+        addressFull: '서울 어딘가 1',
+        addressCity: '서울',
+        addressDistrict: '어딘가구',
+        addressNeighborhood: '어딘가동',
+        latitude: '37.5',
+        longitude: '127.0',
+        mapProvider: 'NAVER',
+        websiteUrl: 'https://example.com',
+        businessHoursText: '월~금 09-18',
+      });
+
+      expect(result.storeName).toBe('매장');
+      expect(result.addressCity).toBe('서울');
+      expect(result.addressDistrict).toBe('어딘가구');
+      expect(result.addressNeighborhood).toBe('어딘가동');
+      expect(result.websiteUrl).toBe('https://example.com');
+      expect(result.businessHoursText).toBe('월~금 09-18');
+    });
+  });
+
+  describe('sellerStoreSpecialClosures / sellerStoreDailyCapacities cursor 분기', () => {
+    it('sellerStoreSpecialClosures: cursor 페이지네이션이 동작한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      for (let i = 0; i < 3; i++) {
+        await prisma.storeSpecialClosure.create({
+          data: {
+            store_id: store.id,
+            closure_date: new Date(`2026-0${i + 1}-01`),
+            reason: `r${i}`,
+          },
+        });
+      }
+      const first = await service.sellerStoreSpecialClosures(account.id, {
+        limit: 2,
+      });
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).not.toBeNull();
+
+      const second = await service.sellerStoreSpecialClosures(account.id, {
+        limit: 2,
+        cursor: first.nextCursor as string,
+      });
+      expect(second.items.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('sellerStoreDailyCapacities: cursor 페이지네이션이 동작한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      for (let i = 1; i <= 3; i++) {
+        await prisma.storeDailyCapacity.create({
+          data: {
+            store_id: store.id,
+            capacity_date: new Date(`2026-05-0${i}`),
+            capacity: 10 * i,
+          },
+        });
+      }
+      const first = await service.sellerStoreDailyCapacities(account.id, {
+        limit: 2,
+      });
+      expect(first.items).toHaveLength(2);
+      expect(first.nextCursor).not.toBeNull();
+      const second = await service.sellerStoreDailyCapacities(account.id, {
+        limit: 2,
+        cursor: first.nextCursor as string,
+      });
+      expect(second.items.length).toBeGreaterThanOrEqual(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Test DB 전면 도입 플랜의 마지막 단계(PR 9). 커버리지 핫스팟에 타깃 테스트를 추가하여 주요 지표를 상향하고, coverageThreshold를 실측 기반으로 조정.

**커버리지 변화**: 93.83 / 81.07 / 88.46 / 94.4 → **96.58 / 86.72 / 93.04 / 96.93**
**coverageThreshold**: 92/81/88/93 → **96/86/92/96**

### 보강 대상
- seller 도메인: product-crud / option / content / store / conversation 서비스 분기
- seller-product-mutation resolver: 23개 mutation 전체 배선 테스트(기존 3개 → 전체)
- auth: controller 전체 엔드포인트, repository null-처리 분기, strategy fail-fast, service me/returnTo 엣지
- order.repository: pickup/created 필터 조합
- common/utils/request-context: 배열 헤더 / GraphQL meta 분기

### jest.mock 잔존 검토
허용 목록(Logger / S3 / OIDC)만 남아있어 추가 제거 없음.

## Plan 원안(90/90/90/90) 대비 차이

statements / functions / lines는 모두 90+ 달성. **branches는 86.72로 미달**.

**원인**: TypeScript `emitDecoratorMetadata`가 NestJS resolver / controller 각 메서드마다 `__param/__metadata` 관련 conditional expression을 삽입하는데, 한쪽 분기(fallback)가 런타임에서 실행되지 않음. 각 resolver 파일의 branch 커버리지 하한이 구조적으로 ~75%에서 고정됨.

**영향 파일군**: `features/**/resolvers/*-{query,mutation}.resolver.ts`, `features/auth/controllers/auth.controller.ts` 등 ~10+개.

이 파일들은 pass-through 성격이므로 브랜치 부족분이 품질 리스크로 이어지지 않으며, 실제 비즈니스 로직은 service.spec에서 검증.

## Test plan
- [x] CI check 통과
- [x] CI pr-title 통과
- [x] CI coverage-report 통과 (4지표 모두 threshold 이상)
- [x] Codecov 리포트 확인
- [x] CodeQL 통과