### PR TITLE
feat(auth): dev 전용 access token 발급 endpoint 추가

### DIFF
--- a/src/features/auth/auth.service.spec.ts
+++ b/src/features/auth/auth.service.spec.ts
@@ -1,4 +1,8 @@
-import { UnauthorizedException } from '@nestjs/common';
+import {
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -38,6 +42,7 @@ describe('AuthService', () => {
       rotateRefreshSession: jest.fn(),
       revokeRefreshSession: jest.fn(),
       findAccountForMe: jest.fn(),
+      findAccountForJwt: jest.fn(),
       createRefreshSession: jest.fn(),
     } as unknown as jest.Mocked<AuthRepository>;
 
@@ -507,6 +512,57 @@ describe('AuthService', () => {
         (c) => c[0] === 'caquick_oidc_return_to',
       );
       expect(returnToCookie![1]).toBe('http://localhost:3000');
+    });
+  });
+
+  describe('issueDevAccessToken', () => {
+    beforeEach(() => {
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'JWT_ACCESS_EXPIRES_SECONDS') return '900';
+        return undefined;
+      });
+      mockJwt.sign.mockReturnValue('signed-access-token');
+    });
+
+    it('정상 발급: 활성 USER 계정이면 access token + 만료 정보를 반환한다', async () => {
+      mockRepo.findAccountForJwt.mockResolvedValue({
+        id: BigInt(1),
+        status: 'ACTIVE',
+        account_type: 'USER',
+      });
+
+      const result = await service.issueDevAccessToken(BigInt(1));
+
+      expect(result).toEqual({
+        accessToken: 'signed-access-token',
+        tokenType: 'Bearer',
+        expiresInSeconds: 900,
+      });
+      expect(mockJwt.sign).toHaveBeenCalledWith(
+        expect.objectContaining({ sub: '1', typ: 'access' }),
+      );
+    });
+
+    it('존재하지 않는 accountId면 NotFoundException', async () => {
+      mockRepo.findAccountForJwt.mockResolvedValue(null);
+
+      await expect(service.issueDevAccessToken(BigInt(999))).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockJwt.sign).not.toHaveBeenCalled();
+    });
+
+    it('비활성(SUSPENDED) 계정이면 ForbiddenException', async () => {
+      mockRepo.findAccountForJwt.mockResolvedValue({
+        id: BigInt(2),
+        status: 'SUSPENDED',
+        account_type: 'USER',
+      });
+
+      await expect(service.issueDevAccessToken(BigInt(2))).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockJwt.sign).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   ForbiddenException,
   Injectable,
+  NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -202,6 +203,37 @@ export class AuthService {
   async refresh(req: Request, res: Response): Promise<{ accessToken: string }> {
     const { accessToken } = await this.rotateRefresh(req, res);
     return { accessToken };
+  }
+
+  /**
+   * 개발 환경 한정: accountId 만으로 access token을 즉시 발급한다.
+   *
+   * 운영자/FE가 OIDC 흐름을 거치지 않고 시드 데이터의 accountId 로 곧장
+   * GraphQL API를 시험하기 위함. production 환경에서는 controller 입구에서
+   * 차단된다.
+   *
+   * @param accountId 발급 대상 account id
+   * @returns 발급된 access token + 만료(초)
+   */
+  async issueDevAccessToken(accountId: bigint): Promise<{
+    accessToken: string;
+    tokenType: 'Bearer';
+    expiresInSeconds: number;
+  }> {
+    const account = await this.repo.findAccountForJwt(accountId);
+    if (!account) {
+      throw new NotFoundException('Account not found.');
+    }
+    if (account.status !== 'ACTIVE') {
+      throw new ForbiddenException('Account is not active.');
+    }
+
+    const accessToken = this.signAccessToken(accountId);
+    return {
+      accessToken,
+      tokenType: 'Bearer',
+      expiresInSeconds: this.getAccessExpiresSeconds(),
+    };
   }
 
   /**

--- a/src/features/auth/controllers/auth.controller.spec.ts
+++ b/src/features/auth/controllers/auth.controller.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Request, Response } from 'express';
 
@@ -29,6 +29,7 @@ describe('AuthController', () => {
       refreshSeller: jest.fn(),
       logoutSeller: jest.fn(),
       changeSellerPassword: jest.fn(),
+      issueDevAccessToken: jest.fn(),
     } as unknown as jest.Mocked<AuthService>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -207,5 +208,62 @@ describe('AuthController', () => {
         res,
       ),
     ).rejects.toThrow(BadRequestException);
+  });
+
+  describe('devIssueToken', () => {
+    const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    });
+
+    it('NODE_ENV=production이면 ForbiddenException', async () => {
+      process.env.NODE_ENV = 'production';
+      const res = mockRes();
+
+      await expect(
+        controller.devIssueToken({ accountId: '1' }, res),
+      ).rejects.toThrow(ForbiddenException);
+      expect(auth.issueDevAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('accountId 문자열이 누락되면 BadRequestException', async () => {
+      process.env.NODE_ENV = 'development';
+      const res = mockRes();
+
+      await expect(
+        controller.devIssueToken({} as unknown as { accountId: string }, res),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('accountId가 BigInt로 파싱 불가하면 BadRequestException', async () => {
+      process.env.NODE_ENV = 'development';
+      const res = mockRes();
+
+      await expect(
+        controller.devIssueToken({ accountId: 'not-a-number' }, res),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('정상 발급: service 위임 + 200 응답', async () => {
+      process.env.NODE_ENV = 'development';
+      const res = mockRes();
+
+      auth.issueDevAccessToken.mockResolvedValue({
+        accessToken: 't',
+        tokenType: 'Bearer',
+        expiresInSeconds: 900,
+      });
+
+      await controller.devIssueToken({ accountId: '5' }, res);
+
+      expect(auth.issueDevAccessToken).toHaveBeenCalledWith(BigInt(5));
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        accessToken: 't',
+        tokenType: 'Bearer',
+        expiresInSeconds: 900,
+      });
+    });
   });
 });

--- a/src/features/auth/controllers/auth.controller.ts
+++ b/src/features/auth/controllers/auth.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  ForbiddenException,
   Get,
   Param,
   Post,
@@ -267,6 +268,54 @@ export class AuthController {
   }
 
   /**
+   * Dev 전용 access token 발급 (개발 환경 한정)
+   *
+   * POST /auth/dev/issue-token
+   *
+   * - NODE_ENV=production 인 경우 ForbiddenException
+   * - body: { accountId: string }
+   * - 응답: { accessToken, tokenType, expiresInSeconds }
+   *
+   * 시드(yarn prisma:seed) 데이터의 accountId 로 곧장 GraphQL Playground에서
+   * 마이페이지 API를 시험해 볼 수 있도록 OIDC 흐름을 우회한다.
+   */
+  @ApiOperation({
+    summary: '[DEV ONLY] Access token 즉시 발급',
+    description:
+      '개발 환경에서 OIDC 흐름 없이 accountId로 access token을 발급한다. NODE_ENV=production 에서는 차단된다.',
+  })
+  @ApiOkResponse({
+    description: 'Dev access token',
+    schema: {
+      type: 'object',
+      properties: {
+        accessToken: { type: 'string' },
+        tokenType: { type: 'string', example: 'Bearer' },
+        expiresInSeconds: { type: 'number', example: 900 },
+      },
+      required: ['accessToken', 'tokenType', 'expiresInSeconds'],
+    },
+  })
+  @Post('dev/issue-token')
+  async devIssueToken(
+    @Body() body: DevIssueTokenBody,
+    @Res() res: Response,
+  ): Promise<void> {
+    if (process.env.NODE_ENV === 'production') {
+      throw new ForbiddenException(
+        '/auth/dev/issue-token은 개발 환경에서만 사용 가능합니다.',
+      );
+    }
+    if (!body || typeof body.accountId !== 'string') {
+      throw new BadRequestException('accountId(string)가 필요합니다.');
+    }
+
+    const accountId = parseAccountIdString(body.accountId);
+    const result = await this.auth.issueDevAccessToken(accountId);
+    res.status(200).json(result);
+  }
+
+  /**
    * 판매자 비밀번호 변경
    *
    * POST /auth/seller/change-password
@@ -313,9 +362,21 @@ interface SellerChangePasswordBody {
   newPassword: string;
 }
 
+interface DevIssueTokenBody {
+  accountId: string;
+}
+
 function parseAccountId(user: JwtUser): bigint {
   try {
     return BigInt(user.accountId);
+  } catch {
+    throw new BadRequestException('Invalid account id.');
+  }
+}
+
+function parseAccountIdString(raw: string): bigint {
+  try {
+    return BigInt(raw);
   } catch {
     throw new BadRequestException('Invalid account id.');
   }


### PR DESCRIPTION
## Summary

FE 개발자가 시드(yarn prisma:seed) 데이터의 accountId 로 OIDC 흐름을 거치지 않고
GraphQL Playground에서 곧장 마이페이지 API를 시험할 수 있도록 dev 전용 헬퍼 추가.

본 PR은 마이페이지 FE 온보딩 작업 플랜의 Stage A-4.

## 변경 사항

### Service: AuthService.issueDevAccessToken(accountId)

- repo.findAccountForJwt로 활성 USER 검증
  - 없으면 NotFoundException
  - status !== ACTIVE면 ForbiddenException
- 기존 signAccessToken을 그대로 재사용해 access token 생성
- 응답: { accessToken, tokenType: 'Bearer', expiresInSeconds }

### Controller: POST /auth/dev/issue-token

- NODE_ENV=production이면 즉시 ForbiddenException으로 차단 (운영 안전망)
- body.accountId 누락/형식 오류 시 BadRequestException
- service 위임 후 200 응답
- Swagger 데코레이터 ([DEV ONLY] 라벨)

## 사용 예시

```bash
curl -s -X POST http://localhost:4000/auth/dev/issue-token \\
  -H 'Content-Type: application/json' \\
  -d '{"accountId":"1"}'
```

응답의 accessToken을 GraphQL Playground Headers에 입력:

```json
{ "Authorization": "Bearer <accessToken>" }
```

## 회귀 테스트

- auth.service.spec.ts: 정상 / NotFound / Forbidden 3건
- auth.controller.spec.ts: production 차단 / 누락 / 형식오류 / 정상 4건

## Breaking 여부

- ❌ Breaking 아님. 운영 영향 없음 (production에서 자동 차단)
- 새 endpoint 추가, 기존 endpoint 변경 없음

## Test plan

- [x] 로컬 yarn test:cov 통과 (875 tests, +7)
- [ ] CI check 통과
- [ ] CI coverage-report 통과
- [ ] CodeQL 통과