### PR TITLE
feat(auth): REST Body class-validator DTO 도입 (Auth 3종)

### DIFF
--- a/src/common/validators/strong-password.validator.spec.ts
+++ b/src/common/validators/strong-password.validator.spec.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { IsStrongPassword } from '@/common/validators/strong-password.validator';
+
+class Sample {
+  @IsStrongPassword()
+  password!: string;
+}
+
+function build(plain: object): Sample {
+  return plainToInstance(Sample, plain);
+}
+
+describe('IsStrongPassword', () => {
+  it.each([
+    ['8자 + 4종', 'Aa1!aaaa'],
+    ['긴 비밀번호', 'My!Sup3rL0ngPassword#WithSymbols'],
+    [
+      '64자 경계',
+      'A'.repeat(15) + 'a'.repeat(15) + '0'.repeat(15) + '!'.repeat(19),
+    ], // 64
+  ])('허용: %s', async (_label, value) => {
+    const dto = build({ password: value });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it.each([
+    ['7자', 'Aa1!aaa'],
+    ['65자', 'Aa1!' + 'b'.repeat(61)],
+    ['소문자 누락', 'AAAA1111!!!!'],
+    ['대문자 누락', 'aaaa1111!!!!'],
+    ['숫자 누락', 'AAaa!!@@##'],
+    ['특수문자 누락', 'AAaa1122334'],
+  ])('거절: %s', async (_label, value) => {
+    const dto = build({ password: value });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('password');
+  });
+
+  it('trim 후 길이 판정: 앞뒤 공백만으로 길이 채울 수 없음', async () => {
+    const dto = build({ password: '   Aa1!aa   ' }); // 12 chars raw, 7 trimmed
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('문자열이 아닌 값은 거절한다', async () => {
+    const dto = build({ password: 12345678 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/src/common/validators/strong-password.validator.ts
+++ b/src/common/validators/strong-password.validator.ts
@@ -1,0 +1,40 @@
+import type {
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+import { Validate, ValidatorConstraint } from 'class-validator';
+
+/**
+ * 강력한 비밀번호 정책 검증.
+ *
+ * 왜: 판매자 비밀번호 변경 등에서 길이 8~64 + 소문자/대문자/숫자/특수문자
+ * 4종 포함을 요구한다. 기존 auth.service.assertStrongPassword 의 로직을
+ * 그대로 옮겨와 DTO 레이어에서 일원화.
+ *
+ * 길이 판정은 trim 후 기준 (기존 동작 호환).
+ */
+@ValidatorConstraint({ name: 'IsStrongPassword', async: false })
+export class IsStrongPasswordConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown): boolean {
+    if (typeof value !== 'string') return false;
+    const pw = value.trim();
+    if (pw.length < 8 || pw.length > 64) return false;
+    return (
+      /[a-z]/.test(pw) &&
+      /[A-Z]/.test(pw) &&
+      /[0-9]/.test(pw) &&
+      /[^A-Za-z0-9]/.test(pw)
+    );
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    return `${args.property} must be 8~64 characters and include lower/upper case, number, and special character.`;
+  }
+}
+
+export function IsStrongPassword(
+  validationOptions?: ValidationOptions,
+): PropertyDecorator {
+  return Validate(IsStrongPasswordConstraint, [], validationOptions);
+}

--- a/src/features/auth/auth.seller.service.spec.ts
+++ b/src/features/auth/auth.seller.service.spec.ts
@@ -347,47 +347,10 @@ describe('AuthService (seller)', () => {
       ).rejects.toThrow('Only SELLER account is allowed.');
     });
 
-    it('현재 비밀번호가 빈 문자열이면 BadRequestException을 던져야 한다', async () => {
-      // Arrange
-      repo.findSellerCredentialByAccountId.mockResolvedValue(
-        sellerCredential as never,
-      );
-
-      // Act & Assert
-      await expect(
-        service.changeSellerPassword({
-          accountId: BigInt(10),
-          currentPassword: '',
-          newPassword: 'NewPassword!456',
-          req: mockReq,
-        }),
-      ).rejects.toThrow(BadRequestException);
-      await expect(
-        service.changeSellerPassword({
-          accountId: BigInt(10),
-          currentPassword: '',
-          newPassword: 'NewPassword!456',
-          req: mockReq,
-        }),
-      ).rejects.toThrow('Current and new password are required.');
-    });
-
-    it('새 비밀번호가 빈 문자열이면 BadRequestException을 던져야 한다', async () => {
-      // Arrange
-      repo.findSellerCredentialByAccountId.mockResolvedValue(
-        sellerCredential as never,
-      );
-
-      // Act & Assert
-      await expect(
-        service.changeSellerPassword({
-          accountId: BigInt(10),
-          currentPassword: 'OldPassword!123',
-          newPassword: '',
-          req: mockReq,
-        }),
-      ).rejects.toThrow(BadRequestException);
-    });
+    // NOTE: currentPassword/newPassword 의 형식 검증(빈 문자열, 길이, 복잡도)은
+    // DTO + ValidationPipe 책임으로 이전됨 (P0-3).
+    // - 길이/필수 검증: seller-change-password.input.spec.ts
+    // - 강 정책 검증: strong-password.validator.spec.ts
 
     it('현재 비밀번호가 틀리면 UnauthorizedException을 던져야 한다', async () => {
       // Arrange
@@ -413,64 +376,6 @@ describe('AuthService (seller)', () => {
           req: mockReq,
         }),
       ).rejects.toThrow('Current password is invalid.');
-    });
-
-    it('새 비밀번호가 정책(8~64자, 대소문자/숫자/특수문자)을 위반하면 BadRequestException을 던져야 한다', async () => {
-      // Arrange
-      repo.findSellerCredentialByAccountId.mockResolvedValue(
-        sellerCredential as never,
-      );
-      jest.spyOn(argon2, 'verify').mockResolvedValue(true);
-
-      // 너무 짧은 비밀번호
-      await expect(
-        service.changeSellerPassword({
-          accountId: BigInt(10),
-          currentPassword: 'OldPassword!123',
-          newPassword: 'Ab1!',
-          req: mockReq,
-        }),
-      ).rejects.toThrow(BadRequestException);
-
-      // 소문자 없음
-      await expect(
-        service.changeSellerPassword({
-          accountId: BigInt(10),
-          currentPassword: 'OldPassword!123',
-          newPassword: 'ABCDEFGH!123',
-          req: mockReq,
-        }),
-      ).rejects.toThrow(BadRequestException);
-
-      // 대문자 없음
-      await expect(
-        service.changeSellerPassword({
-          accountId: BigInt(10),
-          currentPassword: 'OldPassword!123',
-          newPassword: 'abcdefgh!123',
-          req: mockReq,
-        }),
-      ).rejects.toThrow(BadRequestException);
-
-      // 숫자 없음
-      await expect(
-        service.changeSellerPassword({
-          accountId: BigInt(10),
-          currentPassword: 'OldPassword!123',
-          newPassword: 'Abcdefgh!xyz',
-          req: mockReq,
-        }),
-      ).rejects.toThrow(BadRequestException);
-
-      // 특수문자 없음
-      await expect(
-        service.changeSellerPassword({
-          accountId: BigInt(10),
-          currentPassword: 'OldPassword!123',
-          newPassword: 'Abcdefgh1234',
-          req: mockReq,
-        }),
-      ).rejects.toThrow(BadRequestException);
     });
 
     it('새 비밀번호가 기존 비밀번호와 동일하면 BadRequestException을 던져야 한다', async () => {

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -339,11 +339,7 @@ export class AuthService {
       throw new ForbiddenException('Only SELLER account is allowed.');
     }
 
-    const currentPassword = args.currentPassword;
-    const newPassword = args.newPassword;
-    if (!currentPassword || !newPassword) {
-      throw new BadRequestException('Current and new password are required.');
-    }
+    const { currentPassword, newPassword } = args;
 
     const isCurrentPasswordValid = await argon2.verify(
       credential.password_hash,
@@ -352,8 +348,6 @@ export class AuthService {
     if (!isCurrentPasswordValid) {
       throw new UnauthorizedException('Current password is invalid.');
     }
-
-    this.assertStrongPassword(newPassword);
 
     const isSamePassword = await argon2.verify(
       credential.password_hash,
@@ -654,29 +648,6 @@ export class AuthService {
       accessToken,
       accountId: session.account_id,
     };
-  }
-
-  /**
-   * 판매자 비밀번호 정책을 검증한다.
-   *
-   * @param rawPassword 입력 비밀번호
-   */
-  private assertStrongPassword(rawPassword: string): void {
-    const password = rawPassword.trim();
-    if (password.length < 8 || password.length > 64) {
-      throw new BadRequestException('Password length must be 8~64.');
-    }
-
-    const hasLower = /[a-z]/.test(password);
-    const hasUpper = /[A-Z]/.test(password);
-    const hasNumber = /[0-9]/.test(password);
-    const hasSpecial = /[^A-Za-z0-9]/.test(password);
-
-    if (!hasLower || !hasUpper || !hasNumber || !hasSpecial) {
-      throw new BadRequestException(
-        'Password must include upper/lower case, number, and special character.',
-      );
-    }
   }
 
   /**

--- a/src/features/auth/controllers/auth.controller.ts
+++ b/src/features/auth/controllers/auth.controller.ts
@@ -25,6 +25,9 @@ import {
 import type { Request, Response } from 'express';
 
 import { AuthService } from '@/features/auth/auth.service';
+import { DevIssueTokenInput } from '@/features/auth/dto/inputs/dev-issue-token.input';
+import { SellerChangePasswordInput } from '@/features/auth/dto/inputs/seller-change-password.input';
+import { SellerLoginInput } from '@/features/auth/dto/inputs/seller-login.input';
 import { parseOidcProvider } from '@/features/auth/types/oidc-provider.type';
 import { CurrentUser, JwtAuthGuard, type JwtUser } from '@/global/auth';
 
@@ -192,7 +195,7 @@ export class AuthController {
   })
   @Post('seller/login')
   async sellerLogin(
-    @Body() body: SellerLoginBody,
+    @Body() body: SellerLoginInput,
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {
@@ -298,16 +301,13 @@ export class AuthController {
   })
   @Post('dev/issue-token')
   async devIssueToken(
-    @Body() body: DevIssueTokenBody,
+    @Body() body: DevIssueTokenInput,
     @Res() res: Response,
   ): Promise<void> {
     if (process.env.NODE_ENV === 'production') {
       throw new ForbiddenException(
         '/auth/dev/issue-token은 개발 환경에서만 사용 가능합니다.',
       );
-    }
-    if (!body || typeof body.accountId !== 'string') {
-      throw new BadRequestException('accountId(string)가 필요합니다.');
     }
 
     const accountId = parseAccountIdString(body.accountId);
@@ -337,7 +337,7 @@ export class AuthController {
   @Post('seller/change-password')
   async sellerChangePassword(
     @CurrentUser() user: JwtUser,
-    @Body() body: SellerChangePasswordBody,
+    @Body() body: SellerChangePasswordInput,
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {
@@ -350,20 +350,6 @@ export class AuthController {
     });
     res.status(200).json({ ok: true });
   }
-}
-
-interface SellerLoginBody {
-  username: string;
-  password: string;
-}
-
-interface SellerChangePasswordBody {
-  currentPassword: string;
-  newPassword: string;
-}
-
-interface DevIssueTokenBody {
-  accountId: string;
 }
 
 function parseAccountId(user: JwtUser): bigint {

--- a/src/features/auth/dto/inputs/dev-issue-token.input.spec.ts
+++ b/src/features/auth/dto/inputs/dev-issue-token.input.spec.ts
@@ -1,0 +1,49 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { DevIssueTokenInput } from '@/features/auth/dto/inputs/dev-issue-token.input';
+
+function build(plain: object): DevIssueTokenInput {
+  return plainToInstance(DevIssueTokenInput, plain);
+}
+
+describe('DevIssueTokenInput', () => {
+  it.each([
+    ['1', '1'],
+    ['123', '123'],
+    ['0', '0'],
+    ['999999999999999999', '999999999999999999'], // BigInt 범위
+  ])('허용: %s', async (_label, value) => {
+    const dto = build({ accountId: value });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it.each([
+    ['빈 문자열', ''],
+    ['음수', '-1'],
+    ['소수', '1.5'],
+    ['알파벳 혼재', 'abc'],
+    ['공백 포함', ' 1'],
+    ['끝 공백', '1 '],
+  ])('거절: %s ("%s")', async (_label, value) => {
+    const dto = build({ accountId: value });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('accountId');
+  });
+
+  it('accountId 누락 거절', async () => {
+    const dto = build({});
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('accountId');
+  });
+
+  it('숫자 타입은 거절한다', async () => {
+    const dto = build({ accountId: 123 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/src/features/auth/dto/inputs/dev-issue-token.input.ts
+++ b/src/features/auth/dto/inputs/dev-issue-token.input.ts
@@ -1,0 +1,12 @@
+import { IsString, Matches } from 'class-validator';
+
+/**
+ * POST /auth/dev/issue-token Body (개발 환경 한정).
+ *
+ * accountId 는 BigInt 호환 숫자 문자열. 부호/소수 불허.
+ */
+export class DevIssueTokenInput {
+  @IsString()
+  @Matches(/^\d+$/, { message: 'accountId must be a numeric string.' })
+  accountId!: string;
+}

--- a/src/features/auth/dto/inputs/seller-change-password.input.spec.ts
+++ b/src/features/auth/dto/inputs/seller-change-password.input.spec.ts
@@ -1,0 +1,53 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { SellerChangePasswordInput } from '@/features/auth/dto/inputs/seller-change-password.input';
+
+function build(plain: object): SellerChangePasswordInput {
+  return plainToInstance(SellerChangePasswordInput, plain);
+}
+
+describe('SellerChangePasswordInput', () => {
+  it('유효 입력 통과', async () => {
+    const dto = build({
+      currentPassword: 'old!Pass1',
+      newPassword: 'New!Pass1',
+    });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('currentPassword 길이 8 미만 거절', async () => {
+    const dto = build({ currentPassword: 'short', newPassword: 'New!Pass1' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('currentPassword');
+  });
+
+  it('newPassword 강 정책 미충족 (특수문자 누락) 거절', async () => {
+    const dto = build({
+      currentPassword: 'old!Pass1',
+      newPassword: 'NoSpecial1',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('newPassword');
+  });
+
+  it('newPassword 길이 8 미만 거절', async () => {
+    const dto = build({
+      currentPassword: 'old!Pass1',
+      newPassword: 'Aa1!',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('newPassword');
+  });
+
+  it('두 필드 모두 누락 거절', async () => {
+    const dto = build({});
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(2);
+  });
+});

--- a/src/features/auth/dto/inputs/seller-change-password.input.ts
+++ b/src/features/auth/dto/inputs/seller-change-password.input.ts
@@ -1,0 +1,19 @@
+import { IsString, Length } from 'class-validator';
+
+import { IsStrongPassword } from '@/common/validators/strong-password.validator';
+
+/**
+ * POST /auth/seller/change-password Body.
+ *
+ * currentPassword: 기존 비밀번호. argon2.verify 가 실제 인증을 담당하므로
+ * 형식 검증만 (8~64 길이). 강 정책은 적용하지 않는다.
+ * newPassword: 강 비밀번호 정책 적용 (길이 + 복잡도 4종).
+ */
+export class SellerChangePasswordInput {
+  @IsString()
+  @Length(8, 64)
+  currentPassword!: string;
+
+  @IsStrongPassword()
+  newPassword!: string;
+}

--- a/src/features/auth/dto/inputs/seller-login.input.spec.ts
+++ b/src/features/auth/dto/inputs/seller-login.input.spec.ts
@@ -1,0 +1,59 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { SellerLoginInput } from '@/features/auth/dto/inputs/seller-login.input';
+
+function build(plain: object): SellerLoginInput {
+  return plainToInstance(SellerLoginInput, plain);
+}
+
+describe('SellerLoginInput', () => {
+  it('유효 입력 통과', async () => {
+    const dto = build({ username: 'seller01', password: 'Aa1!aaaa' });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('username 길이 4 미만 거절', async () => {
+    const dto = build({ username: 'abc', password: 'Aa1!aaaa' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('username');
+  });
+
+  it('username 길이 50 초과 거절', async () => {
+    const dto = build({ username: 'a'.repeat(51), password: 'Aa1!aaaa' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('username');
+  });
+
+  it('password 길이 8 미만 거절', async () => {
+    const dto = build({ username: 'seller01', password: 'short' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('password');
+  });
+
+  it('password 길이 64 초과 거절', async () => {
+    const dto = build({ username: 'seller01', password: 'a'.repeat(65) });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('password');
+  });
+
+  it('username · password 동시 위반 시 두 에러 보고', async () => {
+    const dto = build({ username: 'a', password: 'b' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(2);
+    const props = errors.map((e) => e.property).sort();
+    expect(props).toEqual(['password', 'username']);
+  });
+
+  it('필드 누락 거절', async () => {
+    const dto = build({});
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(2);
+  });
+});

--- a/src/features/auth/dto/inputs/seller-login.input.ts
+++ b/src/features/auth/dto/inputs/seller-login.input.ts
@@ -1,0 +1,18 @@
+import { IsString, Length } from 'class-validator';
+
+/**
+ * POST /auth/seller/login Body.
+ *
+ * username 길이 4~50, password 길이 8~64 까지 기본 형식만 검증한다.
+ * 실제 인증은 argon2.verify 가 담당. 로그인 시점에는 강 정책(복잡도)을
+ * 적용하지 않는다 (사용자 등록 시점의 정책만 신뢰).
+ */
+export class SellerLoginInput {
+  @IsString()
+  @Length(4, 50)
+  username!: string;
+
+  @IsString()
+  @Length(8, 64)
+  password!: string;
+}


### PR DESCRIPTION
## Summary

- Auth REST 3개 엔드포인트(`/auth/seller/login`, `/auth/seller/change-password`, `/auth/dev/issue-token`)의 Body 를 class DTO + class-validator 로 전환
- `auth.controller.ts` 인라인 interface 3종 제거. `devIssueToken` 의 inline 형식 체크 제거 (DTO 가 처리)
- `auth.service.changeSellerPassword` 의 수동 검증(빈 문자열 / 강 비밀번호 정책) 제거 + `assertStrongPassword` private 메서드 삭제. 책임이 DTO 레이어로 완전 이전
- 신규 `IsStrongPassword` 커스텀 validator 추가 (`src/common/validators/`)

## 배경 / Plan 연결

- 출처: P0-3 단계 2 (Auth REST DTO) — 검증 전략 A-2 의 첫 도메인 적용
- 전제: 직전 PR (DTO 검증 인프라 + 동기화 가드)

## FE 영향 (사전 협의 필요)

빈 입력 / 잘못된 형식에 대해 다음 엔드포인트의 응답 상태코드가 변경됩니다 (정상 입력은 동일):

| 엔드포인트 | Before | After |
|---|---|---|
| `POST /auth/seller/login` | 401 | 400 (ValidationPipe) |
| `POST /auth/seller/change-password` | 400 (다른 메시지) | 400 (DTO 표준 메시지) |
| `POST /auth/dev/issue-token` | 400 (다른 메시지) | 400 (DTO 표준 메시지) |

상세 협의 사항(룰별 Before/After 응답 예시, FE 액션 체크리스트)은 별도 공유 예정.

## 후속 작업 (별도 PR)

- P0-3 단계 3: User GraphQL Input 전수 DTO 화
- P0-3 단계 4: Seller GraphQL Input 전수 DTO 화

## Test plan

- [x] 로컬 `yarn lint` 통과
- [x] 로컬 `yarn test` 950/950 통과 (회귀 없음)
- [x] 로컬 `yarn dto:check` 정상 (errors 0)
- [x] `npx tsc --noEmit` 통과
- [x] CI: lint / type-check / test:cov 통과
- [x] CI: dto:check warning step 정상 종료
- [x] CI: codecov/patch (89.65% / target 80%) 통과