### PR TITLE
feat(user): 생년월일 1900-01-01 이전 입력 거부

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ docs/*
 .env.example
 caquick_ddl.sql
 src/features/example/*
+
+.figma/

--- a/src/features/user/constants/user.constants.ts
+++ b/src/features/user/constants/user.constants.ts
@@ -8,6 +8,13 @@ export const MAX_NICKNAME_LENGTH = 20;
 export const MIN_PHONE_LENGTH = 7;
 export const MAX_PHONE_LENGTH = 20;
 
+// ── 생년월일 ──
+
+// figma 명세 외 정책 결정: 1900-01-01 이전 입력은 거부 (사실상 봇/오입력 방지).
+// normalizeBirthDate가 로컬 타임존 기준 setHours(0,0,0,0)으로 정렬하므로
+// 비교 기준도 동일하게 로컬 타임존 자정으로 둔다.
+export const MIN_BIRTH_DATE = new Date(1900, 0, 1);
+
 // ── 페이지네이션 ──
 
 export const DEFAULT_PAGINATION_LIMIT = 20;

--- a/src/features/user/constants/user.constants.ts
+++ b/src/features/user/constants/user.constants.ts
@@ -11,9 +11,9 @@ export const MAX_PHONE_LENGTH = 20;
 // ── 생년월일 ──
 
 // figma 명세 외 정책 결정: 1900-01-01 이전 입력은 거부 (사실상 봇/오입력 방지).
-// normalizeBirthDate가 로컬 타임존 기준 setHours(0,0,0,0)으로 정렬하므로
-// 비교 기준도 동일하게 로컬 타임존 자정으로 둔다.
-export const MIN_BIRTH_DATE = new Date(1900, 0, 1);
+// GraphQL DateTime은 ISO string을 UTC로 해석하므로 비교 기준도 UTC 자정으로 둔다.
+// 운영 timezone과 무관하게 동일하게 동작.
+export const MIN_BIRTH_DATE = new Date(Date.UTC(1900, 0, 1));
 
 // ── 페이지네이션 ──
 

--- a/src/features/user/services/user-base.service.spec.ts
+++ b/src/features/user/services/user-base.service.spec.ts
@@ -222,6 +222,21 @@ describe('UserBaseService (real DB)', () => {
       );
     });
 
+    it('1899-12-31 등 1900-01-01 이전이면 BadRequestException을 던진다', () => {
+      expect(() => service.testNormalizeBirthDate('1899-12-31')).toThrow(
+        BadRequestException,
+      );
+      expect(() =>
+        service.testNormalizeBirthDate(new Date(1850, 0, 1)),
+      ).toThrow(BadRequestException);
+    });
+
+    it('1900-01-01은 통과한다', () => {
+      const result = service.testNormalizeBirthDate(new Date(1900, 0, 1));
+      expect(result).toBeInstanceOf(Date);
+      expect(result?.getFullYear()).toBe(1900);
+    });
+
     it('문자열 날짜를 Date 객체로 변환한다', () => {
       const result = service.testNormalizeBirthDate('1990-05-15');
       expect(result).toBeInstanceOf(Date);

--- a/src/features/user/services/user-base.service.spec.ts
+++ b/src/features/user/services/user-base.service.spec.ts
@@ -226,32 +226,37 @@ describe('UserBaseService (real DB)', () => {
       expect(() => service.testNormalizeBirthDate('1899-12-31')).toThrow(
         BadRequestException,
       );
-      expect(() =>
-        service.testNormalizeBirthDate(new Date(1850, 0, 1)),
-      ).toThrow(BadRequestException);
+      expect(() => service.testNormalizeBirthDate('1850-01-01')).toThrow(
+        BadRequestException,
+      );
     });
 
-    it('1900-01-01은 통과한다', () => {
-      const result = service.testNormalizeBirthDate(new Date(1900, 0, 1));
+    it('1900-01-01은 통과한다 (UTC 기준)', () => {
+      const result = service.testNormalizeBirthDate('1900-01-01');
       expect(result).toBeInstanceOf(Date);
-      expect(result?.getFullYear()).toBe(1900);
+      expect(result?.getUTCFullYear()).toBe(1900);
+      expect(result?.getUTCMonth()).toBe(0);
+      expect(result?.getUTCDate()).toBe(1);
     });
 
     it('문자열 날짜를 Date 객체로 변환한다', () => {
       const result = service.testNormalizeBirthDate('1990-05-15');
       expect(result).toBeInstanceOf(Date);
-      expect(result?.getFullYear()).toBe(1990);
+      expect(result?.getUTCFullYear()).toBe(1990);
+      expect(result?.getUTCMonth()).toBe(4);
+      expect(result?.getUTCDate()).toBe(15);
     });
 
-    it('오늘 날짜는 미래로 취급하지 않고 그대로 반환한다', () => {
-      const today = new Date();
-      today.setHours(12, 0, 0, 0);
+    it('오늘(UTC) 날짜는 미래로 취급하지 않고 그대로 반환한다', () => {
+      const now = new Date();
+      const todayIso = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
 
-      const result = service.testNormalizeBirthDate(today);
+      const result = service.testNormalizeBirthDate(todayIso);
 
       expect(result).toBeInstanceOf(Date);
-      // 시간은 00:00:00으로 내부 정규화되지만 날짜 자체는 오늘과 같아야 함
-      expect(result?.toDateString()).toBe(today.toDateString());
+      expect(result?.getUTCFullYear()).toBe(now.getUTCFullYear());
+      expect(result?.getUTCMonth()).toBe(now.getUTCMonth());
+      expect(result?.getUTCDate()).toBe(now.getUTCDate());
     });
   });
 

--- a/src/features/user/services/user-base.service.ts
+++ b/src/features/user/services/user-base.service.ts
@@ -108,16 +108,21 @@ export abstract class UserBaseService {
     if (Number.isNaN(date.getTime())) {
       throw new BadRequestException('Invalid birthDate.');
     }
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const normalized = new Date(date);
-    normalized.setHours(0, 0, 0, 0);
+    // DB가 @db.Date(시간 무시) + GraphQL DateTime이 ISO string을 UTC로 해석하므로
+    // timezone 독립적으로 UTC 자정 기준으로 정규화한다.
+    const normalized = new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
     if (normalized < MIN_BIRTH_DATE) {
       throw new BadRequestException(
         'birthDate is too old (before 1900-01-01).',
       );
     }
-    if (normalized > today) {
+    const now = new Date();
+    const todayUtc = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+    );
+    if (normalized > todayUtc) {
       throw new BadRequestException('birthDate cannot be in the future.');
     }
     return normalized;

--- a/src/features/user/services/user-base.service.ts
+++ b/src/features/user/services/user-base.service.ts
@@ -10,6 +10,7 @@ import {
   MAX_NICKNAME_LENGTH,
   MAX_PAGINATION_LIMIT,
   MAX_PHONE_LENGTH,
+  MIN_BIRTH_DATE,
   MIN_NICKNAME_LENGTH,
   MIN_PHONE_LENGTH,
 } from '@/features/user/constants/user.constants';
@@ -111,6 +112,11 @@ export abstract class UserBaseService {
     today.setHours(0, 0, 0, 0);
     const normalized = new Date(date);
     normalized.setHours(0, 0, 0, 0);
+    if (normalized < MIN_BIRTH_DATE) {
+      throw new BadRequestException(
+        'birthDate is too old (before 1900-01-01).',
+      );
+    }
     if (normalized > today) {
       throw new BadRequestException('birthDate cannot be in the future.');
     }


### PR DESCRIPTION
## Summary

- 회원정보 수정/온보딩의 생년월일 정규화 로직(`normalizeBirthDate`)에 1900-01-01 이전 날짜 거부 정책 추가
- 봇/오입력 방지 목적의 가벼운 하한 검증
- 비교 기준은 normalize와 동일한 로컬 타임존 자정으로 둠

## 변경 사항

- `MIN_BIRTH_DATE = new Date(1900, 0, 1)` 상수 추가 (`user.constants.ts`)
- `user-base.service.ts` `normalizeBirthDate`에 `< MIN_BIRTH_DATE` 거부 분기 추가
- 회귀 테스트 2건 추가 (1899-12-31/1850 reject, 1900-01-01 통과)

## Breaking 여부

- 매우 약한 Breaking. 1900-01-01 이전 입력은 사실상 봇/오입력만 해당
- 마이그레이션: 없음 (DB 스키마 변경 없음)
- 기존 row 영향: 없음 (읽기 시 검증 안 함, 새 입력만 검증)

## Test plan

- [x] 로컬 `yarn test:cov` 통과 (820 tests)
- [ ] CI check 통과
- [ ] CI coverage-report 통과
- [ ] CodeQL 통과