### PR TITLE
fix(test-infra): truncateAll 실패 시 FOREIGN_KEY_CHECKS 복원 보장

### DIFF
--- a/src/test/db/truncate.ts
+++ b/src/test/db/truncate.ts
@@ -56,6 +56,13 @@ async function loadTableNames(conn: mysql.Connection): Promise<string[]> {
  * - multi-statement 배치로 1회 round-trip
  * - SET FOREIGN_KEY_CHECKS=0 으로 FK 순서 무시
  * - `_prisma_migrations`는 제외 (스키마 이력 유지)
+ *
+ * FK 복원 안전성:
+ *   multi-statement 중간 DELETE가 실패하면 MySQL은 후속 statement를 실행하지 않고
+ *   abort하므로 마지막의 `SET FOREIGN_KEY_CHECKS = 1`이 누락될 수 있다. 이 경우
+ *   캐시된 connection은 FK 비활성 상태로 남아 후속 테스트의 FK 위반을 silent하게
+ *   통과시킬 위험이 있다. 성공 케이스의 1 round-trip 성능은 유지하면서, 실패 시에만
+ *   별도 쿼리로 명시 복원한다.
  */
 export async function truncateAll(): Promise<void> {
   const conn = await getConnection();
@@ -67,7 +74,16 @@ export async function truncateAll(): Promise<void> {
     .join('\n');
   const sql = `SET FOREIGN_KEY_CHECKS = 0;\n${deleteStatements}\nSET FOREIGN_KEY_CHECKS = 1;`;
 
-  await conn.query(sql);
+  try {
+    await conn.query(sql);
+  } catch (err) {
+    try {
+      await conn.query('SET FOREIGN_KEY_CHECKS = 1');
+    } catch {
+      // 복원 자체가 실패해도 원래 에러를 우선 throw 한다.
+    }
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

PR #70(develop → main)의 Codex P2 리뷰 반영. truncateAll 배치 실행 중 한 statement가 실패하면 후속 SET=1이 누락되어 캐시된 connection이 FK 비활성 상태로 남는 회귀 위험을 차단.

## 문제

기존 truncateAll은 `SET FOREIGN_KEY_CHECKS = 0` + `DELETE × N` + `SET FOREIGN_KEY_CHECKS = 1` 을 multi-statement 단일 쿼리로 실행 (PR #67의 성능 개선분).

- MySQL은 multi-statement 중간에 에러가 나면 후속 statement를 실행하지 않고 abort
- `cachedConn`이 worker별로 영구 캐시 + FK_CHECKS는 session-level 변수
- 결과: DELETE 1건이라도 실패하면 다음 truncateAll까지(혹은 그 사이 모든 테스트) FK 검사 비활성 상태로 동작 → silent contamination 위험

## 수정

```ts
try {
  await conn.query(sql);
} catch (err) {
  try {
    await conn.query('SET FOREIGN_KEY_CHECKS = 1');
  } catch {
    /* 복원 자체 실패는 원래 에러로 덮인다 */
  }
  throw err;
}
```

- 성공 케이스: round-trip 1회 (PR #67의 98s → 22s 개선분 그대로 유지)
- 실패 케이스: round-trip 2회 + 명시 복원 후 원래 에러 throw

## Test plan
- [x] 로컬 yarn test: 75 suites / 808 tests 통과
- [ ] CI check 통과
- [ ] CI coverage-report 통과