### PR TITLE
refactor(audit-log): AuditLogRepository를 신규 audit-log 모듈로 분리 (P0-1 단계 2)

### DIFF
--- a/src/features/audit-log/audit-log.module.ts
+++ b/src/features/audit-log/audit-log.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log/repositories/audit-log.repository.interface';
+
+/**
+ * AuditLog 도메인 모듈
+ *
+ * - 모든 feature 가 감사 로그를 쓰는 단일 진입점
+ * - interface + DI Token 패턴으로 제공
+ */
+@Module({
+  providers: [
+    {
+      provide: AUDIT_LOG_REPOSITORY,
+      useClass: AuditLogRepository,
+    },
+  ],
+  exports: [AUDIT_LOG_REPOSITORY],
+})
+export class AuditLogModule {}

--- a/src/features/audit-log/index.ts
+++ b/src/features/audit-log/index.ts
@@ -1,0 +1,6 @@
+export { AuditLogModule } from '@/features/audit-log/audit-log.module';
+export { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
+export {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log/repositories/audit-log.repository.interface';

--- a/src/features/audit-log/repositories/audit-log.repository.interface.ts
+++ b/src/features/audit-log/repositories/audit-log.repository.interface.ts
@@ -1,0 +1,36 @@
+import type {
+  AuditActionType,
+  AuditLog,
+  AuditTargetType,
+  Prisma,
+} from '@prisma/client';
+
+/**
+ * AuditLog Repository 토큰 (Nest DI 주입용).
+ */
+export const AUDIT_LOG_REPOSITORY = Symbol('AUDIT_LOG_REPOSITORY');
+
+/**
+ * AuditLog Repository 인터페이스.
+ *
+ * 모든 도메인(auth/seller/...)의 감사 로그 작성 진입점.
+ * 단일 책임: AuditLog 테이블 write.
+ */
+export interface IAuditLogRepository {
+  /**
+   * 감사 로그를 생성한다.
+   *
+   * @param args 감사 로그 작성 정보
+   */
+  createAuditLog(args: {
+    actorAccountId: bigint;
+    storeId?: bigint | null;
+    targetType: AuditTargetType;
+    targetId: bigint;
+    action: AuditActionType;
+    beforeJson?: Prisma.InputJsonValue | null;
+    afterJson?: Prisma.InputJsonValue | null;
+    ipAddress?: string;
+    userAgent?: string;
+  }): Promise<AuditLog>;
+}

--- a/src/features/audit-log/repositories/audit-log.repository.spec.ts
+++ b/src/features/audit-log/repositories/audit-log.repository.spec.ts
@@ -1,0 +1,92 @@
+import type { PrismaClient } from '@prisma/client';
+import { AuditActionType, AuditTargetType } from '@prisma/client';
+
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createAccount } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('AuditLogRepository (real DB)', () => {
+  let repo: AuditLogRepository;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [AuditLogRepository],
+    });
+    repo = module.get(AuditLogRepository);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  describe('createAuditLog', () => {
+    it('감사 로그를 생성한다', async () => {
+      const account = await createAccount(prisma);
+
+      await repo.createAuditLog({
+        actorAccountId: account.id,
+        targetType: AuditTargetType.CHANGE_PASSWORD,
+        targetId: account.id,
+        action: AuditActionType.UPDATE,
+        beforeJson: null,
+        afterJson: { changed: true },
+        ipAddress: '1.2.3.4',
+        userAgent: 'test',
+      });
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].action).toBe(AuditActionType.UPDATE);
+    });
+
+    it('storeId/ipAddress/userAgent/beforeJson 모두 생략해도 기본 null 처리로 생성된다', async () => {
+      const account = await createAccount(prisma);
+
+      await repo.createAuditLog({
+        actorAccountId: account.id,
+        targetType: AuditTargetType.STORE,
+        targetId: account.id,
+        action: AuditActionType.UPDATE,
+      });
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].store_id).toBeNull();
+      expect(logs[0].ip_address).toBeNull();
+      expect(logs[0].user_agent).toBeNull();
+      expect(logs[0].before_json).toBeNull();
+      expect(logs[0].after_json).toBeNull();
+    });
+
+    it('storeId를 명시하면 해당 값으로 저장된다', async () => {
+      const account = await createAccount(prisma);
+      const storeId = BigInt(42);
+
+      await repo.createAuditLog({
+        actorAccountId: account.id,
+        storeId,
+        targetType: AuditTargetType.STORE,
+        targetId: account.id,
+        action: AuditActionType.UPDATE,
+      });
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs[0].store_id).toBe(storeId);
+    });
+  });
+});

--- a/src/features/audit-log/repositories/audit-log.repository.ts
+++ b/src/features/audit-log/repositories/audit-log.repository.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import {
+  type AuditActionType,
+  type AuditLog,
+  type AuditTargetType,
+  Prisma,
+} from '@prisma/client';
+
+import type { IAuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository.interface';
+import { PrismaService } from '@/prisma';
+
+/**
+ * AuditLog Repository 구체 구현.
+ *
+ * `audit_log` 테이블 write 전용. read 가 필요하면 별도 메서드를 추가한다.
+ */
+@Injectable()
+export class AuditLogRepository implements IAuditLogRepository {
+  /**
+   * @param prisma PrismaService
+   */
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createAuditLog(args: {
+    actorAccountId: bigint;
+    storeId?: bigint | null;
+    targetType: AuditTargetType;
+    targetId: bigint;
+    action: AuditActionType;
+    beforeJson?: Prisma.InputJsonValue | null;
+    afterJson?: Prisma.InputJsonValue | null;
+    ipAddress?: string;
+    userAgent?: string;
+  }): Promise<AuditLog> {
+    return this.prisma.auditLog.create({
+      data: {
+        actor_account_id: args.actorAccountId,
+        store_id: args.storeId ?? null,
+        target_type: args.targetType,
+        target_id: args.targetId,
+        action: args.action,
+        before_json:
+          args.beforeJson === null ? Prisma.JsonNull : args.beforeJson,
+        after_json: args.afterJson === null ? Prisma.JsonNull : args.afterJson,
+        ip_address: args.ipAddress ?? null,
+        user_agent: args.userAgent ?? null,
+      },
+    });
+  }
+}

--- a/src/features/auth/auth.module.ts
+++ b/src/features/auth/auth.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 
+import { AuditLogModule } from '@/features/audit-log';
 import { AuthService } from '@/features/auth/auth.service';
 import { AuthController } from '@/features/auth/controllers/auth.controller';
 import { AuthRepository } from '@/features/auth/repositories/auth.repository';
@@ -16,7 +17,7 @@ import { AuthGlobalModule } from '@/global/auth/auth-global.module';
  * - JWT 가드/모듈은 global/auth/auth-global.module.ts에서 제공
  */
 @Module({
-  imports: [AuthGlobalModule],
+  imports: [AuthGlobalModule, AuditLogModule],
   controllers: [AuthController],
   providers: [
     AuthService,

--- a/src/features/auth/auth.seller.service.spec.ts
+++ b/src/features/auth/auth.seller.service.spec.ts
@@ -11,6 +11,10 @@ import argon2 from 'argon2';
 import type { Request, Response } from 'express';
 
 import { ClockService } from '@/common/providers/clock.service';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { AuthService } from '@/features/auth/auth.service';
 import { AuthRepository } from '@/features/auth/repositories/auth.repository';
 import {
@@ -23,6 +27,7 @@ describe('AuthService (seller)', () => {
   let service: AuthService;
   let repo: jest.Mocked<AuthRepository>;
   let refreshSessions: jest.Mocked<IRefreshSessionRepository>;
+  let auditLogs: jest.Mocked<IAuditLogRepository>;
   let mockConfig: jest.Mocked<ConfigService>;
 
   const mockReq = {
@@ -42,7 +47,6 @@ describe('AuthService (seller)', () => {
       findSellerCredentialByAccountId: jest.fn(),
       updateSellerLastLogin: jest.fn(),
       updateSellerPasswordHash: jest.fn(),
-      createAuditLog: jest.fn(),
     } as unknown as jest.Mocked<AuthRepository>;
 
     refreshSessions = {
@@ -51,6 +55,10 @@ describe('AuthService (seller)', () => {
       rotateRefreshSession: jest.fn(),
       revokeRefreshSession: jest.fn(),
       revokeAllRefreshSessions: jest.fn(),
+    };
+
+    auditLogs = {
+      createAuditLog: jest.fn(),
     };
 
     mockConfig = {
@@ -70,6 +78,10 @@ describe('AuthService (seller)', () => {
         {
           provide: REFRESH_SESSION_REPOSITORY,
           useValue: refreshSessions,
+        },
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useValue: auditLogs,
         },
         { provide: ClockService, useValue: { now: () => new Date() } },
       ],
@@ -289,7 +301,7 @@ describe('AuthService (seller)', () => {
         BigInt(10),
         expect.any(Date),
       );
-      expect(repo.createAuditLog).toHaveBeenCalledWith(
+      expect(auditLogs.createAuditLog).toHaveBeenCalledWith(
         expect.objectContaining({
           actorAccountId: BigInt(10),
           storeId: BigInt(5),

--- a/src/features/auth/auth.service.spec.ts
+++ b/src/features/auth/auth.service.spec.ts
@@ -9,6 +9,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import type { Request, Response } from 'express';
 
 import { ClockService } from '@/common/providers/clock.service';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { AuthService } from '@/features/auth/auth.service';
 import { AuthRepository } from '@/features/auth/repositories/auth.repository';
 import {
@@ -25,6 +29,7 @@ describe('AuthService', () => {
   let mockOidc: jest.Mocked<OidcClientService>;
   let mockRepo: jest.Mocked<AuthRepository>;
   let mockRefreshSessions: jest.Mocked<IRefreshSessionRepository>;
+  let mockAuditLogs: jest.Mocked<IAuditLogRepository>;
 
   beforeEach(async () => {
     mockConfig = {
@@ -55,6 +60,10 @@ describe('AuthService', () => {
       createRefreshSession: jest.fn(),
     };
 
+    mockAuditLogs = {
+      createAuditLog: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
@@ -65,6 +74,10 @@ describe('AuthService', () => {
         {
           provide: REFRESH_SESSION_REPOSITORY,
           useValue: mockRefreshSessions,
+        },
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useValue: mockAuditLogs,
         },
         { provide: ClockService, useValue: { now: () => new Date() } },
       ],

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -24,6 +24,10 @@ import {
   getEnvAsNumber,
 } from '@/common/helpers/config.helper';
 import { ClockService } from '@/common/providers/clock.service';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { ALLOWED_RETURN_TO_DOMAINS } from '@/features/auth/constants/auth.constants';
 import {
   AuthCookie,
@@ -53,6 +57,7 @@ export class AuthService {
    * @param oidc OidcClientService
    * @param repo AuthRepository
    * @param refreshSessions RefreshSessionRepository
+   * @param auditLogs AuditLogRepository
    * @param clock ClockService
    */
   constructor(
@@ -62,6 +67,8 @@ export class AuthService {
     private readonly repo: AuthRepository,
     @Inject(REFRESH_SESSION_REPOSITORY)
     private readonly refreshSessions: IRefreshSessionRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    private readonly auditLogs: IAuditLogRepository,
     private readonly clock: ClockService,
   ) {}
 
@@ -382,7 +389,7 @@ export class AuthService {
     });
     await this.refreshSessions.revokeAllRefreshSessions(args.accountId, now);
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: args.accountId,
       storeId: credential.seller_account.store?.id ?? null,
       targetType: AuditTargetType.CHANGE_PASSWORD,

--- a/src/features/auth/repositories/auth.repository.spec.ts
+++ b/src/features/auth/repositories/auth.repository.spec.ts
@@ -1,9 +1,5 @@
 import type { PrismaClient } from '@prisma/client';
-import {
-  AuditActionType,
-  AuditTargetType,
-  IdentityProvider,
-} from '@prisma/client';
+import { IdentityProvider } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
 import { AuthRepository } from '@/features/auth/repositories/auth.repository';
@@ -302,52 +298,6 @@ describe('AuthRepository (real DB)', () => {
         where: { seller_account_id: sellerAccount.id },
       });
       expect(updated!.password_hash).toBe('new_hash_value');
-    });
-  });
-
-  // ─── Audit Log ───
-
-  describe('createAuditLog', () => {
-    it('감사 로그를 생성한다', async () => {
-      const account = await createAccount(prisma);
-
-      await repo.createAuditLog({
-        actorAccountId: account.id,
-        targetType: AuditTargetType.CHANGE_PASSWORD,
-        targetId: account.id,
-        action: AuditActionType.UPDATE,
-        beforeJson: null,
-        afterJson: { changed: true },
-        ipAddress: '1.2.3.4',
-        userAgent: 'test',
-      });
-
-      const logs = await prisma.auditLog.findMany({
-        where: { actor_account_id: account.id },
-      });
-      expect(logs).toHaveLength(1);
-      expect(logs[0].action).toBe(AuditActionType.UPDATE);
-    });
-
-    it('storeId/ipAddress/userAgent/beforeJson 모두 생략해도 기본 null 처리로 생성된다', async () => {
-      const account = await createAccount(prisma);
-
-      await repo.createAuditLog({
-        actorAccountId: account.id,
-        targetType: AuditTargetType.STORE,
-        targetId: account.id,
-        action: AuditActionType.UPDATE,
-      });
-
-      const logs = await prisma.auditLog.findMany({
-        where: { actor_account_id: account.id },
-      });
-      expect(logs).toHaveLength(1);
-      expect(logs[0].store_id).toBeNull();
-      expect(logs[0].ip_address).toBeNull();
-      expect(logs[0].user_agent).toBeNull();
-      expect(logs[0].before_json).toBeNull();
-      expect(logs[0].after_json).toBeNull();
     });
   });
 });

--- a/src/features/auth/repositories/auth.repository.ts
+++ b/src/features/auth/repositories/auth.repository.ts
@@ -1,11 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {
-  AccountType,
-  AuditActionType,
-  AuditTargetType,
-  IdentityProvider,
-  Prisma,
-} from '@prisma/client';
+import { AccountType, IdentityProvider } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
 import { PrismaService } from '@/prisma';
@@ -380,36 +374,6 @@ export class AuthRepository {
         password_hash: args.passwordHash,
         password_updated_at: args.now,
         updated_at: args.now,
-      },
-    });
-  }
-
-  /**
-   * 감사 로그를 생성한다.
-   */
-  async createAuditLog(args: {
-    actorAccountId: bigint;
-    storeId?: bigint | null;
-    targetType: AuditTargetType;
-    targetId: bigint;
-    action: AuditActionType;
-    beforeJson?: Prisma.InputJsonValue | null;
-    afterJson?: Prisma.InputJsonValue | null;
-    ipAddress?: string;
-    userAgent?: string;
-  }): Promise<void> {
-    await this.prisma.auditLog.create({
-      data: {
-        actor_account_id: args.actorAccountId,
-        store_id: args.storeId ?? null,
-        target_type: args.targetType,
-        target_id: args.targetId,
-        action: args.action,
-        before_json:
-          args.beforeJson === null ? Prisma.JsonNull : args.beforeJson,
-        after_json: args.afterJson === null ? Prisma.JsonNull : args.afterJson,
-        ip_address: args.ipAddress ?? null,
-        user_agent: args.userAgent ?? null,
       },
     });
   }

--- a/src/features/seller/repositories/seller.repository.ts
+++ b/src/features/seller/repositories/seller.repository.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
   AccountType,
-  AuditActionType,
   AuditTargetType,
   BannerLinkType,
   BannerPlacement,
@@ -403,33 +402,6 @@ export class SellerRepository {
       },
       orderBy: { id: 'desc' },
       take: args.limit + 1,
-    });
-  }
-
-  async createAuditLog(args: {
-    actorAccountId: bigint;
-    storeId?: bigint;
-    targetType: AuditTargetType;
-    targetId: bigint;
-    action: AuditActionType;
-    beforeJson?: Prisma.InputJsonValue | null;
-    afterJson?: Prisma.InputJsonValue | null;
-    ipAddress?: string;
-    userAgent?: string;
-  }) {
-    return this.prisma.auditLog.create({
-      data: {
-        actor_account_id: args.actorAccountId,
-        store_id: args.storeId,
-        target_type: args.targetType,
-        target_id: args.targetId,
-        action: args.action,
-        before_json:
-          args.beforeJson === null ? Prisma.JsonNull : args.beforeJson,
-        after_json: args.afterJson === null ? Prisma.JsonNull : args.afterJson,
-        ip_address: args.ipAddress,
-        user_agent: args.userAgent,
-      },
     });
   }
 }

--- a/src/features/seller/resolvers/seller-content.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-content.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerContentMutationResolver } from '@/features/seller/resolvers/seller-content-mutation.resolver';
@@ -24,6 +25,10 @@ describe('Seller Content Resolvers (real DB)', () => {
         SellerContentService,
         SellerRepository,
         ProductRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     queryResolver = module.get(SellerContentQueryResolver);

--- a/src/features/seller/resolvers/seller-conversation.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-conversation.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { ConversationRepository } from '@/features/conversation';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerConversationMutationResolver } from '@/features/seller/resolvers/seller-conversation-mutation.resolver';
@@ -24,6 +25,10 @@ describe('Seller Conversation Resolvers (real DB)', () => {
         SellerConversationService,
         SellerRepository,
         ConversationRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     queryResolver = module.get(SellerConversationQueryResolver);

--- a/src/features/seller/resolvers/seller-order.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-order.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import {
   OrderDomainService,
   OrderRepository,
@@ -35,6 +36,10 @@ describe('Seller Order Resolvers (real DB)', () => {
         OrderRepository,
         OrderDomainService,
         OrderStatusTransitionPolicy,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     queryResolver = module.get(SellerOrderQueryResolver);

--- a/src/features/seller/resolvers/seller-product.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-product.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import type { SellerAddProductImageInput } from '@/features/seller/dto/inputs/seller-add-product-image.input';
 import type { SellerCreateOptionGroupInput } from '@/features/seller/dto/inputs/seller-create-option-group.input';
@@ -45,6 +46,10 @@ describe('Seller Product Resolvers (real DB)', () => {
         SellerCustomTemplateService,
         SellerRepository,
         ProductRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     queryResolver = module.get(SellerProductQueryResolver);

--- a/src/features/seller/resolvers/seller-store.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-store.resolver.spec.ts
@@ -1,6 +1,7 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerStoreMutationResolver } from '@/features/seller/resolvers/seller-store-mutation.resolver';
 import { SellerStoreQueryResolver } from '@/features/seller/resolvers/seller-store-query.resolver';
@@ -22,6 +23,10 @@ describe('Seller Store Resolvers (real DB)', () => {
         SellerStoreMutationResolver,
         SellerStoreService,
         SellerRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     queryResolver = module.get(SellerStoreQueryResolver);

--- a/src/features/seller/seller.module.ts
+++ b/src/features/seller/seller.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 
+import { AuditLogModule } from '@/features/audit-log';
 import { ConversationModule } from '@/features/conversation';
 import { OrderModule } from '@/features/order';
 import { ProductModule } from '@/features/product';
@@ -23,7 +24,7 @@ import { SellerProductCrudService } from '@/features/seller/services/seller-prod
 import { SellerStoreService } from '@/features/seller/services/seller-store.service';
 
 @Module({
-  imports: [OrderModule, ProductModule, ConversationModule],
+  imports: [OrderModule, ProductModule, ConversationModule, AuditLogModule],
   providers: [
     SellerStoreService,
     SellerProductCrudService,

--- a/src/features/seller/services/seller-base.service.spec.ts
+++ b/src/features/seller/services/seller-base.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import type { IAuditLogRepository } from '@/features/audit-log';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerBaseService } from '@/features/seller/services/seller-base.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
@@ -14,8 +15,8 @@ import { createAccount, setupSellerWithStore } from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
 class TestableSellerBaseService extends SellerBaseService {
-  constructor(repo: SellerRepository) {
-    super(repo);
+  constructor(repo: SellerRepository, auditLogs: IAuditLogRepository) {
+    super(repo, auditLogs);
   }
 
   public testRequireSellerContext(accountId: bigint) {
@@ -57,7 +58,10 @@ describe('SellerBaseService (real DB)', () => {
       providers: [SellerRepository],
     });
     const repo = module.get(SellerRepository);
-    service = new TestableSellerBaseService(repo);
+    const auditLogs: IAuditLogRepository = {
+      createAuditLog: jest.fn(),
+    };
+    service = new TestableSellerBaseService(repo, auditLogs);
     prisma = p;
   });
 

--- a/src/features/seller/services/seller-base.service.ts
+++ b/src/features/seller/services/seller-base.service.ts
@@ -7,6 +7,7 @@ import {
 import { Prisma } from '@prisma/client';
 
 import { parseId } from '@/common/utils/id-parser';
+import type { IAuditLogRepository } from '@/features/audit-log';
 import {
   ACCOUNT_NOT_FOUND,
   DUPLICATE_IDS,
@@ -28,7 +29,10 @@ export interface SellerContext {
 }
 
 export abstract class SellerBaseService {
-  protected constructor(protected readonly repo: SellerRepository) {}
+  protected constructor(
+    protected readonly repo: SellerRepository,
+    protected readonly auditLogs: IAuditLogRepository,
+  ) {}
 
   protected async requireSellerContext(
     accountId: bigint,

--- a/src/features/seller/services/seller-content.service.spec.ts
+++ b/src/features/seller/services/seller-content.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { Prisma, type PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerContentService } from '@/features/seller/services/seller-content.service';
@@ -23,7 +24,15 @@ describe('SellerContentService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [SellerContentService, SellerRepository, ProductRepository],
+      providers: [
+        SellerContentService,
+        SellerRepository,
+        ProductRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
+      ],
     });
     service = module.get(SellerContentService);
     prisma = p;

--- a/src/features/seller/services/seller-content.service.ts
+++ b/src/features/seller/services/seller-content.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ForbiddenException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -18,6 +19,10 @@ import {
   cleanNullableText,
   cleanRequiredText,
 } from '@/common/utils/text-cleaner';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import {
   BANNER_NOT_FOUND,
@@ -62,9 +67,11 @@ import type {
 export class SellerContentService extends SellerBaseService {
   constructor(
     repo: SellerRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    auditLogs: IAuditLogRepository,
     private readonly productRepository: ProductRepository,
   ) {
-    super(repo);
+    super(repo, auditLogs);
   }
   async sellerFaqTopics(accountId: bigint): Promise<SellerFaqTopicOutput[]> {
     const ctx = await this.requireSellerContext(accountId);
@@ -88,7 +95,7 @@ export class SellerContentService extends SellerBaseService {
       isActive: input.isActive ?? true,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -136,7 +143,7 @@ export class SellerContentService extends SellerBaseService {
       },
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -162,7 +169,7 @@ export class SellerContentService extends SellerBaseService {
     if (!current) throw new NotFoundException(FAQ_TOPIC_NOT_FOUND);
 
     await this.repo.softDeleteFaqTopic(topicId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -234,7 +241,7 @@ export class SellerContentService extends SellerBaseService {
       isActive: input.isActive ?? true,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -273,7 +280,7 @@ export class SellerContentService extends SellerBaseService {
     const data = this.buildBannerUpdateData(input, resolved);
     const row = await this.repo.updateBanner({ bannerId, data });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -451,7 +458,7 @@ export class SellerContentService extends SellerBaseService {
     if (!current) throw new NotFoundException(BANNER_NOT_FOUND);
 
     await this.repo.softDeleteBanner(bannerId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,

--- a/src/features/seller/services/seller-conversation.service.spec.ts
+++ b/src/features/seller/services/seller-conversation.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { ConversationRepository } from '@/features/conversation';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerConversationService } from '@/features/seller/services/seller-conversation.service';
@@ -19,6 +20,10 @@ describe('SellerConversationService (real DB)', () => {
         SellerConversationService,
         SellerRepository,
         ConversationRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     service = module.get(SellerConversationService);

--- a/src/features/seller/services/seller-conversation.service.ts
+++ b/src/features/seller/services/seller-conversation.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -11,6 +12,10 @@ import {
 
 import { parseId } from '@/common/utils/id-parser';
 import { cleanNullableText } from '@/common/utils/text-cleaner';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { ConversationRepository } from '@/features/conversation';
 import {
   BODY_HTML_REQUIRED,
@@ -40,9 +45,11 @@ import type {
 export class SellerConversationService extends SellerBaseService {
   constructor(
     repo: SellerRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    auditLogs: IAuditLogRepository,
     private readonly conversationRepository: ConversationRepository,
   ) {
-    super(repo);
+    super(repo, auditLogs);
   }
   async sellerConversations(
     accountId: bigint,
@@ -139,7 +146,7 @@ export class SellerConversationService extends SellerBaseService {
         now: new Date(),
       });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.CONVERSATION,

--- a/src/features/seller/services/seller-custom-template.service.spec.ts
+++ b/src/features/seller/services/seller-custom-template.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient, Product } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerCustomTemplateService } from '@/features/seller/services/seller-custom-template.service';
@@ -19,6 +20,10 @@ describe('SellerCustomTemplateService (real DB)', () => {
         SellerCustomTemplateService,
         SellerRepository,
         ProductRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     service = module.get(SellerCustomTemplateService);

--- a/src/features/seller/services/seller-custom-template.service.ts
+++ b/src/features/seller/services/seller-custom-template.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -7,6 +8,10 @@ import { AuditActionType, AuditTargetType } from '@prisma/client';
 
 import { parseId } from '@/common/utils/id-parser';
 import { cleanRequiredText } from '@/common/utils/text-cleaner';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import {
   CUSTOM_TEMPLATE_NOT_FOUND,
@@ -36,9 +41,11 @@ import type {
 export class SellerCustomTemplateService extends SellerBaseService {
   constructor(
     repo: SellerRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    auditLogs: IAuditLogRepository,
     private readonly productRepository: ProductRepository,
   ) {
-    super(repo);
+    super(repo, auditLogs);
   }
 
   async sellerUpsertProductCustomTemplate(
@@ -61,7 +68,7 @@ export class SellerCustomTemplateService extends SellerBaseService {
       isActive: input.isActive ?? true,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -93,7 +100,7 @@ export class SellerCustomTemplateService extends SellerBaseService {
       input.isActive,
     );
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -151,7 +158,7 @@ export class SellerCustomTemplateService extends SellerBaseService {
       height: input.height ?? null,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -177,7 +184,7 @@ export class SellerCustomTemplateService extends SellerBaseService {
     }
 
     await this.productRepository.softDeleteCustomTextToken(tokenId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -224,7 +231,7 @@ export class SellerCustomTemplateService extends SellerBaseService {
       tokenIds,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,

--- a/src/features/seller/services/seller-option.service.spec.ts
+++ b/src/features/seller/services/seller-option.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient, Product } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerOptionService } from '@/features/seller/services/seller-option.service';
@@ -15,7 +16,15 @@ describe('SellerOptionService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [SellerOptionService, SellerRepository, ProductRepository],
+      providers: [
+        SellerOptionService,
+        SellerRepository,
+        ProductRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
+      ],
     });
     service = module.get(SellerOptionService);
     prisma = p;

--- a/src/features/seller/services/seller-option.service.ts
+++ b/src/features/seller/services/seller-option.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -10,6 +11,10 @@ import {
   cleanNullableText,
   cleanRequiredText,
 } from '@/common/utils/text-cleaner';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import {
   idsMismatchError,
@@ -43,9 +48,11 @@ import type {
 export class SellerOptionService extends SellerBaseService {
   constructor(
     repo: SellerRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    auditLogs: IAuditLogRepository,
     private readonly productRepository: ProductRepository,
   ) {
-    super(repo);
+    super(repo, auditLogs);
   }
 
   async sellerCreateOptionGroup(
@@ -82,7 +89,7 @@ export class SellerOptionService extends SellerBaseService {
       },
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -145,7 +152,7 @@ export class SellerOptionService extends SellerBaseService {
       },
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -171,7 +178,7 @@ export class SellerOptionService extends SellerBaseService {
     }
 
     await this.productRepository.softDeleteOptionGroup(optionGroupId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -218,7 +225,7 @@ export class SellerOptionService extends SellerBaseService {
       optionGroupIds,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -260,7 +267,7 @@ export class SellerOptionService extends SellerBaseService {
       },
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -321,7 +328,7 @@ export class SellerOptionService extends SellerBaseService {
       },
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -347,7 +354,7 @@ export class SellerOptionService extends SellerBaseService {
     }
 
     await this.productRepository.softDeleteOptionItem(optionItemId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -393,7 +400,7 @@ export class SellerOptionService extends SellerBaseService {
       optionItemIds,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,

--- a/src/features/seller/services/seller-order.service.spec.ts
+++ b/src/features/seller/services/seller-order.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { OrderStatus, type PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import {
   OrderDomainService,
   OrderRepository,
@@ -34,6 +35,10 @@ describe('SellerOrderService (real DB)', () => {
         OrderRepository,
         OrderDomainService,
         OrderStatusTransitionPolicy,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     service = module.get(SellerOrderService);

--- a/src/features/seller/services/seller-order.service.ts
+++ b/src/features/seller/services/seller-order.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -8,6 +9,10 @@ import { OrderStatus } from '@prisma/client';
 import { toDate } from '@/common/utils/date-parser';
 import { parseId } from '@/common/utils/id-parser';
 import { cleanNullableText } from '@/common/utils/text-cleaner';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { OrderDomainService, OrderRepository } from '@/features/order';
 import {
   CANCELLATION_NOTE_REQUIRED,
@@ -64,10 +69,12 @@ interface OrderItemRow {
 export class SellerOrderService extends SellerBaseService {
   constructor(
     repo: SellerRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    auditLogs: IAuditLogRepository,
     private readonly orderRepository: OrderRepository,
     private readonly orderDomainService: OrderDomainService,
   ) {
-    super(repo);
+    super(repo, auditLogs);
   }
   async sellerOrderList(
     accountId: bigint,

--- a/src/features/seller/services/seller-product-crud.service.spec.ts
+++ b/src/features/seller/services/seller-product-crud.service.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerProductCrudService } from '@/features/seller/services/seller-product-crud.service';
@@ -28,6 +29,10 @@ describe('SellerProductCrudService (real DB)', () => {
         SellerProductCrudService,
         SellerRepository,
         ProductRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
       ],
     });
     service = module.get(SellerProductCrudService);

--- a/src/features/seller/services/seller-product-crud.service.ts
+++ b/src/features/seller/services/seller-product-crud.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -10,6 +11,10 @@ import {
   cleanNullableText,
   cleanRequiredText,
 } from '@/common/utils/text-cleaner';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import { ProductRepository } from '@/features/product';
 import {
   IMAGE_LIMIT_EXCEEDED,
@@ -120,9 +125,11 @@ interface ProductDetailRow {
 export class SellerProductCrudService extends SellerBaseService {
   constructor(
     repo: SellerRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    auditLogs: IAuditLogRepository,
     private readonly productRepository: ProductRepository,
   ) {
-    super(repo);
+    super(repo, auditLogs);
   }
 
   async sellerProducts(
@@ -205,7 +212,7 @@ export class SellerProductCrudService extends SellerBaseService {
       sortOrder: 0,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -251,7 +258,7 @@ export class SellerProductCrudService extends SellerBaseService {
       data,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -288,7 +295,7 @@ export class SellerProductCrudService extends SellerBaseService {
     if (!current) throw new NotFoundException(PRODUCT_NOT_FOUND);
 
     await this.productRepository.softDeleteProduct(productId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -322,7 +329,7 @@ export class SellerProductCrudService extends SellerBaseService {
       },
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -370,7 +377,7 @@ export class SellerProductCrudService extends SellerBaseService {
       sortOrder: input.sortOrder ?? count,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -402,7 +409,7 @@ export class SellerProductCrudService extends SellerBaseService {
     }
 
     await this.productRepository.softDeleteProductImage(imageId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -448,7 +455,7 @@ export class SellerProductCrudService extends SellerBaseService {
       imageIds,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -488,7 +495,7 @@ export class SellerProductCrudService extends SellerBaseService {
       categoryIds,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,
@@ -534,7 +541,7 @@ export class SellerProductCrudService extends SellerBaseService {
       tagIds,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.PRODUCT,

--- a/src/features/seller/services/seller-store.service.spec.ts
+++ b/src/features/seller/services/seller-store.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
+import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerStoreService } from '@/features/seller/services/seller-store.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
@@ -18,7 +19,14 @@ describe('SellerStoreService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [SellerStoreService, SellerRepository],
+      providers: [
+        SellerStoreService,
+        SellerRepository,
+        {
+          provide: AUDIT_LOG_REPOSITORY,
+          useClass: AuditLogRepository,
+        },
+      ],
     });
     service = module.get(SellerStoreService);
     prisma = p;

--- a/src/features/seller/services/seller-store.service.ts
+++ b/src/features/seller/services/seller-store.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -11,6 +12,10 @@ import {
   cleanNullableText,
   cleanRequiredText,
 } from '@/common/utils/text-cleaner';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
 import {
   CLOSE_BEFORE_OPEN,
   DAILY_CAPACITY_NOT_FOUND,
@@ -63,8 +68,12 @@ import type {
 
 @Injectable()
 export class SellerStoreService extends SellerBaseService {
-  constructor(repo: SellerRepository) {
-    super(repo);
+  constructor(
+    repo: SellerRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    auditLogs: IAuditLogRepository,
+  ) {
+    super(repo, auditLogs);
   }
   async sellerMyStore(accountId: bigint): Promise<SellerStoreOutput> {
     const ctx = await this.requireSellerContext(accountId);
@@ -143,7 +152,7 @@ export class SellerStoreService extends SellerBaseService {
       data,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -271,7 +280,7 @@ export class SellerStoreService extends SellerBaseService {
       closeTime,
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -318,7 +327,7 @@ export class SellerStoreService extends SellerBaseService {
           reason,
         });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -345,7 +354,7 @@ export class SellerStoreService extends SellerBaseService {
     if (!found) throw new NotFoundException(SPECIAL_CLOSURE_NOT_FOUND);
 
     await this.repo.softDeleteStoreSpecialClosure(closureId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -395,7 +404,7 @@ export class SellerStoreService extends SellerBaseService {
       },
     });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -451,7 +460,7 @@ export class SellerStoreService extends SellerBaseService {
           capacity: input.capacity,
         });
 
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,
@@ -478,7 +487,7 @@ export class SellerStoreService extends SellerBaseService {
     if (!found) throw new NotFoundException(DAILY_CAPACITY_NOT_FOUND);
 
     await this.repo.softDeleteStoreDailyCapacity(capacityId);
-    await this.repo.createAuditLog({
+    await this.auditLogs.createAuditLog({
       actorAccountId: ctx.accountId,
       storeId: ctx.storeId,
       targetType: AuditTargetType.STORE,


### PR DESCRIPTION
## Summary

- AuthRepository · SellerRepository 양쪽에 중복 구현되어 있던 `createAuditLog` 를 **단일 책임의 audit-log 모듈**로 통합.
- 신규 Repository 는 P1-1 방침에 따라 interface + Symbol DI Token 패턴.
- 두 도메인 모듈이 AuditLogModule 을 import 하여 공유 (cross-feature import 위반 없이 깔끔하게).

## Scope

- **신규**
  - 모듈: \`src/features/audit-log/\`
  - \`IAuditLogRepository\` + \`AUDIT_LOG_REPOSITORY\` Symbol 토큰
  - \`AuditLogRepository\` 구체 구현
  - \`audit-log.repository.spec.ts\` (실DB 통합 테스트)
- **제거**
  - \`AuthRepository.createAuditLog\` (Auth feature 의 1곳 사용)
  - \`SellerRepository.createAuditLog\` (Seller 6개 서비스 36개 사용)
- **변경**
  - AuthService: \`this.repo.createAuditLog\` → \`this.auditLogs.createAuditLog\`
  - 6개 Seller Service: \`this.repo.createAuditLog\` → \`this.auditLogs.createAuditLog\`
  - SellerBaseService: \`protected readonly auditLogs: IAuditLogRepository\` 추가, 7개 subclass 생성자 전달
  - AuthModule + SellerModule: \`AuditLogModule\` import
  - 영향 받은 spec 모두 \`AUDIT_LOG_REPOSITORY\` provider 등록 동반 갱신

## Non-goals

- AuthService 자체 분해(Token / Session / SellerCredential 분리) 는 P0-1 후속 단계
- AuthRepository 의 나머지(Account / SellerCredential) 분리는 P0-1 단계 3

## Plan deviation 안내

원 플랜은 audit-log 를 \`auth/repositories/\` 에 두는 안이었습니다. 실제 코드를 보니 Seller 서비스에서 36곳 사용 중이라 auth 내부로 두면 \`seller → auth\` 도메인 의존이 생겨 cross-cutting 한 audit 의 성격과 맞지 않아 **별도 audit-log 모듈로 분리**했습니다. 두 도메인이 동일한 import 라인을 통해 공유합니다.

## Impact

- FE: 없음 (응답·엔드포인트·에러 형태 동일)
- DB: 변경 없음 (\`audit_log\` 테이블 스키마/쿼리 그대로)
- Coverage: 1168 tests pass, 전 임계 통과

## Test plan

- [x] yarn validate (lint + tsc + dto:check + test:cov) 로컬 통과
- [x] audit-log.repository.spec.ts 신규 통합 테스트 (실DB)
- [x] 기존 auth/seller spec 들이 새 provider 등록 후 회귀 없음
- [ ] CI 통과 확인