### PR TITLE
chore(ci): deploy 워크플로우를 수동 trigger로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,10 @@
 name: Deploy Backend
 
+# 현재 개발 단계 인프라 비용 절감 차원에서 RDS 삭제(스냅샷 보관) + EC2 중지
+# 상태이므로 자동 배포를 비활성화한다. 인프라 복구 후 재개 시 trigger를
+# `push: branches: ["main"]`으로 되돌리면 된다.
 on:
-  push:
-    branches: ["main"]
+  workflow_dispatch:
 
 concurrency:
   group: backend-deploy


### PR DESCRIPTION
## Summary
- 개발 단계 인프라 비용 절감 차원에서 RDS 인스턴스 삭제(스냅샷 보관) + EC2 인스턴스 중지된 상태.
- 그 상태로 두면 main 머지마다 deploy 워크플로우가 실패하면서 (a) Discord 알림 노이즈, (b) 실패한 S3 artifact 누적, (c) 매번 100MB+ zip 빌드/업로드로 시간/소액 비용 낭비가 발생.
- on: trigger를 `workflow_dispatch`로 변경해 수동 실행만 허용.

## 영향 없음 확인
- `pr-check.yml` — testcontainers로 MySQL 자체 spin-up, RDS 무관. 그대로
- `discord-notify.yml` — 알림만, AWS 무관. 그대로
- `codeql.yml` — 정적 분석. 그대로
- terraform — GitHub repo 설정만 관리 (AWS infra 미관리), drift 우려 없음

## 재개 절차
인프라(RDS 스냅샷 복원 + EC2 시작) 복구 후 `on:` 블록을 아래로 revert:
```yaml
on:
  push:
    branches: ["main"]
```

## Test plan
- [x] 워크플로우 파일 syntax 변경 외 로직 변경 없음
- [ ] 머지 후 main에 push 발생 시 deploy 워크플로우가 트리거되지 않는지 확인