### PR TITLE
chore: develop → main 릴리즈 (마이페이지 소셜 provider 노출 + deploy CI 수동 전환)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,10 @@
 name: Deploy Backend
 
+# 현재 개발 단계 인프라 비용 절감 차원에서 RDS 삭제(스냅샷 보관) + EC2 중지
+# 상태이므로 자동 배포를 비활성화한다. 인프라 복구 후 재개 시 trigger를
+# `push: branches: ["main"]`으로 되돌리면 된다.
 on:
-  push:
-    branches: ["main"]
+  workflow_dispatch:
 
 concurrency:
   group: backend-deploy

--- a/src/features/user/repositories/user.repository.spec.ts
+++ b/src/features/user/repositories/user.repository.spec.ts
@@ -1,0 +1,75 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { UserRepository } from '@/features/user/repositories/user.repository';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createAccount, createUserProfile } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * 본 spec은 UserRepository 중 "서비스/리졸버 spec으로는 직접 도달이 어려운"
+ * API contract만 좁게 검증한다. 일반적인 비즈니스 분기는 service spec에서
+ * 다룬다는 컨벤션을 깨지 않기 위한 의도.
+ */
+describe('UserRepository (real DB)', () => {
+  let repo: UserRepository;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [UserRepository],
+    });
+    repo = module.get(UserRepository);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  // ─────────────────────────────────────────────
+  // findAccountWithProfile - withDeleted 플래그 contract
+  //
+  // 호출부(UserBaseService.requireActiveUser)가 항상 withDeleted:true로
+  // 호출하기 때문에 서비스 spec으로는 falsy 브랜치가 검증되지 않는다.
+  // soft-delete extension(applySoftDeleteArgs)이 where에 deleted_at own-key
+  // 유무로 자동 필터 주입 여부를 분기하므로, 그 상호작용을 여기서 못박는다.
+  // ─────────────────────────────────────────────
+  describe('findAccountWithProfile - withDeleted flag', () => {
+    it('withDeleted 미지정이면 soft-deleted 계정은 null로 반환된다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+      await prisma.account.update({
+        where: { id: account.id },
+        data: { deleted_at: new Date() },
+      });
+
+      const result = await repo.findAccountWithProfile(account.id);
+
+      expect(result).toBeNull();
+    });
+
+    it('withDeleted: true 이면 soft-deleted 계정도 그대로 반환된다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+      const deletedAt = new Date();
+      await prisma.account.update({
+        where: { id: account.id },
+        data: { deleted_at: deletedAt },
+      });
+
+      const result = await repo.findAccountWithProfile(account.id, {
+        withDeleted: true,
+      });
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(account.id);
+      expect(result?.deleted_at).not.toBeNull();
+    });
+  });
+});

--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -2,11 +2,17 @@ import { Injectable } from '@nestjs/common';
 import {
   AccountType,
   CustomDraftStatus,
+  IdentityProvider,
   NotificationEvent,
   NotificationType,
 } from '@prisma/client';
 
 import { PrismaService } from '@/prisma';
+
+export interface UserAccountIdentity {
+  provider: IdentityProvider;
+  last_login_at: Date | null;
+}
 
 export interface UserAccountWithProfile {
   id: bigint;
@@ -22,6 +28,7 @@ export interface UserAccountWithProfile {
     onboarding_completed_at: Date | null;
     deleted_at: Date | null;
   } | null;
+  account_identities: UserAccountIdentity[];
 }
 
 @Injectable()
@@ -59,17 +66,22 @@ export class UserRepository {
     accountId: bigint,
     options?: { withDeleted?: boolean },
   ): Promise<UserAccountWithProfile | null> {
-    const where = {
-      id: accountId,
-      ...(options?.withDeleted ? { deleted_at: undefined } : {}),
-    };
-    const args = {
-      where,
+    return this.prisma.account.findFirst({
+      where: {
+        id: accountId,
+        ...(options?.withDeleted ? { deleted_at: undefined } : {}),
+      },
       include: {
         user_profile: true,
+        // soft-deleted identity는 노출 대상 아님. 최근 로그인 순으로 정렬해
+        // FE가 "최근 로그인 provider" 표시할 때 별도 정렬 없이 사용 가능.
+        account_identities: {
+          where: { deleted_at: null },
+          orderBy: [{ last_login_at: 'desc' }, { id: 'asc' }],
+          select: { provider: true, last_login_at: true },
+        },
       },
-    };
-    return this.prisma.account.findFirst(args);
+    });
   }
 
   async isNicknameTaken(

--- a/src/features/user/resolvers/user-profile.resolver.spec.ts
+++ b/src/features/user/resolvers/user-profile.resolver.spec.ts
@@ -8,7 +8,11 @@ import { UserProfileService } from '@/features/user/services/user-profile.servic
 import { S3Service } from '@/global/storage/s3.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
-import { createAccount, createUserProfile } from '@/test/factories';
+import {
+  createAccount,
+  createAccountIdentity,
+  createUserProfile,
+} from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
 /**
@@ -76,6 +80,22 @@ describe('User Profile Resolvers (real DB)', () => {
       await expect(queryResolver.me({ accountId: '999999' })).rejects.toThrow(
         UnauthorizedException,
       );
+    });
+
+    it('linkedIdentities 필드까지 resolver를 통해 그대로 노출된다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+      await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'KAKAO',
+      });
+
+      const result = await queryResolver.me({
+        accountId: account.id.toString(),
+      });
+
+      expect(result.linkedIdentities).toHaveLength(1);
+      expect(result.linkedIdentities[0].provider).toBe('KAKAO');
     });
   });
 

--- a/src/features/user/services/user-base.service.ts
+++ b/src/features/user/services/user-base.service.ts
@@ -60,6 +60,11 @@ export abstract class UserBaseService {
         profileImageUrl: account.user_profile.profile_image_url,
         onboardingCompletedAt: account.user_profile.onboarding_completed_at,
       },
+      // repository에서 soft-deleted 제외 + 최근 로그인 순으로 정렬해 가져온다.
+      linkedIdentities: account.account_identities.map((identity) => ({
+        provider: identity.provider,
+        lastLoginAt: identity.last_login_at,
+      })),
     };
   }
 

--- a/src/features/user/services/user-profile.service.spec.ts
+++ b/src/features/user/services/user-profile.service.spec.ts
@@ -10,7 +10,11 @@ import { UserProfileService } from '@/features/user/services/user-profile.servic
 import { S3Service } from '@/global/storage/s3.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
-import { createAccount, createUserProfile } from '@/test/factories';
+import {
+  createAccount,
+  createAccountIdentity,
+  createUserProfile,
+} from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
 describe('UserProfileService (real DB)', () => {
@@ -73,6 +77,96 @@ describe('UserProfileService (real DB)', () => {
       await expect(service.me(BigInt(999999))).rejects.toThrow(
         UnauthorizedException,
       );
+    });
+
+    it('연동된 identity가 없으면 linkedIdentities는 빈 배열이다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const result = await service.me(account.id);
+
+      expect(result.linkedIdentities).toEqual([]);
+    });
+
+    it('연동된 identity가 있으면 provider/lastLoginAt을 반환한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+      const identity = await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'GOOGLE',
+      });
+      const loggedInAt = new Date('2025-01-15T10:00:00Z');
+      await prisma.accountIdentity.update({
+        where: { id: identity.id },
+        data: { last_login_at: loggedInAt },
+      });
+
+      const result = await service.me(account.id);
+
+      expect(result.linkedIdentities).toEqual([
+        { provider: 'GOOGLE', lastLoginAt: loggedInAt },
+      ]);
+    });
+
+    it('여러 provider 연동 시 last_login_at desc 순으로 반환한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const oldLogin = new Date('2025-01-01T00:00:00Z');
+      const recentLogin = new Date('2025-03-01T00:00:00Z');
+
+      const google = await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'GOOGLE',
+      });
+      const kakao = await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'KAKAO',
+      });
+      await prisma.accountIdentity.update({
+        where: { id: google.id },
+        data: { last_login_at: oldLogin },
+      });
+      await prisma.accountIdentity.update({
+        where: { id: kakao.id },
+        data: { last_login_at: recentLogin },
+      });
+
+      const result = await service.me(account.id);
+
+      expect(result.linkedIdentities).toEqual([
+        { provider: 'KAKAO', lastLoginAt: recentLogin },
+        { provider: 'GOOGLE', lastLoginAt: oldLogin },
+      ]);
+    });
+
+    it('soft-deleted identity는 linkedIdentities에서 제외된다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+
+      const activeIdentity = await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'GOOGLE',
+      });
+      const deletedIdentity = await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'KAKAO',
+      });
+      await prisma.accountIdentity.update({
+        where: { id: deletedIdentity.id },
+        data: { deleted_at: new Date() },
+      });
+
+      const result = await service.me(account.id);
+
+      expect(result.linkedIdentities).toHaveLength(1);
+      expect(result.linkedIdentities[0]).toMatchObject({ provider: 'GOOGLE' });
+      // soft-deleted 식별자가 우연히 노출되지 않는지 명시적으로 검증
+      expect(result.linkedIdentities.some((i) => i.provider === 'KAKAO')).toBe(
+        false,
+      );
+      // 의도된 활성 identity가 실제 DB row와 매칭되는지 확인
+      expect(activeIdentity.provider).toBe('GOOGLE');
     });
   });
 

--- a/src/features/user/types/user-output.type.ts
+++ b/src/features/user/types/user-output.type.ts
@@ -1,4 +1,8 @@
-import type { AccountType, NotificationType } from '@prisma/client';
+import type {
+  AccountType,
+  IdentityProvider,
+  NotificationType,
+} from '@prisma/client';
 
 export interface UserProfileOutput {
   nickname: string;
@@ -8,12 +12,18 @@ export interface UserProfileOutput {
   onboardingCompletedAt: Date | null;
 }
 
+export interface LinkedIdentityOutput {
+  provider: IdentityProvider;
+  lastLoginAt: Date | null;
+}
+
 export interface MePayload {
   accountId: string;
   email: string | null;
   name: string | null;
   accountType: AccountType;
   profile: UserProfileOutput;
+  linkedIdentities: LinkedIdentityOutput[];
 }
 
 export interface ViewerCounts {

--- a/src/features/user/user-profile.graphql
+++ b/src/features/user/user-profile.graphql
@@ -30,6 +30,22 @@ type MePayload {
   accountType: AccountType!
   """프로필 정보"""
   profile: UserProfile!
+  """연동된 소셜 로그인 식별자 목록(soft-deleted 제외, 최근 로그인 순)"""
+  linkedIdentities: [LinkedIdentity!]!
+}
+
+"""소셜 로그인 Provider 종류"""
+enum IdentityProvider {
+  GOOGLE
+  KAKAO
+}
+
+"""유저 계정에 연동된 소셜 로그인 식별자"""
+type LinkedIdentity {
+  """소셜 로그인 Provider"""
+  provider: IdentityProvider!
+  """해당 provider로 마지막 로그인한 시각(없을 수 있음)"""
+  lastLoginAt: DateTime
 }
 
 """유저 프로필"""


### PR DESCRIPTION
## Summary
develop 누적 2건을 main으로 릴리즈한다.

- **#92** feat(user): MePayload에 소셜 로그인 provider(linkedIdentities) 노출
  - 프론트에서 "이 유저가 어떤 SNS로 로그인했는지" 확인 가능
  - 1 account : N identity 가능 구조에 맞춰 배열로 노출 (`provider` + `lastLoginAt`)
  - soft-deleted identity 제외, 최근 로그인 순 정렬
- **#93** chore(ci): deploy 워크플로우를 수동 trigger로 전환
  - 개발 단계 인프라 비용 절감 차원에서 RDS 삭제(스냅샷 보관) + EC2 중지 상태
  - `on: push: main` → `on: workflow_dispatch`로 변경
  - 인프라 복구 시 trigger 한 줄 revert로 재개

## Notes
- 본 PR이 머지되어도 새 deploy.yml 규칙이 main에 반영된 상태이므로 자동 배포는 트리거되지 않는다 (의도된 동작)
- main에 이미 dependabot PR #89, #91이 머지되어 있어 develop 쪽으로 사후 동기화 필요 (다음 develop 작업 시작 전 main → develop sync 권장)

## Test plan
- [x] develop 브랜치에서 모든 CI(pr-check, codecov, CodeQL) green
- [ ] main 머지 후 deploy 워크플로우가 자동 트리거되지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 조회 시 연동된 소셜 로그인 제공자(Google, Kakao 등)와 각각의 마지막 로그인 시간 정보 표시

* **운영**
  * 자동 배포 워크플로우를 수동 배포로 변경

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CaQuick/caquick-be/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->