### PR TITLE
fix: PR #70 CodeRabbit 리뷰 일괄 반영 (order/banner/logger + spec 품질)

### DIFF
--- a/src/features/order/policies/order-status-transition.policy.spec.ts
+++ b/src/features/order/policies/order-status-transition.policy.spec.ts
@@ -88,6 +88,22 @@ describe('OrderStatusTransitionPolicy', () => {
         ),
       ).toThrow(BadRequestException);
     });
+
+    /**
+     * SUBMITTED는 주문 생성 시점의 초기 상태로, 도메인 정의상 어떤 상태에서도 되돌아갈 수 없다.
+     * 가드가 빠지면 PICKED_UP/CONFIRMED → SUBMITTED 같은 비정상 역전이가 silent하게 통과될 수 있어,
+     * 모든 from 케이스에 대해 reject되는지 명시적으로 회귀 검증한다.
+     */
+    it.each([
+      OrderStatus.CONFIRMED,
+      OrderStatus.MADE,
+      OrderStatus.PICKED_UP,
+      OrderStatus.CANCELED,
+    ])('SUBMITTED로 되돌리는 역전이는 거부 (from=%s)', (from) => {
+      expect(() =>
+        policy.assertSellerTransition(from, OrderStatus.SUBMITTED),
+      ).toThrow(BadRequestException);
+    });
   });
 
   describe('requiresCancellationNote', () => {

--- a/src/features/order/policies/order-status-transition.policy.ts
+++ b/src/features/order/policies/order-status-transition.policy.ts
@@ -17,6 +17,11 @@ export class OrderStatusTransitionPolicy {
       throw new BadRequestException('Order status is already set to target.');
     }
 
+    // SUBMITTED는 주문 생성 시점의 초기 상태이므로 어떤 상태에서도 되돌아갈 수 없다.
+    if (to === OrderStatus.SUBMITTED) {
+      throw new BadRequestException('Invalid order status transition.');
+    }
+
     if (to === OrderStatus.CONFIRMED && from !== OrderStatus.SUBMITTED) {
       throw new BadRequestException('Invalid order status transition.');
     }

--- a/src/features/seller/constants/seller-error-messages.ts
+++ b/src/features/seller/constants/seller-error-messages.ts
@@ -51,6 +51,8 @@ export const LINK_STORE_REQUIRED =
 export const LINK_STORE_MISMATCH = 'Cannot link another store.';
 export const LINK_CATEGORY_REQUIRED =
   'linkCategoryId is required when linkType is CATEGORY.';
+export const LINK_FIELDS_MISMATCH =
+  'Link fields not relevant to the current linkType cannot be set.';
 export const INVALID_BANNER_PLACEMENT = 'Invalid banner placement.';
 export const INVALID_BANNER_LINK_TYPE = 'Invalid banner link type.';
 

--- a/src/features/seller/services/seller-content.service.spec.ts
+++ b/src/features/seller/services/seller-content.service.spec.ts
@@ -310,6 +310,46 @@ describe('SellerContentService (real DB)', () => {
       });
       expect(auditLogs).toHaveLength(1);
     });
+
+    it('linkType=STORE인데 무관한 link 필드(linkProductId/linkUrl)가 함께 들어오면 BadRequest', async () => {
+      // 회귀 가드: 깨진 row(linkType과 무관 필드 동시 set) 생성 시도는 도메인에서 거부 (B-1).
+      const me = await setupSellerWithStore(prisma);
+      const product = await prisma.product.create({
+        data: { store_id: me.store.id, name: 'p', regular_price: 1000 },
+      });
+
+      await expect(
+        service.sellerCreateBanner(me.account.id, {
+          placement: 'STORE',
+          imageUrl: 'https://i.example/x.png',
+          linkType: 'STORE',
+          linkStoreId: me.store.id.toString(),
+          linkProductId: product.id.toString(), // STORE에 무관
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      await expect(
+        service.sellerCreateBanner(me.account.id, {
+          placement: 'STORE',
+          imageUrl: 'https://i.example/x.png',
+          linkType: 'STORE',
+          linkStoreId: me.store.id.toString(),
+          linkUrl: 'https://other.example', // STORE에 무관
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('linkType=NONE인데 link 필드가 들어오면 BadRequest', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      await expect(
+        service.sellerCreateBanner(account.id, {
+          placement: 'HOME_MAIN',
+          imageUrl: 'https://i.example/x.png',
+          linkType: 'NONE',
+          linkUrl: 'https://x.example',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 
   describe('sellerUpdateBanner', () => {
@@ -427,16 +467,38 @@ describe('SellerContentService (real DB)', () => {
       expect(after.link_store_id).toBe(store.id);
     });
 
-    it('linkType 미변경 + 4가지 inner link 필드(linkUrl/linkProductId/linkStoreId/linkCategoryId) 부분 업데이트', async () => {
-      // STORE 타입 banner로 ownership을 확보하면 validateBannerOwnership은 linkStoreId만
-      // 현재 store인지 확인하므로 나머지 linkUrl/linkProductId/linkCategoryId inner 분기를
-      // 자유롭게 검증할 수 있다.
+    it('linkType 미변경 + 같은 linkType의 link 필드만 부분 업데이트는 허용된다', async () => {
+      // STORE 타입 banner의 linkStoreId만 input으로 업데이트하는 정상 경로.
+      // assertInputLinkFieldsMatch가 input 기준이므로 무관 필드만 안 보내면 통과한다.
+      const me = await setupSellerWithStore(prisma);
+      const banner = await prisma.banner.create({
+        data: {
+          placement: 'STORE',
+          image_url: 'https://i.example/a.png',
+          link_type: 'STORE',
+          link_store_id: me.store.id,
+        },
+      });
+
+      await service.sellerUpdateBanner(me.account.id, {
+        bannerId: banner.id.toString(),
+        // linkType 미지정 + linkStoreId만 set → STORE에 매칭되는 필드라 통과
+        linkStoreId: me.store.id.toString(),
+      });
+
+      const after = await prisma.banner.findUniqueOrThrow({
+        where: { id: banner.id },
+      });
+      expect(after.link_type).toBe('STORE');
+      expect(after.link_store_id).toBe(me.store.id);
+    });
+
+    it('linkType 미변경 + 무관한 link 필드(linkProductId)를 set하면 BadRequest로 거부된다', async () => {
+      // 회귀 가드: STORE 타입 banner에 linkProductId가 함께 들어오는 정합성 위반 입력은
+      // 도메인 레벨에서 즉시 거부되어야 한다 (B-1 정책).
       const me = await setupSellerWithStore(prisma);
       const product = await prisma.product.create({
         data: { store_id: me.store.id, name: 'p', regular_price: 1000 },
-      });
-      const category = await prisma.category.create({
-        data: { name: '이벤트', category_type: 'EVENT' },
       });
       const banner = await prisma.banner.create({
         data: {
@@ -444,28 +506,21 @@ describe('SellerContentService (real DB)', () => {
           image_url: 'https://i.example/a.png',
           link_type: 'STORE',
           link_store_id: me.store.id,
-          link_url: 'https://old.example',
         },
       });
 
-      await service.sellerUpdateBanner(me.account.id, {
-        bannerId: banner.id.toString(),
-        // linkType 미지정 → else branch
-        // 4개 inner 분기 모두 발동
-        linkUrl: 'https://new.example',
-        linkProductId: product.id.toString(),
-        linkStoreId: me.store.id.toString(),
-        linkCategoryId: category.id.toString(),
-      });
+      await expect(
+        service.sellerUpdateBanner(me.account.id, {
+          bannerId: banner.id.toString(),
+          linkProductId: product.id.toString(),
+        }),
+      ).rejects.toThrow(BadRequestException);
 
+      // DB에는 변경 없음
       const after = await prisma.banner.findUniqueOrThrow({
         where: { id: banner.id },
       });
-      expect(after.link_type).toBe('STORE');
-      expect(after.link_url).toBe('https://new.example');
-      expect(after.link_product_id).toBe(product.id);
-      expect(after.link_store_id).toBe(me.store.id);
-      expect(after.link_category_id).toBe(category.id);
+      expect(after.link_product_id).toBeNull();
     });
 
     it('linkType 미변경 + linkProductId를 null로 (falsy 분기: parseId 미호출 경로)', async () => {

--- a/src/features/seller/services/seller-content.service.ts
+++ b/src/features/seller/services/seller-content.service.ts
@@ -26,6 +26,7 @@ import {
   INVALID_BANNER_LINK_TYPE,
   INVALID_BANNER_PLACEMENT,
   LINK_CATEGORY_REQUIRED,
+  LINK_FIELDS_MISMATCH,
   LINK_PRODUCT_MISMATCH,
   LINK_PRODUCT_REQUIRED,
   LINK_STORE_MISMATCH,
@@ -205,8 +206,11 @@ export class SellerContentService extends SellerBaseService {
     input: SellerCreateBannerInput,
   ): Promise<SellerBannerOutput> {
     const ctx = await this.requireSellerContext(accountId);
+    const intendedLinkType = input.linkType ?? 'NONE';
+    // 호출자가 intendedLinkType과 무관한 link 필드를 보냈는지 검증 (B-1 정합성 가드)
+    this.assertInputLinkFieldsMatch(intendedLinkType, input);
     await this.validateBannerOwnership(ctx, {
-      linkType: input.linkType ?? 'NONE',
+      linkType: intendedLinkType,
       linkProductId: input.linkProductId ? parseId(input.linkProductId) : null,
       linkStoreId: input.linkStoreId ? parseId(input.linkStoreId) : null,
       linkCategoryId: input.linkCategoryId
@@ -258,6 +262,17 @@ export class SellerContentService extends SellerBaseService {
       storeId: ctx.storeId,
     });
     if (!current) throw new NotFoundException(BANNER_NOT_FOUND);
+
+    const intendedLinkType = (input.linkType ?? current.link_type) as
+      | 'NONE'
+      | 'URL'
+      | 'PRODUCT'
+      | 'STORE'
+      | 'CATEGORY';
+    // input에 명시된 link 필드가 intendedLinkType과 매칭되는지 검증 (B-1 정합성 가드).
+    // resolved 기준으로 검증하면 STORE→NONE 같은 정상 변경에서도 current 잔여값으로 false positive가 발생하므로,
+    // input 기준으로만 검증한다.
+    this.assertInputLinkFieldsMatch(intendedLinkType, input);
 
     const resolved = this.resolveNextBannerLinkValues(input, current);
     await this.validateBannerOwnership(ctx, resolved);
@@ -523,6 +538,48 @@ export class SellerContentService extends SellerBaseService {
 
     if (args.linkType === 'CATEGORY' && !args.linkCategoryId) {
       throw new BadRequestException(LINK_CATEGORY_REQUIRED);
+    }
+  }
+
+  /**
+   * 호출자(create/update 입력) 기준으로 intendedLinkType과 무관한 link 필드가 함께
+   * 들어왔는지 검증한다. 깨진 row(linkType=STORE인데 link_product_id가 set되는 등)를
+   * 도메인 레벨에서 fail-fast로 거부한다.
+   *
+   * - NONE: 모든 link_* 필드 X
+   * - URL: linkUrl만
+   * - PRODUCT: linkProductId만
+   * - STORE: linkStoreId만
+   * - CATEGORY: linkCategoryId만
+   *
+   * `null`은 명시적 clear 의도이므로 "set 의도 없음"으로 간주한다.
+   * `undefined`(input 미지정)도 마찬가지.
+   * 빈 문자열은 의미 없는 값이므로 falsy로 처리해 통과시킨다.
+   */
+  private assertInputLinkFieldsMatch(
+    intendedLinkType: 'NONE' | 'URL' | 'PRODUCT' | 'STORE' | 'CATEGORY',
+    input: {
+      linkUrl?: string | null;
+      linkProductId?: string | null;
+      linkStoreId?: string | null;
+      linkCategoryId?: string | null;
+    },
+  ): void {
+    const hasUrl = !!input.linkUrl && input.linkUrl.trim().length > 0;
+    const hasProduct = !!input.linkProductId;
+    const hasStore = !!input.linkStoreId;
+    const hasCategory = !!input.linkCategoryId;
+
+    const allowed: Record<typeof intendedLinkType, boolean> = {
+      NONE: !hasUrl && !hasProduct && !hasStore && !hasCategory,
+      URL: !hasProduct && !hasStore && !hasCategory,
+      PRODUCT: !hasUrl && !hasStore && !hasCategory,
+      STORE: !hasUrl && !hasProduct && !hasCategory,
+      CATEGORY: !hasUrl && !hasProduct && !hasStore,
+    };
+
+    if (!allowed[intendedLinkType]) {
+      throw new BadRequestException(LINK_FIELDS_MISMATCH);
     }
   }
 

--- a/src/features/seller/services/seller-product-crud.service.spec.ts
+++ b/src/features/seller/services/seller-product-crud.service.spec.ts
@@ -81,12 +81,36 @@ describe('SellerProductCrudService (real DB)', () => {
     it('자기 매장 상품만 반환하고 nextCursor 동작', async () => {
       const me = await setupSellerWithStore(prisma);
       const other = await setupSellerWithStore(prisma);
+      const myProducts = await Promise.all([
+        createSellerProduct(me.store.id),
+        createSellerProduct(me.store.id),
+        createSellerProduct(me.store.id),
+      ]);
+      const othersProduct = await createSellerProduct(other.store.id);
+
+      // limit 충분히 크게 잡아 length만으로 통과하지 않도록 한다.
+      const result = await service.sellerProducts(me.account.id, { limit: 10 });
+
+      const returnedIds = result.items.map((it) => it.id).sort();
+      const myIds = myProducts.map((p) => p.id.toString()).sort();
+      // 반환 셋이 정확히 본인 매장 상품 셋과 일치 (타 매장 제외 검증 포함)
+      expect(returnedIds).toEqual(myIds);
+      expect(returnedIds).not.toContain(othersProduct.id.toString());
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('limit 페이지네이션은 nextCursor를 반환하고 자기 매장 외 데이터는 노출되지 않는다', async () => {
+      const me = await setupSellerWithStore(prisma);
+      const other = await setupSellerWithStore(prisma);
       for (let i = 0; i < 3; i++) await createSellerProduct(me.store.id);
-      await createSellerProduct(other.store.id);
+      const othersProduct = await createSellerProduct(other.store.id);
 
       const result = await service.sellerProducts(me.account.id, { limit: 2 });
       expect(result.items).toHaveLength(2);
       expect(result.nextCursor).not.toBeNull();
+      expect(result.items.map((it) => it.id)).not.toContain(
+        othersProduct.id.toString(),
+      );
     });
   });
 

--- a/src/features/user/services/user-engagement.service.spec.ts
+++ b/src/features/user/services/user-engagement.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 import { NotificationEvent, NotificationType } from '@prisma/client';
 
@@ -117,9 +121,10 @@ describe('UserEngagementService (real DB)', () => {
         data: { deleted_at: new Date() },
       });
 
-      await expect(service.likeReview(liker.id, review.id)).rejects.toThrow(
-        /Account is deleted/,
-      );
+      // 제목과 일치하도록 예외 타입 + 메시지 둘 다 검증한다 (회귀 감지력 ↑).
+      const promise = service.likeReview(liker.id, review.id);
+      await expect(promise).rejects.toThrow(UnauthorizedException);
+      await expect(promise).rejects.toThrow(/Account is deleted/);
     });
   });
 });

--- a/src/features/user/services/user-review.service.spec.ts
+++ b/src/features/user/services/user-review.service.spec.ts
@@ -246,20 +246,40 @@ describe('UserReviewService (real DB)', () => {
 
     it('soft-delete된 리뷰가 있으면 복원하여 새 rating/content/media를 반영한다', async () => {
       const ctx = await setupReviewableOrderItem();
+      const NEW_CONTENT = '복원 후 새 내용입니다. 아주 만족스럽습니다.';
 
-      // 첫 작성 후 삭제 (soft delete)
+      // 첫 작성 (media 1건 포함) 후 soft-delete
       const first = await service.writeReview(ctx.accountId, {
         orderItemId: ctx.orderItemId.toString(),
         rating: 3,
         content: VALID_CONTENT,
+        media: [
+          {
+            mediaType: 'IMAGE',
+            mediaUrl: 'https://i.example/old.png',
+            sortOrder: 0,
+          },
+        ],
       });
       await service.deleteMyReview(ctx.accountId, first.reviewId);
 
-      // 다시 작성 → 같은 row 복원
+      // 다시 작성 → 같은 row 복원, rating/content/media 모두 새 값으로 교체되어야 함
       const restored = await service.writeReview(ctx.accountId, {
         orderItemId: ctx.orderItemId.toString(),
         rating: 5,
-        content: '복원 후 새 내용입니다. 아주 만족스럽습니다.',
+        content: NEW_CONTENT,
+        media: [
+          {
+            mediaType: 'IMAGE',
+            mediaUrl: 'https://i.example/new1.png',
+            sortOrder: 0,
+          },
+          {
+            mediaType: 'VIDEO',
+            mediaUrl: 'https://i.example/new2.mp4',
+            sortOrder: 1,
+          },
+        ],
       });
 
       expect(restored.reviewId).toBe(first.reviewId);
@@ -268,6 +288,17 @@ describe('UserReviewService (real DB)', () => {
       });
       expect(saved.deleted_at).toBeNull();
       expect(Number(saved.rating)).toBe(5);
+      expect(saved.content).toBe(NEW_CONTENT);
+
+      // media: 새 값 2건만 남고 stale 1건은 정리됐는지 확인
+      const mediaRows = await prisma.reviewMedia.findMany({
+        where: { review_id: BigInt(restored.reviewId), deleted_at: null },
+      });
+      const mediaUrls = mediaRows.map((m) => m.media_url).sort();
+      expect(mediaUrls).toEqual([
+        'https://i.example/new1.png',
+        'https://i.example/new2.mp4',
+      ]);
     });
   });
 

--- a/src/global/logger/logger.spec.ts
+++ b/src/global/logger/logger.spec.ts
@@ -59,25 +59,55 @@ describe('formatDevLogLine (printf 콜백)', () => {
     expect(line).toBe('2026-04-22 10:00:00 warn: single message');
   });
 
-  it('message가 non-string(객체)이면 meta 전체를 JSON.stringify로 직렬화한다', () => {
+  it('message가 non-string(객체)이면 message를 보존하여 meta와 함께 직렬화한다', () => {
     const line = formatDevLogLine({
       level: 'info',
       message: { eventType: 'LOGIN', userId: 7 } as never,
       timestamp: '2026-04-22 10:00:00',
     });
-    // message가 non-string이므로 meta 자체가 출력 대상 (message는 rest에 포함 안됨)
-    expect(line).toBe('2026-04-22 10:00:00 info: {}');
+    // structured log 메시지가 사라지지 않도록 message 키로 보존된다.
+    expect(line).toBe(
+      '2026-04-22 10:00:00 info: {"message":{"eventType":"LOGIN","userId":7}}',
+    );
   });
 
-  it('timestamp 누락 시 현재 시각 ISO 문자열로 fallback', () => {
+  it('non-string message + meta 동시에 있으면 둘 다 직렬화된다', () => {
     const line = formatDevLogLine({
-      level: 'debug',
-      message: 'no ts',
+      level: 'warn',
+      message: { code: 'E1' } as never,
+      timestamp: '2026-04-22 10:00:00',
+      requestId: 'req-1',
     });
-    // ISO 8601 패턴 (yyyy-mm-ddThh:mm:ss.sssZ)
-    expect(line).toMatch(
-      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z debug: no ts$/,
+    expect(line).toBe(
+      '2026-04-22 10:00:00 warn: {"message":{"code":"E1"},"requestId":"req-1"}',
     );
+  });
+
+  it('bigint meta가 포함되어도 throw 없이 문자열로 직렬화된다', () => {
+    const line = formatDevLogLine({
+      level: 'info',
+      message: 'with bigint',
+      timestamp: '2026-04-22 10:00:00',
+      // Number.MAX_SAFE_INTEGER 초과 값은 number로 표현 못 하므로 bigint literal로 정확히 전달
+      accountId: 9007199254740993n,
+    });
+    expect(line).toBe(
+      '2026-04-22 10:00:00 info: with bigint {"accountId":"9007199254740993"}',
+    );
+  });
+
+  it('timestamp 누락 시 현재 시각 ISO 문자열로 fallback (fake timer로 결정성 확보)', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-22T10:00:00.000Z'));
+    try {
+      const line = formatDevLogLine({
+        level: 'debug',
+        message: 'no ts',
+      });
+      expect(line).toBe('2026-04-22T10:00:00.000Z debug: no ts');
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('error level + meta (stack 포함)도 형식에 맞게 문자열화', () => {

--- a/src/global/logger/logger.ts
+++ b/src/global/logger/logger.ts
@@ -5,6 +5,11 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 /**
  * 개발 환경용 로그 포맷에 사용되는 pure printf 콜백. 테스트 가능하도록 export.
+ *
+ * - string message: `${message}${meta-json}` 형식으로 출력
+ * - non-string message(객체/에러/bigint 등): message를 meta의 `message` 키로 보존하여 함께 직렬화
+ *   → `${JSON.stringify({ message, ...meta })}` 형태
+ * - bigint 안전: JSON.stringify의 replacer로 bigint를 문자열로 변환해 throw 방지
  */
 export function formatDevLogLine(
   info: TransformableInfo & { timestamp?: string },
@@ -16,10 +21,22 @@ export function formatDevLogLine(
     unknown
   >;
   if (typeof message === 'string') {
-    const rest = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
+    const rest = Object.keys(meta).length ? ` ${safeJsonStringify(meta)}` : '';
     return `${ts} ${lvl}: ${message}${rest}`;
   }
-  return `${ts} ${lvl}: ${JSON.stringify(meta)}`;
+  // non-string message는 버리지 않고 meta와 합쳐 직렬화한다.
+  const payload: Record<string, unknown> = { message, ...meta };
+  return `${ts} ${lvl}: ${safeJsonStringify(payload)}`;
+}
+
+/**
+ * JSON.stringify + bigint 안전 replacer.
+ * bigint는 JSON으로 직렬화할 수 없어 기본 stringify가 throw하므로, 문자열로 변환한다.
+ */
+function safeJsonStringify(value: unknown): string {
+  return JSON.stringify(value, (_key: string, v: unknown): unknown =>
+    typeof v === 'bigint' ? v.toString() : v,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

PR #70(develop → main)에 달린 CodeRabbit 리뷰 9건 중 옵션 A(권장 6건) + #3(B-1 정책)을 반영합니다.

| # | 위치 | 종류 | 처리 |
|---|---|---|---|
| #2 | order-status-transition.policy | 🔴 production 버그 | SUBMITTED 역전이 가드 추가 + 회귀 테스트 |
| #3 | seller-content.service banner | 🟠 정합성 정책 | linkType과 무관한 link 필드 set 거부 (B-1, create+update 모두) |
| #4 | seller-product-crud.spec | 🟡 약한 assertion | length/cursor만 검증하던 것을 ID 셋 일치 + 타 매장 제외 검증으로 강화 |
| #5 | user-engagement.spec | 🟡 제목-assertion 불일치 | UnauthorizedException 타입 + 메시지 둘 다 검증 |
| #6 | user-review.spec | 🟡 검증 누락 | 복원 테스트에 media 입력/갱신/stale 정리 검증 추가 |
| #7+#9 | logger | 🟡 동작 약점 | non-string message 보존 + bigint 안전 직렬화 + spec 갱신 |

남은 3건(#1 UUID mock, #8 fake timer는 noise 수준이라 생략. #3는 본 PR에서 B-1 채택으로 처리됨).

## #2 — order policy SUBMITTED 역전이 가드

기존 assertSellerTransition은 `to === SUBMITTED` 케이스를 전혀 검사하지 않아 PICKED_UP/CONFIRMED → SUBMITTED 같은 비정상 역전이가 silent하게 통과될 수 있었습니다. SUBMITTED는 주문 생성 시점 초기 상태이므로 어떤 from에서도 되돌아갈 수 없도록 명시 가드 + 모든 from에 대한 it.each 회귀 테스트를 추가했습니다.

## #3 — banner linkType 정합성 정책 (B-1 채택)

호출자가 의도한 linkType과 매칭되지 않는 link_url/product/store/category가 input에 함께 들어오면 도메인 레벨에서 즉시 BadRequest로 거부합니다. create / update 모두 동일 정책. 입력 기준 검증으로 STORE→NONE 같은 정상 변경에서 false positive가 발생하지 않습니다.

기존 깨진 row 데이터 / 프론트 호출 영향 없음(사용자 확인).

## 커버리지

- 818 tests pass (기존 815 + 3)
- 96.57 / 86.51 / 93.08 / 96.91 (모두 임계값 96/86/92/96 이상)

## Test plan
- [x] 로컬 yarn test:cov 통과
- [x] CI check 통과
- [x] CI coverage-report 통과
- [x] CodeQL 통과