### PR TITLE
chore(terraform): develop 보호 정책에 Admin role bypass 추가

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -119,6 +119,16 @@ resource "github_repository_ruleset" "develop_protection" {
     }
   }
 
+  # Repository Admin role 보유자는 develop에 직접 push 가능 (PR/CI 우회).
+  # 주 use case: release 머지 후 develop을 main HEAD로 fast-forward 동기화.
+  # 일반 작업은 여전히 PR + CI 경유 권장. main 보호는 영향받지 않는다.
+  # (GitHub Ruleset bypass_actors는 user 직접 지정 불가 — RepositoryRole/Team만 가능)
+  bypass_actors {
+    actor_id    = 5 # RepositoryRole: Admin
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+
   rules {
     deletion         = true
     non_fast_forward = true


### PR DESCRIPTION
## Summary

release 머지 후 develop을 main HEAD로 fast-forward 동기화할 수 있도록
`develop_protection` 에 `RepositoryRole=Admin` bypass_actors 1건 추가.

## 배경

- GitHub UI의 PR 머지 모드는 모두 새 커밋(merge commit / squash / rebase)을 생성
- 진정한 fast-forward (포인터만 이동)는 PR로 불가능
- release 머지 후 develop은 main의 머지 커밋을 모르는 상태가 누적 → 두 브랜치 SHA drift
- Admin이 release 머지 직후 git push origin main:develop 으로 ff sync 가능하도록 우회 권한 부여

## 변경 사항

- `develop_protection` ruleset에 bypass_actors 1건 추가
  - actor_type: RepositoryRole
  - actor_id: 5 (Admin)
  - bypass_mode: always

GitHub Ruleset API는 user 직접 지정 불가 (RepositoryRole/Team/Integration/OrganizationAdmin만).
현재 레포 admin 4명에게 bypass 권한 부여됨.

## 영향 범위

- main 보호: 그대로 유지 (PR + CI 필수)
- develop 보호: 일반 작업은 여전히 PR 경유 권장
  - admin이 의도적으로 직접 push (ff sync 등) 시에만 우회

## Test plan

- [x] terraform plan: bypass_actors 1건 추가만 변경 (다른 0)
- [ ] 머지 후 terraform apply
- [ ] git push origin main:develop 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **설정 업데이트**
  * 개발(develop) 브랜치 보호 규칙에 관리자 역할이 항상 규칙을 우회할 수 있는 기능이 추가되었습니다. 기존의 삭제/강제 푸시 제한, PR 요구사항 및 필수 상태 확인은 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->