### PR TITLE
refactor(auth): AccountRepository / SellerCredentialRepository 분리 + AuthRepository 제거 (P0-1 단계 3)

### DIFF
--- a/src/features/auth/auth.module.ts
+++ b/src/features/auth/auth.module.ts
@@ -3,9 +3,12 @@ import { Module } from '@nestjs/common';
 import { AuditLogModule } from '@/features/audit-log';
 import { AuthService } from '@/features/auth/auth.service';
 import { AuthController } from '@/features/auth/controllers/auth.controller';
-import { AuthRepository } from '@/features/auth/repositories/auth.repository';
+import { AccountRepository } from '@/features/auth/repositories/account.repository';
+import { ACCOUNT_REPOSITORY } from '@/features/auth/repositories/account.repository.interface';
 import { RefreshSessionRepository } from '@/features/auth/repositories/refresh-session.repository';
 import { REFRESH_SESSION_REPOSITORY } from '@/features/auth/repositories/refresh-session.repository.interface';
+import { SellerCredentialRepository } from '@/features/auth/repositories/seller-credential.repository';
+import { SELLER_CREDENTIAL_REPOSITORY } from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 import { JwtBearerStrategy } from '@/features/auth/strategies/jwt-bearer.strategy';
 import { AuthGlobalModule } from '@/global/auth/auth-global.module';
@@ -22,7 +25,14 @@ import { AuthGlobalModule } from '@/global/auth/auth-global.module';
   providers: [
     AuthService,
     OidcClientService,
-    AuthRepository,
+    {
+      provide: ACCOUNT_REPOSITORY,
+      useClass: AccountRepository,
+    },
+    {
+      provide: SELLER_CREDENTIAL_REPOSITORY,
+      useClass: SellerCredentialRepository,
+    },
     {
       provide: REFRESH_SESSION_REPOSITORY,
       useClass: RefreshSessionRepository,

--- a/src/features/auth/auth.seller.service.spec.ts
+++ b/src/features/auth/auth.seller.service.spec.ts
@@ -16,16 +16,24 @@ import {
   type IAuditLogRepository,
 } from '@/features/audit-log';
 import { AuthService } from '@/features/auth/auth.service';
-import { AuthRepository } from '@/features/auth/repositories/auth.repository';
+import {
+  ACCOUNT_REPOSITORY,
+  type IAccountRepository,
+} from '@/features/auth/repositories/account.repository.interface';
 import {
   REFRESH_SESSION_REPOSITORY,
   type IRefreshSessionRepository,
 } from '@/features/auth/repositories/refresh-session.repository.interface';
+import {
+  SELLER_CREDENTIAL_REPOSITORY,
+  type ISellerCredentialRepository,
+} from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 
 describe('AuthService (seller)', () => {
   let service: AuthService;
-  let repo: jest.Mocked<AuthRepository>;
+  let accounts: jest.Mocked<IAccountRepository>;
+  let sellerCredentials: jest.Mocked<ISellerCredentialRepository>;
   let refreshSessions: jest.Mocked<IRefreshSessionRepository>;
   let auditLogs: jest.Mocked<IAuditLogRepository>;
   let mockConfig: jest.Mocked<ConfigService>;
@@ -42,12 +50,20 @@ describe('AuthService (seller)', () => {
   } as unknown as Response;
 
   beforeEach(async () => {
-    repo = {
+    accounts = {
+      findIdentityByProviderSubject: jest.fn(),
+      findAccountByEmail: jest.fn(),
+      upsertUserByOidcIdentity: jest.fn(),
+      findAccountForJwt: jest.fn(),
+      findAccountForMe: jest.fn(),
+    };
+
+    sellerCredentials = {
       findSellerCredentialByUsername: jest.fn(),
       findSellerCredentialByAccountId: jest.fn(),
       updateSellerLastLogin: jest.fn(),
       updateSellerPasswordHash: jest.fn(),
-    } as unknown as jest.Mocked<AuthRepository>;
+    };
 
     refreshSessions = {
       createRefreshSession: jest.fn(),
@@ -74,7 +90,14 @@ describe('AuthService (seller)', () => {
           useValue: { sign: jest.fn(() => 'mock-access-token') },
         },
         { provide: OidcClientService, useValue: {} },
-        { provide: AuthRepository, useValue: repo },
+        {
+          provide: ACCOUNT_REPOSITORY,
+          useValue: accounts,
+        },
+        {
+          provide: SELLER_CREDENTIAL_REPOSITORY,
+          useValue: sellerCredentials,
+        },
         {
           provide: REFRESH_SESSION_REPOSITORY,
           useValue: refreshSessions,
@@ -116,7 +139,9 @@ describe('AuthService (seller)', () => {
     it('판매자 로그인 성공 시 accessToken과 accountStatus를 반환해야 한다', async () => {
       // Arrange
       jest.spyOn(argon2, 'verify').mockResolvedValue(true);
-      repo.findSellerCredentialByUsername.mockResolvedValue(validCredential);
+      sellerCredentials.findSellerCredentialByUsername.mockResolvedValue(
+        validCredential,
+      );
 
       // Act
       const result = await service.sellerLogin({
@@ -129,7 +154,7 @@ describe('AuthService (seller)', () => {
       // Assert
       expect(result.accessToken).toBe('mock-access-token');
       expect(result.accountStatus).toBe('PENDING');
-      expect(repo.updateSellerLastLogin).toHaveBeenCalledWith(
+      expect(sellerCredentials.updateSellerLastLogin).toHaveBeenCalledWith(
         BigInt(10),
         expect.any(Date),
       );
@@ -173,7 +198,7 @@ describe('AuthService (seller)', () => {
 
     it('존재하지 않는 판매자이면 UnauthorizedException을 던져야 한다', async () => {
       // Arrange
-      repo.findSellerCredentialByUsername.mockResolvedValue(null);
+      sellerCredentials.findSellerCredentialByUsername.mockResolvedValue(null);
 
       // Act & Assert
       await expect(
@@ -203,7 +228,7 @@ describe('AuthService (seller)', () => {
           account_type: AccountType.USER,
         },
       };
-      repo.findSellerCredentialByUsername.mockResolvedValue(
+      sellerCredentials.findSellerCredentialByUsername.mockResolvedValue(
         nonSellerCredential,
       );
 
@@ -229,7 +254,9 @@ describe('AuthService (seller)', () => {
     it('비밀번호가 틀리면 UnauthorizedException을 던져야 한다', async () => {
       // Arrange
       jest.spyOn(argon2, 'verify').mockResolvedValue(false);
-      repo.findSellerCredentialByUsername.mockResolvedValue(validCredential);
+      sellerCredentials.findSellerCredentialByUsername.mockResolvedValue(
+        validCredential,
+      );
 
       // Act & Assert
       await expect(
@@ -272,7 +299,9 @@ describe('AuthService (seller)', () => {
 
     it('비밀번호를 성공적으로 변경해야 한다', async () => {
       // Arrange
-      repo.findSellerCredentialByAccountId.mockResolvedValue(sellerCredential);
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential,
+      );
       // 첫 번째 호출: 현재 비밀번호 확인 (true)
       // 두 번째 호출: 새 비밀번호 동일 여부 확인 (false = 다른 비밀번호)
       jest
@@ -292,7 +321,7 @@ describe('AuthService (seller)', () => {
       });
 
       // Assert
-      expect(repo.updateSellerPasswordHash).toHaveBeenCalledWith({
+      expect(sellerCredentials.updateSellerPasswordHash).toHaveBeenCalledWith({
         sellerAccountId: BigInt(10),
         passwordHash: '$argon2id$v=19$m=65536,t=3,p=4$new$newHash',
         now: expect.any(Date),
@@ -312,7 +341,7 @@ describe('AuthService (seller)', () => {
 
     it('판매자를 찾을 수 없으면 UnauthorizedException을 던져야 한다', async () => {
       // Arrange
-      repo.findSellerCredentialByAccountId.mockResolvedValue(null);
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue(null);
 
       // Act & Assert
       await expect(
@@ -342,7 +371,7 @@ describe('AuthService (seller)', () => {
           account_type: AccountType.USER,
         },
       };
-      repo.findSellerCredentialByAccountId.mockResolvedValue(
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue(
         nonSellerCredential,
       );
 
@@ -372,7 +401,9 @@ describe('AuthService (seller)', () => {
 
     it('현재 비밀번호가 틀리면 UnauthorizedException을 던져야 한다', async () => {
       // Arrange
-      repo.findSellerCredentialByAccountId.mockResolvedValue(sellerCredential);
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential,
+      );
       jest.spyOn(argon2, 'verify').mockResolvedValue(false);
 
       // Act & Assert
@@ -396,7 +427,9 @@ describe('AuthService (seller)', () => {
 
     it('새 비밀번호가 기존 비밀번호와 동일하면 BadRequestException을 던져야 한다', async () => {
       // Arrange
-      repo.findSellerCredentialByAccountId.mockResolvedValue(sellerCredential);
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue(
+        sellerCredential,
+      );
       // 현재 비밀번호 확인: true, 새 비밀번호 동일 여부: true (같은 비밀번호)
       jest
         .spyOn(argon2, 'verify')
@@ -456,7 +489,7 @@ describe('AuthService (seller)', () => {
         token_hash: 'new-hash',
       } as never);
 
-      repo.findSellerCredentialByAccountId.mockResolvedValue({
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue({
         id: BigInt(1),
         seller_account_id: BigInt(10),
         username: 'seller01',
@@ -542,7 +575,7 @@ describe('AuthService (seller)', () => {
         token_hash: 'new-hash',
       } as never);
 
-      repo.findSellerCredentialByAccountId.mockResolvedValue(null);
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue(null);
 
       // Act & Assert
       await expect(
@@ -581,7 +614,7 @@ describe('AuthService (seller)', () => {
         token_hash: 'new-hash',
       } as never);
 
-      repo.findSellerCredentialByAccountId.mockResolvedValue({
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue({
         id: BigInt(1),
         seller_account_id: BigInt(10),
         username: 'seller01',
@@ -625,7 +658,7 @@ describe('AuthService (seller)', () => {
         deleted_at: null,
       });
 
-      repo.findSellerCredentialByAccountId.mockResolvedValue({
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue({
         id: BigInt(1),
         seller_account_id: BigInt(10),
         username: 'seller01',
@@ -710,7 +743,7 @@ describe('AuthService (seller)', () => {
         deleted_at: null,
       });
 
-      repo.findSellerCredentialByAccountId.mockResolvedValue(null);
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue(null);
 
       // Act & Assert
       await expect(
@@ -741,7 +774,7 @@ describe('AuthService (seller)', () => {
         deleted_at: null,
       });
 
-      repo.findSellerCredentialByAccountId.mockResolvedValue({
+      sellerCredentials.findSellerCredentialByAccountId.mockResolvedValue({
         id: BigInt(1),
         seller_account_id: BigInt(10),
         username: 'seller01',

--- a/src/features/auth/auth.service.spec.ts
+++ b/src/features/auth/auth.service.spec.ts
@@ -14,11 +14,18 @@ import {
   type IAuditLogRepository,
 } from '@/features/audit-log';
 import { AuthService } from '@/features/auth/auth.service';
-import { AuthRepository } from '@/features/auth/repositories/auth.repository';
+import {
+  ACCOUNT_REPOSITORY,
+  type IAccountRepository,
+} from '@/features/auth/repositories/account.repository.interface';
 import {
   REFRESH_SESSION_REPOSITORY,
   type IRefreshSessionRepository,
 } from '@/features/auth/repositories/refresh-session.repository.interface';
+import {
+  SELLER_CREDENTIAL_REPOSITORY,
+  type ISellerCredentialRepository,
+} from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
 
@@ -27,7 +34,8 @@ describe('AuthService', () => {
   let mockConfig: jest.Mocked<ConfigService>;
   let mockJwt: jest.Mocked<JwtService>;
   let mockOidc: jest.Mocked<OidcClientService>;
-  let mockRepo: jest.Mocked<AuthRepository>;
+  let mockAccounts: jest.Mocked<IAccountRepository>;
+  let mockSellerCredentials: jest.Mocked<ISellerCredentialRepository>;
   let mockRefreshSessions: jest.Mocked<IRefreshSessionRepository>;
   let mockAuditLogs: jest.Mocked<IAuditLogRepository>;
 
@@ -46,11 +54,20 @@ describe('AuthService', () => {
       toIdentityProvider: jest.fn(),
     } as unknown as jest.Mocked<OidcClientService>;
 
-    mockRepo = {
+    mockAccounts = {
+      findIdentityByProviderSubject: jest.fn(),
+      findAccountByEmail: jest.fn(),
       upsertUserByOidcIdentity: jest.fn(),
-      findAccountForMe: jest.fn(),
       findAccountForJwt: jest.fn(),
-    } as unknown as jest.Mocked<AuthRepository>;
+      findAccountForMe: jest.fn(),
+    };
+
+    mockSellerCredentials = {
+      findSellerCredentialByUsername: jest.fn(),
+      findSellerCredentialByAccountId: jest.fn(),
+      updateSellerLastLogin: jest.fn(),
+      updateSellerPasswordHash: jest.fn(),
+    };
 
     mockRefreshSessions = {
       findActiveRefreshSessionByHash: jest.fn(),
@@ -70,7 +87,14 @@ describe('AuthService', () => {
         { provide: ConfigService, useValue: mockConfig },
         { provide: JwtService, useValue: mockJwt },
         { provide: OidcClientService, useValue: mockOidc },
-        { provide: AuthRepository, useValue: mockRepo },
+        {
+          provide: ACCOUNT_REPOSITORY,
+          useValue: mockAccounts,
+        },
+        {
+          provide: SELLER_CREDENTIAL_REPOSITORY,
+          useValue: mockSellerCredentials,
+        },
         {
           provide: REFRESH_SESSION_REPOSITORY,
           useValue: mockRefreshSessions,
@@ -200,7 +224,7 @@ describe('AuthService', () => {
 
       mockOidc.toIdentityProvider.mockReturnValue('GOOGLE');
 
-      mockRepo.upsertUserByOidcIdentity.mockResolvedValue({
+      mockAccounts.upsertUserByOidcIdentity.mockResolvedValue({
         account: {
           id: BigInt(1),
           email: 'test@example.com',
@@ -224,7 +248,7 @@ describe('AuthService', () => {
         accessToken: 'mock-access-token',
       });
       expect(mockOidc.exchangeCode).toHaveBeenCalled();
-      expect(mockRepo.upsertUserByOidcIdentity).toHaveBeenCalledWith({
+      expect(mockAccounts.upsertUserByOidcIdentity).toHaveBeenCalledWith({
         provider: 'GOOGLE',
         providerSubject: 'google-user-123',
         providerEmail: 'test@example.com',
@@ -429,7 +453,7 @@ describe('AuthService', () => {
   describe('me', () => {
     it('사용자 정보를 성공적으로 반환해야 한다', async () => {
       // Arrange
-      mockRepo.findAccountForMe.mockResolvedValue({
+      mockAccounts.findAccountForMe.mockResolvedValue({
         id: BigInt(1),
         email: 'test@example.com',
         name: 'Test User',
@@ -459,7 +483,7 @@ describe('AuthService', () => {
 
     it('프로필 정보가 불완전하면 needsProfile이 true여야 한다', async () => {
       // Arrange
-      mockRepo.findAccountForMe.mockResolvedValue({
+      mockAccounts.findAccountForMe.mockResolvedValue({
         id: BigInt(1),
         email: 'test@example.com',
         name: 'Test User',
@@ -480,7 +504,7 @@ describe('AuthService', () => {
 
     it('계정을 찾을 수 없으면 UnauthorizedException을 던져야 한다', async () => {
       // Arrange
-      mockRepo.findAccountForMe.mockResolvedValue(null);
+      mockAccounts.findAccountForMe.mockResolvedValue(null);
 
       // Act & Assert
       await expect(service.me(BigInt(999))).rejects.toThrow(
@@ -489,7 +513,7 @@ describe('AuthService', () => {
     });
 
     it('user_profile이 아예 null이면 모든 프로필 필드가 null + needsProfile=true', async () => {
-      mockRepo.findAccountForMe.mockResolvedValue({
+      mockAccounts.findAccountForMe.mockResolvedValue({
         id: BigInt(1),
         email: null,
         name: null,
@@ -557,7 +581,7 @@ describe('AuthService', () => {
     });
 
     it('정상 발급: 활성 USER 계정이면 access token + 만료 정보를 반환한다', async () => {
-      mockRepo.findAccountForJwt.mockResolvedValue({
+      mockAccounts.findAccountForJwt.mockResolvedValue({
         id: BigInt(1),
         status: 'ACTIVE',
         account_type: 'USER',
@@ -576,7 +600,7 @@ describe('AuthService', () => {
     });
 
     it('존재하지 않는 accountId면 NotFoundException', async () => {
-      mockRepo.findAccountForJwt.mockResolvedValue(null);
+      mockAccounts.findAccountForJwt.mockResolvedValue(null);
 
       await expect(service.issueDevAccessToken(BigInt(999))).rejects.toThrow(
         NotFoundException,
@@ -585,7 +609,7 @@ describe('AuthService', () => {
     });
 
     it('비활성(SUSPENDED) 계정이면 ForbiddenException', async () => {
-      mockRepo.findAccountForJwt.mockResolvedValue({
+      mockAccounts.findAccountForJwt.mockResolvedValue({
         id: BigInt(2),
         status: 'SUSPENDED',
         account_type: 'USER',

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -33,11 +33,18 @@ import {
   AuthCookie,
   type CookieSameSite,
 } from '@/features/auth/helpers/auth-cookie.helper';
-import { AuthRepository } from '@/features/auth/repositories/auth.repository';
+import {
+  ACCOUNT_REPOSITORY,
+  type IAccountRepository,
+} from '@/features/auth/repositories/account.repository.interface';
 import {
   REFRESH_SESSION_REPOSITORY,
   type IRefreshSessionRepository,
 } from '@/features/auth/repositories/refresh-session.repository.interface';
+import {
+  SELLER_CREDENTIAL_REPOSITORY,
+  type ISellerCredentialRepository,
+} from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 import {
   parseOidcProvider,
@@ -55,7 +62,8 @@ export class AuthService {
    * @param config ConfigService
    * @param jwt JwtService
    * @param oidc OidcClientService
-   * @param repo AuthRepository
+   * @param accounts AccountRepository
+   * @param sellerCredentials SellerCredentialRepository
    * @param refreshSessions RefreshSessionRepository
    * @param auditLogs AuditLogRepository
    * @param clock ClockService
@@ -64,7 +72,10 @@ export class AuthService {
     private readonly config: ConfigService,
     private readonly jwt: JwtService,
     private readonly oidc: OidcClientService,
-    private readonly repo: AuthRepository,
+    @Inject(ACCOUNT_REPOSITORY)
+    private readonly accounts: IAccountRepository,
+    @Inject(SELLER_CREDENTIAL_REPOSITORY)
+    private readonly sellerCredentials: ISellerCredentialRepository,
     @Inject(REFRESH_SESSION_REPOSITORY)
     private readonly refreshSessions: IRefreshSessionRepository,
     @Inject(AUDIT_LOG_REPOSITORY)
@@ -179,7 +190,8 @@ export class AuthService {
       throw new UnauthorizedException('Invalid seller credentials.');
     }
 
-    const credential = await this.repo.findSellerCredentialByUsername(username);
+    const credential =
+      await this.sellerCredentials.findSellerCredentialByUsername(username);
     if (!credential)
       throw new UnauthorizedException('Invalid seller credentials.');
 
@@ -196,7 +208,10 @@ export class AuthService {
     }
 
     const now = this.clock.now();
-    await this.repo.updateSellerLastLogin(credential.seller_account_id, now);
+    await this.sellerCredentials.updateSellerLastLogin(
+      credential.seller_account_id,
+      now,
+    );
 
     const { accessToken } = await this.issueAuthTokens({
       accountId: credential.seller_account_id,
@@ -236,7 +251,7 @@ export class AuthService {
     tokenType: 'Bearer';
     expiresInSeconds: number;
   }> {
-    const account = await this.repo.findAccountForJwt(accountId);
+    const account = await this.accounts.findAccountForJwt(accountId);
     if (!account) {
       throw new NotFoundException('Account not found.');
     }
@@ -263,7 +278,8 @@ export class AuthService {
     res: Response,
   ): Promise<{ accessToken: string; accountStatus: AccountStatus }> {
     const { accessToken, accountId } = await this.rotateRefresh(req, res);
-    const seller = await this.repo.findSellerCredentialByAccountId(accountId);
+    const seller =
+      await this.sellerCredentials.findSellerCredentialByAccountId(accountId);
     if (!seller || seller.seller_account.account_type !== AccountType.SELLER) {
       throw new UnauthorizedException('Invalid seller refresh token.');
     }
@@ -293,7 +309,7 @@ export class AuthService {
       await this.refreshSessions.findActiveRefreshSessionByHash(tokenHash);
     if (!session) throw new UnauthorizedException('Invalid refresh token.');
 
-    const seller = await this.repo.findSellerCredentialByAccountId(
+    const seller = await this.sellerCredentials.findSellerCredentialByAccountId(
       session.account_id,
     );
     if (!seller || seller.seller_account.account_type !== AccountType.SELLER) {
@@ -349,9 +365,10 @@ export class AuthService {
     newPassword: string;
     req: Request;
   }): Promise<void> {
-    const credential = await this.repo.findSellerCredentialByAccountId(
-      args.accountId,
-    );
+    const credential =
+      await this.sellerCredentials.findSellerCredentialByAccountId(
+        args.accountId,
+      );
     if (!credential) throw new UnauthorizedException('Seller not found.');
     if (credential.seller_account.account_type !== AccountType.SELLER) {
       throw new ForbiddenException('Only SELLER account is allowed.');
@@ -382,7 +399,7 @@ export class AuthService {
       type: argon2.argon2id,
     });
 
-    await this.repo.updateSellerPasswordHash({
+    await this.sellerCredentials.updateSellerPasswordHash({
       sellerAccountId: args.accountId,
       passwordHash: newHash,
       now,
@@ -409,7 +426,7 @@ export class AuthService {
    * @param accountId accountId(BigInt)
    */
   async me(accountId: bigint) {
-    const account = await this.repo.findAccountForMe(accountId);
+    const account = await this.accounts.findAccountForMe(accountId);
     if (!account) throw new UnauthorizedException('Account not found.');
 
     const profile = account.user_profile;
@@ -536,7 +553,7 @@ export class AuthService {
   ) {
     const identityProvider = this.oidc.toIdentityProvider(provider);
 
-    const { account } = await this.repo.upsertUserByOidcIdentity({
+    const { account } = await this.accounts.upsertUserByOidcIdentity({
       provider: identityProvider,
       providerSubject: userInfo.subject,
       providerEmail: userInfo.email,

--- a/src/features/auth/repositories/account.repository.interface.ts
+++ b/src/features/auth/repositories/account.repository.interface.ts
@@ -1,0 +1,77 @@
+import type { IdentityProvider, Prisma } from '@prisma/client';
+
+/**
+ * Account Repository 토큰 (Nest DI 주입용).
+ */
+export const ACCOUNT_REPOSITORY = Symbol('ACCOUNT_REPOSITORY');
+
+/**
+ * include: { user_profile: true } 를 가진 Account.
+ */
+export type AccountWithProfile = Prisma.AccountGetPayload<{
+  include: { user_profile: true };
+}>;
+
+/**
+ * JWT 검증용 좁은 select.
+ */
+export type AccountForJwt = Prisma.AccountGetPayload<{
+  select: { id: true; status: true; account_type: true };
+}>;
+
+/**
+ * include: { account: { include: { user_profile: true } } } 를 가진 AccountIdentity.
+ */
+export type AccountIdentityWithAccount = Prisma.AccountIdentityGetPayload<{
+  include: {
+    account: {
+      include: { user_profile: true };
+    };
+  };
+}>;
+
+/**
+ * Account / AccountIdentity / UserProfile Repository 인터페이스.
+ *
+ * OIDC upsert 와 JWT/Me 조회 등 계정 라이프사이클 read/write 를 담당한다.
+ */
+export interface IAccountRepository {
+  /**
+   * provider + subject 로 AccountIdentity 를 조회한다(soft-delete 제외).
+   */
+  findIdentityByProviderSubject(
+    provider: IdentityProvider,
+    providerSubject: string,
+  ): Promise<AccountIdentityWithAccount | null>;
+
+  /**
+   * 이메일(verified 전제) 로 기존 계정을 찾는다(soft-delete 제외).
+   */
+  findAccountByEmail(email: string): Promise<AccountWithProfile | null>;
+
+  /**
+   * Identity 가 없을 때 계정을 만들거나(또는 이메일로 기존 계정에 붙여서) Identity 를 upsert 한다.
+   *
+   * 정책:
+   * - (provider, subject) 로 우선 식별
+   * - 없으면 신규 계정 생성
+   */
+  upsertUserByOidcIdentity(args: {
+    provider: IdentityProvider;
+    providerSubject: string;
+    providerEmail?: string;
+    emailVerified: boolean;
+    providerDisplayName?: string;
+    providerProfileImageUrl?: string;
+  }): Promise<{ account: AccountWithProfile | null }>;
+
+  /**
+   * access token 검증용으로 계정을 조회한다.
+   */
+  findAccountForJwt(accountId: bigint): Promise<AccountForJwt | null>;
+
+  /**
+   * accountId 기준으로 유저를 조회한다(soft-delete 제외).
+   */
+  findAccountForMe(accountId: bigint): Promise<AccountWithProfile | null>;
+}

--- a/src/features/auth/repositories/account.repository.spec.ts
+++ b/src/features/auth/repositories/account.repository.spec.ts
@@ -2,28 +2,30 @@ import type { PrismaClient } from '@prisma/client';
 import { IdentityProvider } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
-import { AuthRepository } from '@/features/auth/repositories/auth.repository';
+import { AccountRepository } from '@/features/auth/repositories/account.repository';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
 import {
   createAccount,
   createAccountIdentity,
-  createSellerCredential,
   createUserProfile,
 } from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
-describe('AuthRepository (real DB)', () => {
-  let repo: AuthRepository;
+describe('AccountRepository (real DB)', () => {
+  let repo: AccountRepository;
   let prisma: PrismaClient;
   let clock: ClockService;
 
   beforeAll(async () => {
     clock = new ClockService();
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [AuthRepository, { provide: ClockService, useValue: clock }],
+      providers: [
+        AccountRepository,
+        { provide: ClockService, useValue: clock },
+      ],
     });
-    repo = module.get(AuthRepository);
+    repo = module.get(AccountRepository);
     prisma = p;
   });
 
@@ -35,8 +37,6 @@ describe('AuthRepository (real DB)', () => {
   beforeEach(async () => {
     await truncateAll();
   });
-
-  // ─── Identity 조회 ───
 
   describe('findIdentityByProviderSubject', () => {
     it('provider+subject로 Identity를 조회한다', async () => {
@@ -66,8 +66,6 @@ describe('AuthRepository (real DB)', () => {
     });
   });
 
-  // ─── 이메일 계정 조회 ───
-
   describe('findAccountByEmail', () => {
     it('이메일로 계정을 조회한다', async () => {
       const account = await createAccount(prisma, {
@@ -87,8 +85,6 @@ describe('AuthRepository (real DB)', () => {
       expect(result).toBeNull();
     });
   });
-
-  // ─── OIDC Identity Upsert ───
 
   describe('upsertUserByOidcIdentity', () => {
     it('신규 Identity+계정을 생성한다', async () => {
@@ -160,7 +156,7 @@ describe('AuthRepository (real DB)', () => {
     });
 
     it('기존 Identity + account email이 null + user_profile 없는 경우: profile 신규 생성 + email 주입', async () => {
-      // account는 있지만 email/profile이 비어있는 초기 상태 재현
+      // account 는 있지만 email/profile 이 비어있는 초기 상태 재현
       const account = await prisma.account.create({
         data: {
           account_type: 'USER',
@@ -189,8 +185,6 @@ describe('AuthRepository (real DB)', () => {
     });
   });
 
-  // ─── JWT/Me 조회 ───
-
   describe('findAccountForJwt', () => {
     it('계정 id/status/type을 반환한다', async () => {
       const account = await createAccount(prisma, { account_type: 'USER' });
@@ -213,91 +207,6 @@ describe('AuthRepository (real DB)', () => {
 
       expect(found).not.toBeNull();
       expect(found!.user_profile).not.toBeNull();
-    });
-  });
-
-  // ─── Seller 조회 ───
-
-  describe('findSellerCredentialByUsername', () => {
-    it('username으로 판매자 자격정보를 조회한다', async () => {
-      const sellerAccount = await createAccount(prisma, {
-        account_type: 'SELLER',
-      });
-      await createSellerCredential(prisma, {
-        seller_account_id: sellerAccount.id,
-        username: 'test_seller',
-      });
-
-      const found = await repo.findSellerCredentialByUsername('test_seller');
-
-      expect(found).not.toBeNull();
-      expect(found!.username).toBe('test_seller');
-      expect(found!.seller_account.id).toBe(sellerAccount.id);
-    });
-
-    it('존재하지 않는 username이면 null', async () => {
-      const found = await repo.findSellerCredentialByUsername('nonexistent');
-      expect(found).toBeNull();
-    });
-  });
-
-  describe('findSellerCredentialByAccountId', () => {
-    it('accountId로 판매자 자격정보를 조회한다', async () => {
-      const sellerAccount = await createAccount(prisma, {
-        account_type: 'SELLER',
-      });
-      await createSellerCredential(prisma, {
-        seller_account_id: sellerAccount.id,
-      });
-
-      const found = await repo.findSellerCredentialByAccountId(
-        sellerAccount.id,
-      );
-
-      expect(found).not.toBeNull();
-      expect(found!.seller_account_id).toBe(sellerAccount.id);
-    });
-  });
-
-  describe('updateSellerLastLogin', () => {
-    it('최근 로그인 시각을 갱신한다', async () => {
-      const sellerAccount = await createAccount(prisma, {
-        account_type: 'SELLER',
-      });
-      await createSellerCredential(prisma, {
-        seller_account_id: sellerAccount.id,
-      });
-
-      const now = new Date();
-      await repo.updateSellerLastLogin(sellerAccount.id, now);
-
-      const updated = await prisma.sellerCredential.findUnique({
-        where: { seller_account_id: sellerAccount.id },
-      });
-      expect(updated!.last_login_at!.getTime()).toBe(now.getTime());
-    });
-  });
-
-  describe('updateSellerPasswordHash', () => {
-    it('비밀번호 해시를 갱신한다', async () => {
-      const sellerAccount = await createAccount(prisma, {
-        account_type: 'SELLER',
-      });
-      await createSellerCredential(prisma, {
-        seller_account_id: sellerAccount.id,
-      });
-
-      const now = new Date();
-      await repo.updateSellerPasswordHash({
-        sellerAccountId: sellerAccount.id,
-        passwordHash: 'new_hash_value',
-        now,
-      });
-
-      const updated = await prisma.sellerCredential.findUnique({
-        where: { seller_account_id: sellerAccount.id },
-      });
-      expect(updated!.password_hash).toBe('new_hash_value');
     });
   });
 });

--- a/src/features/auth/repositories/account.repository.ts
+++ b/src/features/auth/repositories/account.repository.ts
@@ -1,14 +1,20 @@
 import { Injectable } from '@nestjs/common';
-import { AccountType, IdentityProvider } from '@prisma/client';
+import { AccountType, type IdentityProvider } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
+import type {
+  AccountForJwt,
+  AccountIdentityWithAccount,
+  AccountWithProfile,
+  IAccountRepository,
+} from '@/features/auth/repositories/account.repository.interface';
 import { PrismaService } from '@/prisma';
 
 /**
- * 인증 Repository
+ * Account / AccountIdentity / UserProfile Repository 구체 구현.
  */
 @Injectable()
-export class AuthRepository {
+export class AccountRepository implements IAccountRepository {
   /**
    * @param prisma PrismaService
    * @param clock ClockService
@@ -18,16 +24,10 @@ export class AuthRepository {
     private readonly clock: ClockService,
   ) {}
 
-  /**
-   * provider + subject로 AccountIdentity를 조회한다(soft-delete 제외).
-   *
-   * @param provider provider
-   * @param providerSubject subject
-   */
   async findIdentityByProviderSubject(
     provider: IdentityProvider,
     providerSubject: string,
-  ) {
+  ): Promise<AccountIdentityWithAccount | null> {
     return this.prisma.accountIdentity.findFirst({
       where: {
         provider,
@@ -43,27 +43,13 @@ export class AuthRepository {
     });
   }
 
-  /**
-   * 이메일(verified 전제)로 기존 계정을 찾는다(soft-delete 제외).
-   *
-   * @param email email
-   */
-  async findAccountByEmail(email: string) {
+  async findAccountByEmail(email: string): Promise<AccountWithProfile | null> {
     return this.prisma.account.findFirst({
       where: { email },
       include: { user_profile: true },
     });
   }
 
-  /**
-   * Identity가 없을 때, 계정을 만들거나(또는 이메일로 기존 계정에 붙여서) Identity를 upsert 한다.
-   *
-   * 정책:
-   * - (provider, subject)로 우선 식별
-   * - 없으면 신규 계정 생성
-   *
-   * @param args 생성/연결 정보
-   */
   async upsertUserByOidcIdentity(args: {
     provider: IdentityProvider;
     providerSubject: string;
@@ -71,9 +57,8 @@ export class AuthRepository {
     emailVerified: boolean;
     providerDisplayName?: string;
     providerProfileImageUrl?: string;
-  }) {
+  }): Promise<{ account: AccountWithProfile | null }> {
     return this.prisma.$transaction(async (tx) => {
-      // 기존 Identity 조회
       const found = await tx.accountIdentity.findFirst({
         where: {
           provider: args.provider,
@@ -88,18 +73,16 @@ export class AuthRepository {
 
       const now = this.clock.now();
 
-      // 기존 Identity가 있으면 업데이트
       if (found) {
         return this.updateExistingIdentity(tx, found, args, now);
       }
 
-      // 신규 Identity 생성
       return this.createNewIdentity(tx, args, now);
     });
   }
 
   /**
-   * 기존 Identity와 연결된 계정을 업데이트한다.
+   * 기존 Identity 와 연결된 계정을 업데이트한다.
    */
   private async updateExistingIdentity(
     tx: Parameters<Parameters<typeof this.prisma.$transaction>[0]>[0],
@@ -120,7 +103,6 @@ export class AuthRepository {
     },
     now: Date,
   ) {
-    // Identity 정보 업데이트
     await tx.accountIdentity.update({
       where: { id: found.id },
       data: {
@@ -132,7 +114,7 @@ export class AuthRepository {
       },
     });
 
-    // account email/name은 null일 때만 채움(변경 불가 정책)
+    // account email/name 은 null 일 때만 채움(변경 불가 정책)
     await tx.account.update({
       where: { id: found.account_id },
       data: {
@@ -141,7 +123,6 @@ export class AuthRepository {
       },
     });
 
-    // profile이 없으면 최소 nickname으로 생성
     if (!found.account.user_profile) {
       await this.createUserProfile(
         tx,
@@ -161,7 +142,7 @@ export class AuthRepository {
   }
 
   /**
-   * 신규 Identity를 생성하고 계정에 연결한다.
+   * 신규 Identity 를 생성하고 계정에 연결한다.
    */
   private async createNewIdentity(
     tx: Parameters<Parameters<typeof this.prisma.$transaction>[0]>[0],
@@ -175,7 +156,6 @@ export class AuthRepository {
     },
     now: Date,
   ) {
-    // 신규 계정을 생성한다.
     const accountId = await this.createNewAccount(
       tx,
       args.providerEmail,
@@ -184,7 +164,6 @@ export class AuthRepository {
       args.providerProfileImageUrl,
     );
 
-    // Identity 생성
     await tx.accountIdentity.create({
       data: {
         account_id: accountId,
@@ -236,7 +215,7 @@ export class AuthRepository {
   }
 
   /**
-   * UserProfile을 생성한다.
+   * UserProfile 을 생성한다.
    */
   private async createUserProfile(
     tx: Parameters<Parameters<typeof this.prisma.$transaction>[0]>[0],
@@ -257,12 +236,7 @@ export class AuthRepository {
     });
   }
 
-  /**
-   * access token 검증용으로 계정을 조회한다.
-   *
-   * @param accountId account id
-   */
-  async findAccountForJwt(accountId: bigint) {
+  async findAccountForJwt(accountId: bigint): Promise<AccountForJwt | null> {
     return this.prisma.account.findFirst({
       where: { id: accountId },
       select: {
@@ -273,108 +247,12 @@ export class AuthRepository {
     });
   }
 
-  /**
-   * accountId 기준으로 유저를 조회한다(soft-delete 제외).
-   *
-   * @param accountId account id
-   */
-  async findAccountForMe(accountId: bigint) {
+  async findAccountForMe(
+    accountId: bigint,
+  ): Promise<AccountWithProfile | null> {
     return this.prisma.account.findFirst({
       where: { id: accountId },
       include: { user_profile: true },
-    });
-  }
-
-  /**
-   * username 기준 판매자 자격정보를 조회한다.
-   *
-   * @param username 판매자 username
-   */
-  async findSellerCredentialByUsername(username: string) {
-    return this.prisma.sellerCredential.findFirst({
-      where: { username },
-      include: {
-        seller_account: {
-          select: {
-            id: true,
-            account_type: true,
-            status: true,
-            store: {
-              select: {
-                id: true,
-              },
-            },
-          },
-        },
-      },
-    });
-  }
-
-  /**
-   * 계정 ID 기준 판매자 자격정보를 조회한다.
-   *
-   * @param accountId account id
-   */
-  async findSellerCredentialByAccountId(accountId: bigint) {
-    return this.prisma.sellerCredential.findFirst({
-      where: {
-        seller_account_id: accountId,
-      },
-      include: {
-        seller_account: {
-          select: {
-            id: true,
-            account_type: true,
-            status: true,
-            store: {
-              select: {
-                id: true,
-              },
-            },
-          },
-        },
-      },
-    });
-  }
-
-  /**
-   * 판매자 최근 로그인 시각을 갱신한다.
-   *
-   * @param sellerAccountId seller account id
-   * @param now 기준 시각
-   */
-  async updateSellerLastLogin(
-    sellerAccountId: bigint,
-    now: Date,
-  ): Promise<void> {
-    await this.prisma.sellerCredential.update({
-      where: { seller_account_id: sellerAccountId },
-      data: {
-        last_login_at: now,
-        updated_at: now,
-      },
-    });
-  }
-
-  /**
-   * 판매자 비밀번호 해시를 갱신한다.
-   *
-   * @param sellerAccountId seller account id
-   * @param passwordHash 새 비밀번호 해시
-   * @param now 기준 시각
-   */
-  async updateSellerPasswordHash(args: {
-    sellerAccountId: bigint;
-    passwordHash: string;
-    now: Date;
-  }): Promise<void> {
-    await this.prisma.sellerCredential.update({
-      where: { seller_account_id: args.sellerAccountId },
-      data: {
-        password_hash: args.passwordHash,
-        password_updated_at: args.now,
-        updated_at: args.now,
-      },
     });
   }
 }

--- a/src/features/auth/repositories/seller-credential.repository.interface.ts
+++ b/src/features/auth/repositories/seller-credential.repository.interface.ts
@@ -1,0 +1,59 @@
+import type { Prisma } from '@prisma/client';
+
+/**
+ * SellerCredential Repository 토큰 (Nest DI 주입용).
+ */
+export const SELLER_CREDENTIAL_REPOSITORY = Symbol(
+  'SELLER_CREDENTIAL_REPOSITORY',
+);
+
+/**
+ * 로그인/refresh/비밀번호 변경 흐름에서 사용하는 SellerCredential 페이로드.
+ */
+export type SellerCredentialWithAccount = Prisma.SellerCredentialGetPayload<{
+  include: {
+    seller_account: {
+      select: {
+        id: true;
+        account_type: true;
+        status: true;
+        store: { select: { id: true } };
+      };
+    };
+  };
+}>;
+
+/**
+ * SellerCredential Repository 인터페이스.
+ *
+ * 판매자 자격정보(username/password_hash/last_login_at) 의 read/write 를 담당한다.
+ */
+export interface ISellerCredentialRepository {
+  /**
+   * username 기준 판매자 자격정보를 조회한다.
+   */
+  findSellerCredentialByUsername(
+    username: string,
+  ): Promise<SellerCredentialWithAccount | null>;
+
+  /**
+   * 계정 ID 기준 판매자 자격정보를 조회한다.
+   */
+  findSellerCredentialByAccountId(
+    accountId: bigint,
+  ): Promise<SellerCredentialWithAccount | null>;
+
+  /**
+   * 판매자 최근 로그인 시각을 갱신한다.
+   */
+  updateSellerLastLogin(sellerAccountId: bigint, now: Date): Promise<void>;
+
+  /**
+   * 판매자 비밀번호 해시를 갱신한다.
+   */
+  updateSellerPasswordHash(args: {
+    sellerAccountId: bigint;
+    passwordHash: string;
+    now: Date;
+  }): Promise<void>;
+}

--- a/src/features/auth/repositories/seller-credential.repository.spec.ts
+++ b/src/features/auth/repositories/seller-credential.repository.spec.ts
@@ -1,0 +1,112 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { SellerCredentialRepository } from '@/features/auth/repositories/seller-credential.repository';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createAccount, createSellerCredential } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('SellerCredentialRepository (real DB)', () => {
+  let repo: SellerCredentialRepository;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [SellerCredentialRepository],
+    });
+    repo = module.get(SellerCredentialRepository);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  describe('findSellerCredentialByUsername', () => {
+    it('username으로 판매자 자격정보를 조회한다', async () => {
+      const sellerAccount = await createAccount(prisma, {
+        account_type: 'SELLER',
+      });
+      await createSellerCredential(prisma, {
+        seller_account_id: sellerAccount.id,
+        username: 'test_seller',
+      });
+
+      const found = await repo.findSellerCredentialByUsername('test_seller');
+
+      expect(found).not.toBeNull();
+      expect(found!.username).toBe('test_seller');
+      expect(found!.seller_account.id).toBe(sellerAccount.id);
+    });
+
+    it('존재하지 않는 username이면 null', async () => {
+      const found = await repo.findSellerCredentialByUsername('nonexistent');
+      expect(found).toBeNull();
+    });
+  });
+
+  describe('findSellerCredentialByAccountId', () => {
+    it('accountId로 판매자 자격정보를 조회한다', async () => {
+      const sellerAccount = await createAccount(prisma, {
+        account_type: 'SELLER',
+      });
+      await createSellerCredential(prisma, {
+        seller_account_id: sellerAccount.id,
+      });
+
+      const found = await repo.findSellerCredentialByAccountId(
+        sellerAccount.id,
+      );
+
+      expect(found).not.toBeNull();
+      expect(found!.seller_account_id).toBe(sellerAccount.id);
+    });
+  });
+
+  describe('updateSellerLastLogin', () => {
+    it('최근 로그인 시각을 갱신한다', async () => {
+      const sellerAccount = await createAccount(prisma, {
+        account_type: 'SELLER',
+      });
+      await createSellerCredential(prisma, {
+        seller_account_id: sellerAccount.id,
+      });
+
+      const now = new Date();
+      await repo.updateSellerLastLogin(sellerAccount.id, now);
+
+      const updated = await prisma.sellerCredential.findUnique({
+        where: { seller_account_id: sellerAccount.id },
+      });
+      expect(updated!.last_login_at!.getTime()).toBe(now.getTime());
+    });
+  });
+
+  describe('updateSellerPasswordHash', () => {
+    it('비밀번호 해시를 갱신한다', async () => {
+      const sellerAccount = await createAccount(prisma, {
+        account_type: 'SELLER',
+      });
+      await createSellerCredential(prisma, {
+        seller_account_id: sellerAccount.id,
+      });
+
+      const now = new Date();
+      await repo.updateSellerPasswordHash({
+        sellerAccountId: sellerAccount.id,
+        passwordHash: 'new_hash_value',
+        now,
+      });
+
+      const updated = await prisma.sellerCredential.findUnique({
+        where: { seller_account_id: sellerAccount.id },
+      });
+      expect(updated!.password_hash).toBe('new_hash_value');
+    });
+  });
+});

--- a/src/features/auth/repositories/seller-credential.repository.ts
+++ b/src/features/auth/repositories/seller-credential.repository.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@nestjs/common';
+
+import type {
+  ISellerCredentialRepository,
+  SellerCredentialWithAccount,
+} from '@/features/auth/repositories/seller-credential.repository.interface';
+import { PrismaService } from '@/prisma';
+
+/**
+ * SellerCredential Repository 구체 구현.
+ */
+@Injectable()
+export class SellerCredentialRepository implements ISellerCredentialRepository {
+  /**
+   * @param prisma PrismaService
+   */
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findSellerCredentialByUsername(
+    username: string,
+  ): Promise<SellerCredentialWithAccount | null> {
+    return this.prisma.sellerCredential.findFirst({
+      where: { username },
+      include: {
+        seller_account: {
+          select: {
+            id: true,
+            account_type: true,
+            status: true,
+            store: {
+              select: {
+                id: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  async findSellerCredentialByAccountId(
+    accountId: bigint,
+  ): Promise<SellerCredentialWithAccount | null> {
+    return this.prisma.sellerCredential.findFirst({
+      where: {
+        seller_account_id: accountId,
+      },
+      include: {
+        seller_account: {
+          select: {
+            id: true,
+            account_type: true,
+            status: true,
+            store: {
+              select: {
+                id: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  async updateSellerLastLogin(
+    sellerAccountId: bigint,
+    now: Date,
+  ): Promise<void> {
+    await this.prisma.sellerCredential.update({
+      where: { seller_account_id: sellerAccountId },
+      data: {
+        last_login_at: now,
+        updated_at: now,
+      },
+    });
+  }
+
+  async updateSellerPasswordHash(args: {
+    sellerAccountId: bigint;
+    passwordHash: string;
+    now: Date;
+  }): Promise<void> {
+    await this.prisma.sellerCredential.update({
+      where: { seller_account_id: args.sellerAccountId },
+      data: {
+        password_hash: args.passwordHash,
+        password_updated_at: args.now,
+        updated_at: args.now,
+      },
+    });
+  }
+}

--- a/src/features/auth/strategies/jwt-bearer.strategy.spec.ts
+++ b/src/features/auth/strategies/jwt-bearer.strategy.spec.ts
@@ -2,7 +2,8 @@ import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
-import { AuthRepository } from '@/features/auth/repositories/auth.repository';
+import { AccountRepository } from '@/features/auth/repositories/account.repository';
+import { ACCOUNT_REPOSITORY } from '@/features/auth/repositories/account.repository.interface';
 import { JwtBearerStrategy } from '@/features/auth/strategies/jwt-bearer.strategy';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
@@ -16,18 +17,21 @@ describe('JwtBearerStrategy (real DB)', () => {
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
       providers: [
-        AuthRepository,
         ClockService,
         {
+          provide: ACCOUNT_REPOSITORY,
+          useClass: AccountRepository,
+        },
+        {
           provide: JwtBearerStrategy,
-          useFactory: (repo: AuthRepository) => {
-            // Passport Strategy는 생성자에서 super()를 호출하므로 직접 생성
-            // validate 메서드만 테스트하기 위해 prototype에서 추출
+          useFactory: (accounts: AccountRepository) => {
+            // Passport Strategy 는 생성자에서 super() 를 호출하므로 직접 생성.
+            // validate 메서드만 테스트하기 위해 prototype 에서 추출.
             const instance = Object.create(JwtBearerStrategy.prototype);
-            instance.repo = repo;
+            instance.accounts = accounts;
             return instance;
           },
-          inject: [AuthRepository],
+          inject: [ACCOUNT_REPOSITORY],
         },
       ],
     });
@@ -129,16 +133,16 @@ describe('JwtBearerStrategy (real DB)', () => {
      */
     it('JWT_ACCESS_SECRET 미설정이면 Error', () => {
       const config = { get: () => undefined } as never;
-      const repo = {} as never;
-      expect(() => new JwtBearerStrategy(config, repo)).toThrow(
+      const accounts = {} as never;
+      expect(() => new JwtBearerStrategy(config, accounts)).toThrow(
         'Missing JWT_ACCESS_SECRET',
       );
     });
 
     it('JWT_ACCESS_SECRET이 공백 문자열이면 Error', () => {
       const config = { get: () => '   ' } as never;
-      const repo = {} as never;
-      expect(() => new JwtBearerStrategy(config, repo)).toThrow(
+      const accounts = {} as never;
+      expect(() => new JwtBearerStrategy(config, accounts)).toThrow(
         'Missing JWT_ACCESS_SECRET',
       );
     });

--- a/src/features/auth/strategies/jwt-bearer.strategy.ts
+++ b/src/features/auth/strategies/jwt-bearer.strategy.ts
@@ -1,5 +1,6 @@
 import {
   ForbiddenException,
+  Inject,
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -7,7 +8,10 @@ import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
-import { AuthRepository } from '@/features/auth/repositories/auth.repository';
+import {
+  ACCOUNT_REPOSITORY,
+  type IAccountRepository,
+} from '@/features/auth/repositories/account.repository.interface';
 import type { AccessTokenPayload, JwtUser } from '@/global/auth';
 
 /**
@@ -17,11 +21,12 @@ import type { AccessTokenPayload, JwtUser } from '@/global/auth';
 export class JwtBearerStrategy extends PassportStrategy(Strategy, 'jwt') {
   /**
    * @param config ConfigService
-   * @param repo AuthRepository
+   * @param accounts AccountRepository
    */
   constructor(
     config: ConfigService,
-    private readonly repo: AuthRepository,
+    @Inject(ACCOUNT_REPOSITORY)
+    private readonly accounts: IAccountRepository,
   ) {
     const secret = config.get<string>('JWT_ACCESS_SECRET');
     if (!secret || secret.trim().length === 0) {
@@ -55,7 +60,7 @@ export class JwtBearerStrategy extends PassportStrategy(Strategy, 'jwt') {
       throw new UnauthorizedException('Invalid access token.');
     }
 
-    const account = await this.repo.findAccountForJwt(accountId);
+    const account = await this.accounts.findAccountForJwt(accountId);
 
     // 존재하지 않거나 deleted_at이 찍힌 경우
     if (!account) {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -6,7 +6,7 @@ import request from 'supertest';
 import { App } from 'supertest/types';
 
 import { AppModule } from './../src/app.module';
-import { AuthRepository } from './../src/features/auth/repositories/auth.repository';
+import { ACCOUNT_REPOSITORY } from './../src/features/auth/repositories/account.repository.interface';
 import { UserRepository } from './../src/features/user/repositories/user.repository';
 import { PrismaService } from './../src/prisma';
 
@@ -14,10 +14,11 @@ describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
   let jwt: JwtService;
   let originalJwtSecret: string | undefined;
-  const mockAuthRepository = {
+  const mockAccountRepository = {
     findAccountForJwt: jest.fn().mockResolvedValue({
       id: BigInt(1),
       status: 'ACTIVE',
+      account_type: AccountType.USER,
     }),
   };
   const mockUserRepository = {
@@ -51,8 +52,8 @@ describe('AppController (e2e)', () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     })
-      .overrideProvider(AuthRepository)
-      .useValue(mockAuthRepository)
+      .overrideProvider(ACCOUNT_REPOSITORY)
+      .useValue(mockAccountRepository)
       .overrideProvider(UserRepository)
       .useValue(mockUserRepository)
       .overrideProvider(PrismaService)


### PR DESCRIPTION
## Summary

- AuthRepository 의 잔여 책임을 **2 개 도메인 Repository 로 분리**하고 빈 AuthRepository 자체를 제거.
- 단계 1·2 (RefreshSession / AuditLog) 와 합쳐, God-class 530 줄을 4 개의 책임별 Repository 로 모두 해체.
- 모든 신규 Repository 는 interface + Symbol DI Token 패턴 (P1-1 방침 일관).

## Scope

- **신규**
  - AccountRepository (interface + impl + spec) — Account / AccountIdentity / UserProfile 의 read/write
    - findIdentityByProviderSubject, findAccountByEmail, upsertUserByOidcIdentity,
      findAccountForJwt, findAccountForMe
    - 인터페이스 반환 타입은 \`Prisma.{Model}GetPayload<...>\` 로 명시
  - SellerCredentialRepository (interface + impl + spec) — username / password_hash / last_login_at write
    - findSellerCredentialByUsername, findSellerCredentialByAccountId,
      updateSellerLastLogin, updateSellerPasswordHash
- **제거**
  - AuthRepository (530줄) + 해당 spec
- **변경**
  - AuthService: \`accounts\` / \`sellerCredentials\` 2 개 신규 의존, \`this.repo.*\` 호출 8 개 전환
  - JwtBearerStrategy: \`accounts\` 의존으로 전환
  - AuthModule: 신규 2 개 Repository 를 DI Token 패턴으로 등록
  - 영향 받은 모든 spec 동반 갱신 (auth.service / auth.seller / jwt-bearer / app.e2e)

## P0-1 진행 상황

- ✅ 단계 1: RefreshSessionRepository
- ✅ 단계 2: AuditLogRepository (신규 audit-log 모듈)
- ✅ 단계 3: AccountRepository / SellerCredentialRepository **(본 PR)**
- ⏳ 단계 4: TokenService 추출
- ⏳ 단계 5: OidcLoginService 추출
- ⏳ 단계 6: SellerCredentialService + logout 통합
- ⏳ 단계 7: AuthService 잔여 정리

## Impact

- FE: 없음 (REST 엔드포인트·응답·에러 형태 동일)
- DB: 변경 없음
- Coverage: 1168 tests pass, 전 임계 통과

## Test plan

- [x] yarn validate (lint + tsc + dto:check + test:cov) 로컬 통과
- [x] account.repository.spec.ts / seller-credential.repository.spec.ts 신규 통합 테스트
- [x] auth.service / auth.seller.service / jwt-bearer.strategy / app.e2e 모두 회귀 없음
- [ ] CI 통과 확인