### PR TITLE
fix(user): wishlist 가시성 일관성 + 목록 정렬 안정화 (PR #81 리뷰 반영)

### DIFF
--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -434,7 +434,9 @@ export class UserRepository {
 
   /**
    * 주어진 productIds 중 사용자가 찜한 것들의 product_id 집합을 단일 IN 쿼리로 반환.
-   * 매핑(N+1 회피)용.
+   * 매핑(N+1 회피)용. 가시성 조건(visibleWishlistWhere)을 myWishlist/wishlistCount와
+   * 공유하여, recent-view 등에 노출되는 isWishlisted 플래그가 실제 wishlist 표면
+   * (목록/카운트)과 일관되도록 한다.
    */
   async findWishlistedProductIds(args: {
     accountId: bigint;
@@ -443,8 +445,7 @@ export class UserRepository {
     if (args.productIds.length === 0) return new Set();
     const rows = await this.prisma.wishlistItem.findMany({
       where: {
-        account_id: args.accountId,
-        deleted_at: null,
+        ...this.visibleWishlistWhere(args.accountId),
         product_id: { in: args.productIds },
       },
       select: { product_id: true },
@@ -478,7 +479,8 @@ export class UserRepository {
     const [rows, totalCount] = await this.prisma.$transaction([
       this.prisma.wishlistItem.findMany({
         where,
-        orderBy: { created_at: 'desc' },
+        // 같은 밀리초 생성 시 페이지 경계 흔들림 방지를 위해 product_id를 보조 정렬키로 둔다.
+        orderBy: [{ created_at: 'desc' }, { product_id: 'desc' }],
         skip: args.offset,
         take: args.limit,
         select: {

--- a/src/features/user/services/user-recent-view.service.spec.ts
+++ b/src/features/user/services/user-recent-view.service.spec.ts
@@ -115,6 +115,34 @@ describe('UserRecentViewService (real DB)', () => {
       expect(map.get(notWishlisted.id.toString())).toBe(false);
     });
 
+    it('비활성 store/product에 대한 wishlist는 isWishlisted=false로 매핑된다 (myWishlist 가시성과 일치)', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      const inactiveStore = await createStore(prisma, { is_active: false });
+      const productOfInactiveStore = await createProduct(prisma, {
+        store_id: inactiveStore.id,
+      });
+      // recent-view 항목으로는 보이지만, 그 product의 store가 비활성이라
+      // myWishlist에는 노출되지 않음 → isWishlisted도 false여야 일관됨
+      await createRecentProductView(prisma, {
+        account_id: account.id,
+        product_id: productOfInactiveStore.id,
+      });
+      await prisma.wishlistItem.create({
+        data: {
+          account_id: account.id,
+          product_id: productOfInactiveStore.id,
+        },
+      });
+
+      const result = await service.list(account.id);
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].productId).toBe(
+        productOfInactiveStore.id.toString(),
+      );
+      expect(result.items[0].isWishlisted).toBe(false);
+    });
+
     it('pagination: offset + limit < totalCount면 hasMore true', async () => {
       const account = await createAccount(prisma, { account_type: 'USER' });
       const store = await createStore(prisma);


### PR DESCRIPTION
## Summary

PR #81 (develop→main 릴리즈)에 달린 Codex/CodeRabbit 리뷰 2건 반영.
머지 후 develop 갱신 → PR #81에 자동 포함됨.

## 변경 사항

### Codex P2: findWishlistedProductIds 가시성 일관성
- 매핑용 IN 쿼리도 visibleWishlistWhere helper를 사용하도록 통일
- 이전 fix(PR #80)에서 myWishlist/wishlistCount/findWishlistItems 세 곳을 통일했으나, 이 메서드만 누락되어 있던 상태
- 효과: 비활성 store에 속한 product가 recent-view에서 isWishlisted=true로 보이지만 myWishlist에는 안 보이는 모순 회피

### CodeRabbit Major: findWishlistItems orderBy tie-breaker
- orderBy에 product_id desc 보조 정렬키 추가
- 같은 밀리초에 생성된 항목의 페이지 경계 흔들림 방지

### 회귀 테스트
- recent-view spec 1건 추가: 비활성 store의 product에 wishlist가 있어도 isWishlisted=false로 매핑됨 (가시성 일관)

## Breaking 여부

- ❌ Breaking 아님. 가시성 조건 좁히기와 정렬 보조키 추가뿐
- 마이그레이션: 없음

## Test plan

- [x] 로컬 yarn test:cov 통과 (868 tests, +1)
- [ ] CI check 통과
- [ ] CI coverage-report 통과
- [ ] CodeQL 통과