### PR TITLE
feat(user): 전화번호 정규식 010-XXXX-XXXX 고정

### DIFF
--- a/src/features/user/constants/user.constants.ts
+++ b/src/features/user/constants/user.constants.ts
@@ -5,8 +5,9 @@ export const MAX_NICKNAME_LENGTH = 20;
 
 // ── 전화번호 ──
 
-export const MIN_PHONE_LENGTH = 7;
-export const MAX_PHONE_LENGTH = 20;
+// 정책: 010-XXXX-XXXX 고정 (13자). figma 명세 기준.
+export const PHONE_REGEX = /^010-\d{4}-\d{4}$/;
+export const PHONE_FORMAT_EXAMPLE = '010-XXXX-XXXX';
 
 // ── 생년월일 ──
 

--- a/src/features/user/services/user-base.service.spec.ts
+++ b/src/features/user/services/user-base.service.spec.ts
@@ -183,21 +183,33 @@ describe('UserBaseService (real DB)', () => {
       expect(service.testNormalizePhoneNumber('   ')).toBeNull();
     });
 
-    it('길이가 하한 미만이면 BadRequestException을 던진다', () => {
-      expect(() => service.testNormalizePhoneNumber('12345')).toThrow(
-        BadRequestException,
-      );
-    });
+    it.each([['010-0000-0000'], ['010-1234-5678'], ['010-9999-9999']])(
+      '정상 형식 %s 은 그대로 반환한다',
+      (raw) => {
+        expect(service.testNormalizePhoneNumber(raw)).toBe(raw);
+      },
+    );
 
-    it('숫자와 하이픈 외 문자가 포함되면 BadRequestException을 던진다', () => {
-      expect(() => service.testNormalizePhoneNumber('010-abc-1234')).toThrow(
-        BadRequestException,
-      );
-    });
-
-    it('유효한 전화번호를 반환한다', () => {
-      expect(service.testNormalizePhoneNumber('010-1234-5678')).toBe(
+    it('앞뒤 공백을 trim하여 검증한다', () => {
+      expect(service.testNormalizePhoneNumber('  010-1234-5678  ')).toBe(
         '010-1234-5678',
+      );
+    });
+
+    it.each([
+      ['011-1234-5678'], // 010 prefix 외
+      ['019-1234-5678'], // 010 prefix 외
+      ['010-123-4567'], // 자릿수 부족
+      ['010-12345-6789'], // 자릿수 초과
+      ['01012345678'], // 하이픈 없음
+      ['010 1234 5678'], // 공백 구분자
+      ['+82-10-1234-5678'], // 국가코드 포함
+      ['010-abc-1234'], // 문자 포함
+      ['010--1234-5678'], // 하이픈 위치 잘못
+      ['12345'], // 짧은 임의 문자열
+    ])('비정상 형식 %s 은 BadRequestException을 던진다', (raw) => {
+      expect(() => service.testNormalizePhoneNumber(raw)).toThrow(
+        BadRequestException,
       );
     });
   });

--- a/src/features/user/services/user-base.service.ts
+++ b/src/features/user/services/user-base.service.ts
@@ -9,10 +9,10 @@ import {
   DEFAULT_PAGINATION_LIMIT,
   MAX_NICKNAME_LENGTH,
   MAX_PAGINATION_LIMIT,
-  MAX_PHONE_LENGTH,
   MIN_BIRTH_DATE,
   MIN_NICKNAME_LENGTH,
-  MIN_PHONE_LENGTH,
+  PHONE_FORMAT_EXAMPLE,
+  PHONE_REGEX,
 } from '@/features/user/constants/user.constants';
 import type { UserAccountWithProfile } from '@/features/user/repositories/user.repository';
 import { UserRepository } from '@/features/user/repositories/user.repository';
@@ -90,14 +90,10 @@ export abstract class UserBaseService {
     if (raw === undefined || raw === null) return null;
     const trimmed = raw.trim();
     if (trimmed.length === 0) return null;
-    if (
-      trimmed.length < MIN_PHONE_LENGTH ||
-      trimmed.length > MAX_PHONE_LENGTH
-    ) {
-      throw new BadRequestException('Invalid phone number length.');
-    }
-    if (!/^[0-9-]+$/.test(trimmed)) {
-      throw new BadRequestException('Invalid phone number format.');
+    if (!PHONE_REGEX.test(trimmed)) {
+      throw new BadRequestException(
+        `Invalid phone number format. Expected ${PHONE_FORMAT_EXAMPLE}.`,
+      );
     }
     return trimmed;
   }


### PR DESCRIPTION
## Summary

- 전화번호 검증을 ^010-\d{4}-\d{4}\$ (13자 고정)로 강화
- 기존 ^[0-9-]+\$ + 7~20자 정책은 '01-2-3' 같은 비정상 패턴도 통과시켜 사실상 비검증 상태였음
- 마이페이지 figma 명세에 맞춰 010 prefix만 허용

## 변경 사항

- PHONE_REGEX, PHONE_FORMAT_EXAMPLE 상수 추가 (user.constants.ts)
- MIN_PHONE_LENGTH, MAX_PHONE_LENGTH 상수 제거 (정규식으로 대체)
- normalizePhoneNumber: 정규식 단일 검증으로 단순화 + 명확한 에러 메시지
- 회귀 테스트: 정상 3건 + trim 1건 + 비정상 10건 (table-driven)

## Breaking 여부

- 부분 Breaking: 기존에 통과하던 비-010 번호, 자릿수 다른 번호가 reject됨
- 영향 범위: completeOnboarding / updateMyProfile 입력 검증
- DB 기존 row: 영향 없음 (읽기 시 검증 안 함, 새 입력만 검증)
- DB 데이터 현재 0건 + 프론트 미개발 → 운영 영향 없음

## Test plan

- [x] 로컬 yarn test:cov 통과 (831 tests)
- [x] CI check 통과
- [x] CI coverage-report 통과
- [x] CodeQL 통과