### PR TITLE
feat(common): A-2 DTO 검증 인프라 + SDL 동기화 가드 도입

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint
         run: yarn lint
 
+      - name: DTO ↔ SDL sync check (warning during migration)
+        run: yarn dto:check --warning
+
       - name: Test with coverage
         run: yarn test:cov
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prisma:seed": "prisma db seed",
     "graphql:codegen": "graphql-codegen --config codegen.yml",
     "graphql:docs": "spectaql -c spectaql.yml",
+    "dto:check": "ts-node -r tsconfig-paths/register scripts/check-graphql-dto-sync.ts",
     "prepare": "husky"
   },
   "prisma": {

--- a/scripts/check-graphql-dto-sync.ts
+++ b/scripts/check-graphql-dto-sync.ts
@@ -1,0 +1,245 @@
+/**
+ * SDL ↔ DTO 동기화 검사 스크립트.
+ *
+ * 왜: A-2 전략(모든 Input을 class + class-validator로 정의)에서 SDL과 DTO class가
+ * 어긋나면 런타임 검증이 실제 스키마와 불일치하게 된다. 빌드 시점에 차단한다.
+ *
+ * 검사 항목:
+ *  - SDL `input` 타입에 대응하는 DTO class가 존재하는지 (`--strict` 시)
+ *  - 양쪽 모두 존재할 때 필드명과 필수여부가 일치하는지
+ *
+ * 모드:
+ *  - default: DTO가 있는 항목만 검사. SDL only는 정보 출력
+ *  - --strict: 모든 SDL input 에 DTO 필수
+ *  - --warning: 종료코드 0 (CI 경고용)
+ *
+ * 사용: yarn dto:check [--strict] [--warning]
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join, resolve } from 'node:path';
+
+import type { InputObjectTypeDefinitionNode, TypeNode } from 'graphql';
+import { Kind, parse } from 'graphql';
+import { Project } from 'ts-morph';
+import type { ClassDeclaration } from 'ts-morph';
+
+interface FieldShape {
+  name: string;
+  required: boolean;
+}
+
+interface DtoEntry {
+  fields: FieldShape[];
+  file: string;
+}
+
+const REPO_ROOT = resolve(__dirname, '..');
+const SDL_ROOTS = [join(REPO_ROOT, 'src')];
+const DTO_FILE_SUFFIX = '.input.ts';
+const SDL_FILE_EXT = '.graphql';
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.yarn']);
+
+const args = new Set(process.argv.slice(2));
+const STRICT = args.has('--strict');
+const WARNING_ONLY = args.has('--warning');
+
+function walk(dir: string, predicate: (path: string) => boolean): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(full, predicate));
+    } else if (predicate(full)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function unwrapType(typeNode: TypeNode): { required: boolean } {
+  // GraphQL: 외곽 NON_NULL 이면 required. LIST 내부 NON_NULL 은 무시 (요소 nullability)
+  return { required: typeNode.kind === Kind.NON_NULL_TYPE };
+}
+
+function loadSdlInputs(): Map<string, FieldShape[]> {
+  const result = new Map<string, FieldShape[]>();
+  const files: string[] = [];
+  for (const root of SDL_ROOTS) {
+    if (!safeStat(root)) continue;
+    files.push(...walk(root, (p) => extname(p) === SDL_FILE_EXT));
+  }
+
+  for (const file of files) {
+    const sdl = readFileSync(file, 'utf8');
+    let doc;
+    try {
+      doc = parse(sdl);
+    } catch {
+      // SDL 파싱 실패는 다른 도구가 잡는다. 여기서는 무시.
+      continue;
+    }
+    for (const def of doc.definitions) {
+      if (def.kind !== Kind.INPUT_OBJECT_TYPE_DEFINITION) continue;
+      const input = def;
+      const fields: FieldShape[] = (input.fields ?? []).map((f) => ({
+        name: f.name.value,
+        required: unwrapType(f.type).required,
+      }));
+      result.set(input.name.value, fields);
+    }
+  }
+
+  return result;
+}
+
+function collectClassFields(cls: ClassDeclaration): FieldShape[] {
+  const out: FieldShape[] = [];
+  const seen = new Set<string>();
+
+  let current: ClassDeclaration | undefined = cls;
+  while (current) {
+    for (const prop of current.getProperties()) {
+      const name = prop.getName();
+      if (seen.has(name)) continue;
+      seen.add(name);
+      // 필수여부 추정: `?` 없으면 필수. `@IsOptional()` 은 별도 신호이지만 여기서는
+      // TS 문법(`?`) 기준으로만 본다. (class-validator 데코레이터는 런타임 검증의
+      // 영역이고, SDL 정합 기준은 TS 시그니처와 동등하다고 본다.)
+      const required = !prop.hasQuestionToken();
+      out.push({ name, required });
+    }
+    current = current.getBaseClass();
+  }
+
+  return out;
+}
+
+function loadDtoClasses(): Map<string, DtoEntry> {
+  const result = new Map<string, DtoEntry>();
+  const files: string[] = [];
+  for (const root of SDL_ROOTS) {
+    if (!safeStat(root)) continue;
+    files.push(...walk(root, (p) => p.endsWith(DTO_FILE_SUFFIX)));
+  }
+  if (files.length === 0) return result;
+
+  const project = new Project({
+    tsConfigFilePath: join(REPO_ROOT, 'tsconfig.json'),
+    skipAddingFilesFromTsConfig: true,
+  });
+  project.addSourceFilesAtPaths(files);
+
+  for (const sourceFile of project.getSourceFiles()) {
+    for (const cls of sourceFile.getClasses()) {
+      const name = cls.getName();
+      if (!name) continue;
+      if (!name.endsWith('Input')) continue;
+      result.set(name, {
+        fields: collectClassFields(cls),
+        file: sourceFile.getFilePath(),
+      });
+    }
+  }
+
+  return result;
+}
+
+interface Report {
+  errors: string[];
+  info: string[];
+}
+
+function compare(
+  sdl: Map<string, FieldShape[]>,
+  dto: Map<string, DtoEntry>,
+): Report {
+  const errors: string[] = [];
+  const info: string[] = [];
+
+  for (const [name, sdlFields] of sdl) {
+    const dtoEntry = dto.get(name);
+    if (!dtoEntry) {
+      const msg = `SDL input "${name}" 에 대응하는 DTO class 가 없습니다.`;
+      if (STRICT) errors.push(`[MISSING_DTO] ${msg}`);
+      else info.push(`[INFO] ${msg}`);
+      continue;
+    }
+
+    const sdlMap = new Map(sdlFields.map((f) => [f.name, f]));
+    const dtoMap = new Map(dtoEntry.fields.map((f) => [f.name, f]));
+
+    for (const f of sdlFields) {
+      const dtoField = dtoMap.get(f.name);
+      if (!dtoField) {
+        errors.push(
+          `[FIELD_MISSING] ${name}.${f.name}: SDL에는 있으나 DTO 에 없음. (${dtoEntry.file})`,
+        );
+        continue;
+      }
+      if (dtoField.required !== f.required) {
+        errors.push(
+          `[REQUIRED_MISMATCH] ${name}.${f.name}: SDL required=${String(f.required)}, DTO required=${String(dtoField.required)}. (${dtoEntry.file})`,
+        );
+      }
+    }
+
+    for (const f of dtoEntry.fields) {
+      if (!sdlMap.has(f.name)) {
+        errors.push(
+          `[EXTRA_DTO_FIELD] ${name}.${f.name}: DTO 에 있으나 SDL 에 없음. (${dtoEntry.file})`,
+        );
+      }
+    }
+  }
+
+  return { errors, info };
+}
+
+function safeStat(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function main(): void {
+  const sdl = loadSdlInputs();
+  const dto = loadDtoClasses();
+  const { errors, info } = compare(sdl, dto);
+
+  console.log(
+    `[dto:check] SDL inputs=${sdl.size}, DTO classes=${dto.size}, mode=${STRICT ? 'strict' : 'lenient'}${WARNING_ONLY ? ' (warning)' : ''}`,
+  );
+
+  if (info.length > 0 && !STRICT) {
+    console.log(`\nInfo (${info.length}):`);
+    for (const line of info) {
+      console.log(`  ${line}`);
+    }
+  }
+
+  if (errors.length === 0) {
+    console.log('\n✓ SDL ↔ DTO sync OK');
+    process.exit(0);
+  }
+
+  console.error(`\nMismatches (${errors.length}):`);
+  for (const line of errors) {
+    console.error(`  ${line}`);
+  }
+
+  if (WARNING_ONLY) {
+    console.warn(
+      '\n[warning mode] CI 를 실패시키지 않습니다. 마이그레이션 완료 후 warning 플래그 제거 + --strict 로 승격하세요.',
+    );
+    process.exit(0);
+  }
+
+  process.exit(1);
+}
+
+main();

--- a/src/common/dto/cursor.input.spec.ts
+++ b/src/common/dto/cursor.input.spec.ts
@@ -1,0 +1,44 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { CursorInput } from '@/common/dto/cursor.input';
+
+function build(plain: object): CursorInput {
+  return plainToInstance(CursorInput, plain);
+}
+
+describe('CursorInput', () => {
+  it('cursor 생략은 허용한다', async () => {
+    const dto = build({ limit: 20 });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('cursor 문자열은 허용한다', async () => {
+    const dto = build({ cursor: 'abc123', limit: 20 });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('cursor 가 문자열이 아니면 거절한다', async () => {
+    const dto = build({ cursor: 123, limit: 20 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('cursor');
+    expect(errors[0].constraints).toHaveProperty('isString');
+  });
+
+  it('limit 0은 거절한다', async () => {
+    const dto = build({ limit: 0 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('limit');
+  });
+
+  it('limit 101은 거절한다', async () => {
+    const dto = build({ limit: 101 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('limit');
+  });
+});

--- a/src/common/dto/cursor.input.ts
+++ b/src/common/dto/cursor.input.ts
@@ -1,0 +1,18 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+/**
+ * cursor 기반 페이지네이션 공통 입력.
+ *
+ * 왜: seller 도메인 다수 목록 조회에서 cursor + limit 패턴 반복. limit 상한은
+ * 100으로 통일하여 운영 보호.
+ */
+export class CursorInput {
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit!: number;
+}

--- a/src/common/dto/pagination.input.spec.ts
+++ b/src/common/dto/pagination.input.spec.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { PaginationInput } from '@/common/dto/pagination.input';
+
+function build(plain: object): PaginationInput {
+  return plainToInstance(PaginationInput, plain);
+}
+
+describe('PaginationInput', () => {
+  it('유효한 입력은 에러 없음', async () => {
+    const dto = build({ offset: 0, limit: 20 });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('offset 음수는 거절한다', async () => {
+    const dto = build({ offset: -1, limit: 20 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('offset');
+    expect(errors[0].constraints).toHaveProperty('min');
+  });
+
+  it('limit 0은 거절한다', async () => {
+    const dto = build({ offset: 0, limit: 0 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('limit');
+  });
+
+  it('limit 101은 거절한다', async () => {
+    const dto = build({ offset: 0, limit: 101 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('limit');
+    expect(errors[0].constraints).toHaveProperty('max');
+  });
+
+  it('offset · limit 동시 위반 시 두 에러 모두 보고한다', async () => {
+    const dto = build({ offset: -5, limit: 200 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(2);
+    const properties = errors.map((e) => e.property).sort();
+    expect(properties).toEqual(['limit', 'offset']);
+  });
+
+  it('정수가 아닌 값은 거절한다', async () => {
+    const dto = build({ offset: 1.5, limit: 20 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('isInt');
+  });
+});

--- a/src/common/dto/pagination.input.ts
+++ b/src/common/dto/pagination.input.ts
@@ -1,0 +1,18 @@
+import { IsInt, Max, Min } from 'class-validator';
+
+/**
+ * offset 기반 페이지네이션 공통 입력.
+ *
+ * 왜: user/seller 도메인의 offset/limit 수동 검증이 여러 곳에 산재되어 있어
+ * 단일 진실 소스로 통합. 한도 100은 운영 보호 목적의 상한.
+ */
+export class PaginationInput {
+  @IsInt()
+  @Min(0)
+  offset!: number;
+
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit!: number;
+}

--- a/src/common/validators/decimal-string.validator.spec.ts
+++ b/src/common/validators/decimal-string.validator.spec.ts
@@ -1,0 +1,49 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { IsDecimalString } from '@/common/validators/decimal-string.validator';
+
+class Sample {
+  @IsDecimalString()
+  price!: string;
+}
+
+function build(plain: object): Sample {
+  return plainToInstance(Sample, plain);
+}
+
+describe('IsDecimalString', () => {
+  it.each([
+    ['정수 문자열', '1000'],
+    ['소수 문자열', '1000.50'],
+    ['음수 정수', '-50'],
+    ['음수 소수', '-12.345'],
+    ['0', '0'],
+  ])('허용: %s ("%s")', async (_label, value) => {
+    const dto = build({ price: value });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it.each([
+    ['빈 문자열', ''],
+    ['쉼표 포함', '1,000'],
+    ['통화 기호', '$100'],
+    ['끝 점', '100.'],
+    ['앞 점', '.5'],
+    ['알파벳 혼재', '1e10'],
+    ['공백 포함', ' 100'],
+  ])('거절: %s ("%s")', async (_label, value) => {
+    const dto = build({ price: value });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('price');
+  });
+
+  it('숫자 타입은 거절한다', async () => {
+    const dto = build({ price: 1000 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/src/common/validators/decimal-string.validator.ts
+++ b/src/common/validators/decimal-string.validator.ts
@@ -1,0 +1,31 @@
+import type {
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { Validate, ValidatorConstraint } from 'class-validator';
+
+/**
+ * 통화/소수 문자열인지 검증한다 (예: "1000", "1000.50", "-12.3").
+ *
+ * 왜: seller 도메인의 가격/할인 입력이 Prisma `Decimal` 컬럼으로 들어가
+ * 부동소수 오차를 피하려고 문자열로 전달된다. seller-base.service.ts:76
+ * 부근의 수동 검증을 데코레이터로 통합.
+ */
+@ValidatorConstraint({ name: 'IsDecimalString', async: false })
+export class IsDecimalStringConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+    return /^-?\d+(\.\d+)?$/.test(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} must be a decimal string (e.g. "1000" or "1000.50").`;
+  }
+}
+
+export function IsDecimalString(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return Validate(IsDecimalStringConstraint, [], validationOptions);
+}

--- a/src/common/validators/time-string.validator.spec.ts
+++ b/src/common/validators/time-string.validator.spec.ts
@@ -1,0 +1,48 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { IsTimeString } from '@/common/validators/time-string.validator';
+
+class Sample {
+  @IsTimeString()
+  openAt!: string;
+}
+
+function build(plain: object): Sample {
+  return plainToInstance(Sample, plain);
+}
+
+describe('IsTimeString', () => {
+  it.each([
+    ['00:00', '00:00'],
+    ['09:30', '09:30'],
+    ['12:00', '12:00'],
+    ['23:59', '23:59'],
+  ])('허용: %s', async (_label, value) => {
+    const dto = build({ openAt: value });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it.each([
+    ['24:00 (시 경계 초과)', '24:00'],
+    ['09:60 (분 경계 초과)', '09:60'],
+    ['9:30 (시 1자리)', '9:30'],
+    ['09:5 (분 1자리)', '09:5'],
+    ['콜론 누락', '0930'],
+    ['공백 포함', '09: 30'],
+    ['빈 문자열', ''],
+  ])('거절: %s', async (_label, value) => {
+    const dto = build({ openAt: value });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('openAt');
+  });
+
+  it('숫자 타입은 거절한다', async () => {
+    const dto = build({ openAt: 930 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/src/common/validators/time-string.validator.ts
+++ b/src/common/validators/time-string.validator.ts
@@ -1,0 +1,30 @@
+import type {
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { Validate, ValidatorConstraint } from 'class-validator';
+
+/**
+ * "HH:MM" (24시간제) 형식 검증.
+ *
+ * 왜: seller 도메인 영업시간 입력이 HH:MM 문자열로 전달된다.
+ * seller-base.service.ts:64 부근의 수동 검증을 데코레이터로 통합.
+ */
+@ValidatorConstraint({ name: 'IsTimeString', async: false })
+export class IsTimeStringConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+    return /^([01]\d|2[0-3]):[0-5]\d$/.test(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} must be HH:MM (00:00 ~ 23:59).`;
+  }
+}
+
+export function IsTimeString(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return Validate(IsTimeStringConstraint, [], validationOptions);
+}


### PR DESCRIPTION
## Summary

- `PaginationInput` / `CursorInput` base DTO + `IsDecimalString` / `IsTimeString` 커스텀 validator 추가. 향후 도메인별 Input class 가 베이스를 상속하여 사용 (offset/limit/cursor/decimal/time 검증 통합)
- SDL ↔ DTO 동기화 검사 스크립트 (`yarn dto:check`) 추가. 마이그레이션 진행 중에는 warning 모드로 CI 정보만 출력. 전수 DTO 화 완료 후 `--strict` 로 격상 예정
- 본 PR 단독으로는 도메인 동작에 영향 없음. 후속 PR(Auth REST → User Input → Seller Input)에서 실제 검증 적용

## 배경

A-2 검증 전략(GraphQL Input · REST Body 모두 class + class-validator 로 통일) 도입의 1차 인프라 PR. SDL 단일 소스는 유지하되, codegen interface 는 Resolver 반환 타입용, 검증은 class DTO 경유.

현재 산재된 수동 검증 25곳 이상(`offset/limit`, `nickname` 정규식, `birthDate`, `rating`, `price`, 영업시간 등)을 데코레이터로 흡수해갈 예정.

## 후속 작업 (별도 PR)

- P0-3 단계 2: Auth REST Body 3종 DTO 화 (`SellerLoginInput` 등)
- P0-3 단계 3·4: User · Seller GraphQL Input 전수 DTO 화
- 마이그레이션 완료 후 `dto:check` warning → strict 승격

## Test plan

- [x] 로컬 `yarn lint` 통과
- [x] 로컬 `yarn test` 918/918 통과 (회귀 없음)
- [x] 로컬 `yarn dto:check` 실행: 46 SDL inputs · 2 DTO base · errors 0
- [ ] CI: lint / type-check / test:cov 통과
- [ ] CI: dto:check warning step info 46건 출력 후 정상 종료 (실패 안 함)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 페이지네이션 입력 타입 추가 (오프셋/리밋, 커서 기반)
  * 소수 문자열 및 시간 형식 검증 기능 추가

* **Tests**
  * 페이지네이션 입력 검증 테스트 추가
  * 커스텀 검증기 유닛 테스트 추가

* **Chores**
  * CI 워크플로우에 동기화 검사 단계 추가
  * 검증 스크립트 및 패키지 스크립트 구성

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CaQuick/caquick-be/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->