### PR TITLE
feat(user): 회원정보 수정에 name 필드 추가

### DIFF
--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -96,18 +96,39 @@ export class UserRepository {
   async updateProfile(args: {
     accountId: bigint;
     nickname?: string;
+    name?: string;
     birthDate?: Date | null;
     phoneNumber?: string | null;
   }): Promise<void> {
-    await this.prisma.userProfile.update({
-      where: { account_id: args.accountId },
-      data: {
-        ...(args.nickname !== undefined ? { nickname: args.nickname } : {}),
-        ...(args.birthDate !== undefined ? { birth_date: args.birthDate } : {}),
-        ...(args.phoneNumber !== undefined
-          ? { phone_number: args.phoneNumber }
-          : {}),
-      },
+    const hasName = args.name !== undefined;
+    const hasProfileFields =
+      args.nickname !== undefined ||
+      args.birthDate !== undefined ||
+      args.phoneNumber !== undefined;
+
+    // name은 account 테이블, 나머지는 user_profile 테이블이라
+    // 두 테이블 부분 실패 방지를 위해 transaction으로 묶는다.
+    await this.prisma.$transaction(async (tx) => {
+      if (hasName) {
+        await tx.account.update({
+          where: { id: args.accountId },
+          data: { name: args.name },
+        });
+      }
+      if (hasProfileFields) {
+        await tx.userProfile.update({
+          where: { account_id: args.accountId },
+          data: {
+            ...(args.nickname !== undefined ? { nickname: args.nickname } : {}),
+            ...(args.birthDate !== undefined
+              ? { birth_date: args.birthDate }
+              : {}),
+            ...(args.phoneNumber !== undefined
+              ? { phone_number: args.phoneNumber }
+              : {}),
+          },
+        });
+      }
     });
   }
 

--- a/src/features/user/services/user-profile.service.spec.ts
+++ b/src/features/user/services/user-profile.service.spec.ts
@@ -222,6 +222,98 @@ describe('UserProfileService (real DB)', () => {
         service.updateMyProfile(me.id, { nickname: 'taken' }),
       ).rejects.toThrow(ConflictException);
     });
+
+    it('name만 단독 업데이트하면 Account.name이 갱신된다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: '구이름',
+      });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const result = await service.updateMyProfile(account.id, {
+        name: '새이름',
+      });
+
+      expect(result.name).toBe('새이름');
+      const saved = await prisma.account.findUniqueOrThrow({
+        where: { id: account.id },
+      });
+      expect(saved.name).toBe('새이름');
+    });
+
+    it('name 입력 시 trim 후 저장한다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: '구이름',
+      });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const result = await service.updateMyProfile(account.id, {
+        name: '  홍길동  ',
+      });
+
+      expect(result.name).toBe('홍길동');
+    });
+
+    it('name이 빈 문자열이면 BadRequestException', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: '구이름',
+      });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      await expect(
+        service.updateMyProfile(account.id, { name: '' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('name이 공백-only이면 BadRequestException', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: '구이름',
+      });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      await expect(
+        service.updateMyProfile(account.id, { name: '   ' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('name + nickname 동시 업데이트 시 둘 다 반영된다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: '구이름',
+      });
+      await createUserProfile(prisma, {
+        account_id: account.id,
+        nickname: 'oldNick',
+      });
+
+      const result = await service.updateMyProfile(account.id, {
+        name: '새이름',
+        nickname: 'newNick',
+      });
+
+      expect(result.name).toBe('새이름');
+      expect(result.profile.nickname).toBe('newNick');
+    });
+
+    it('name 미지정 시 기존 Account.name이 유지된다', async () => {
+      const account = await createAccount(prisma, {
+        account_type: 'USER',
+        name: '유지될이름',
+      });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      await service.updateMyProfile(account.id, {
+        nickname: 'newNick',
+      });
+
+      const saved = await prisma.account.findUniqueOrThrow({
+        where: { id: account.id },
+      });
+      expect(saved.name).toBe('유지될이름');
+    });
   });
 
   // ─── updateMyProfileImage ───

--- a/src/features/user/services/user-profile.service.ts
+++ b/src/features/user/services/user-profile.service.ts
@@ -73,10 +73,11 @@ export class UserProfileService extends UserBaseService {
     await this.requireActiveUser(accountId);
 
     const hasNickname = input.nickname !== undefined;
+    const hasName = input.name !== undefined;
     const hasBirthDate = input.birthDate !== undefined;
     const hasPhoneNumber = input.phoneNumber !== undefined;
 
-    if (!hasNickname && !hasBirthDate && !hasPhoneNumber) {
+    if (!hasNickname && !hasName && !hasBirthDate && !hasPhoneNumber) {
       throw new BadRequestException('No fields to update.');
     }
 
@@ -89,6 +90,16 @@ export class UserProfileService extends UserBaseService {
       if (isTaken) throw new ConflictException('Nickname already exists.');
     }
 
+    // figma 명세: 이름은 필수값. 전송되었지만 trim 후 빈 문자열이면 reject.
+    let name: string | undefined = undefined;
+    if (hasName) {
+      const normalized = this.normalizeName(input.name);
+      if (!normalized) {
+        throw new BadRequestException('Name cannot be empty.');
+      }
+      name = normalized;
+    }
+
     const birthDate = hasBirthDate
       ? this.normalizeBirthDate(input.birthDate)
       : undefined;
@@ -99,6 +110,7 @@ export class UserProfileService extends UserBaseService {
     await this.repo.updateProfile({
       accountId,
       ...(hasNickname ? { nickname } : {}),
+      ...(hasName ? { name } : {}),
       ...(hasBirthDate ? { birthDate } : {}),
       ...(hasPhoneNumber ? { phoneNumber } : {}),
     });

--- a/src/features/user/types/user-input.type.ts
+++ b/src/features/user/types/user-input.type.ts
@@ -7,6 +7,7 @@ export interface CompleteOnboardingInput {
 
 export interface UpdateMyProfileInput {
   nickname?: string | null;
+  name?: string | null;
   birthDate?: Date | null;
   phoneNumber?: string | null;
 }

--- a/src/features/user/user-profile.graphql
+++ b/src/features/user/user-profile.graphql
@@ -62,6 +62,8 @@ input CompleteOnboardingInput {
 input UpdateMyProfileInput {
   """닉네임"""
   nickname: String
+  """이름(전송 시 trim 후 비어있으면 reject)"""
+  name: String
   """생년월일"""
   birthDate: DateTime
   """전화번호"""


### PR DESCRIPTION
## Summary

- 마이페이지 figma 명세 03-profile-edit의 '이름 입력 (필수값)' 정책 반영
- updateMyProfile에 name 처리 추가 + 필수값 검증
- name은 Account 테이블, 나머지(닉네임/생일/전화)는 user_profile 테이블이라 transaction으로 묶음

## 변경 사항

- SDL UpdateMyProfileInput에 name: String 추가
- TS DTO 및 codegen 갱신
- service: hasName 분기 + normalizeName 검증 (trim 후 빈 문자열은 reject)
- repository: updateProfile args에 name? 추가, account/user_profile update를 단일 transaction으로 묶음
- 회귀 테스트 6건
  - name만 단독 업데이트
  - trim 동작
  - 빈 문자열 reject
  - 공백-only reject
  - name + nickname 동시 업데이트
  - name 미지정 시 기존 값 유지

## Breaking 여부

- ❌ Breaking 아님. SDL에 옵셔널 필드만 추가
- 기존 호출 (name 미전송)은 동작 변경 없음

## Test plan

- [x] 로컬 yarn test:cov 통과 (837 tests)
- [x] CI check 통과
- [x] CI coverage-report 통과
- [x] CodeQL 통과