### PR TITLE
refactor(auth): TokenService 추출 (P0-1 단계 4)

### DIFF
--- a/src/features/auth/auth.module.ts
+++ b/src/features/auth/auth.module.ts
@@ -10,6 +10,8 @@ import { REFRESH_SESSION_REPOSITORY } from '@/features/auth/repositories/refresh
 import { SellerCredentialRepository } from '@/features/auth/repositories/seller-credential.repository';
 import { SELLER_CREDENTIAL_REPOSITORY } from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
+import { TokenService } from '@/features/auth/services/token.service';
+import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
 import { JwtBearerStrategy } from '@/features/auth/strategies/jwt-bearer.strategy';
 import { AuthGlobalModule } from '@/global/auth/auth-global.module';
 
@@ -25,6 +27,10 @@ import { AuthGlobalModule } from '@/global/auth/auth-global.module';
   providers: [
     AuthService,
     OidcClientService,
+    {
+      provide: TOKEN_SERVICE,
+      useClass: TokenService,
+    },
     {
       provide: ACCOUNT_REPOSITORY,
       useClass: AccountRepository,

--- a/src/features/auth/auth.seller.service.spec.ts
+++ b/src/features/auth/auth.seller.service.spec.ts
@@ -29,6 +29,8 @@ import {
   type ISellerCredentialRepository,
 } from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
+import { TokenService } from '@/features/auth/services/token.service';
+import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
 
 describe('AuthService (seller)', () => {
   let service: AuthService;
@@ -90,6 +92,10 @@ describe('AuthService (seller)', () => {
           useValue: { sign: jest.fn(() => 'mock-access-token') },
         },
         { provide: OidcClientService, useValue: {} },
+        {
+          provide: TOKEN_SERVICE,
+          useClass: TokenService,
+        },
         {
           provide: ACCOUNT_REPOSITORY,
           useValue: accounts,

--- a/src/features/auth/auth.service.spec.ts
+++ b/src/features/auth/auth.service.spec.ts
@@ -27,6 +27,8 @@ import {
   type ISellerCredentialRepository,
 } from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
+import { TokenService } from '@/features/auth/services/token.service';
+import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
 import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
 
 describe('AuthService', () => {
@@ -87,6 +89,10 @@ describe('AuthService', () => {
         { provide: ConfigService, useValue: mockConfig },
         { provide: JwtService, useValue: mockJwt },
         { provide: OidcClientService, useValue: mockOidc },
+        {
+          provide: TOKEN_SERVICE,
+          useClass: TokenService,
+        },
         {
           provide: ACCOUNT_REPOSITORY,
           useValue: mockAccounts,

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -1,5 +1,3 @@
-import { createHash, randomBytes } from 'node:crypto';
-
 import {
   BadRequestException,
   ForbiddenException,
@@ -9,7 +7,6 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { JwtService } from '@nestjs/jwt';
 import {
   AccountType,
   AuditActionType,
@@ -19,20 +16,18 @@ import {
 import argon2 from 'argon2';
 import type { Request, Response } from 'express';
 
-import {
-  getEnvAsBoolean,
-  getEnvAsNumber,
-} from '@/common/helpers/config.helper';
 import { ClockService } from '@/common/providers/clock.service';
 import {
   AUDIT_LOG_REPOSITORY,
   type IAuditLogRepository,
 } from '@/features/audit-log';
 import { ALLOWED_RETURN_TO_DOMAINS } from '@/features/auth/constants/auth.constants';
+import { AuthCookieOptions } from '@/features/auth/helpers/auth-cookie-options.helper';
+import { AuthCookie } from '@/features/auth/helpers/auth-cookie.helper';
 import {
-  AuthCookie,
-  type CookieSameSite,
-} from '@/features/auth/helpers/auth-cookie.helper';
+  getIp,
+  getUserAgent,
+} from '@/features/auth/helpers/auth-request-meta.helper';
 import {
   ACCOUNT_REPOSITORY,
   type IAccountRepository,
@@ -47,11 +42,14 @@ import {
 } from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 import {
+  TOKEN_SERVICE,
+  type ITokenService,
+} from '@/features/auth/services/token.service.interface';
+import {
   parseOidcProvider,
   type OidcProvider,
 } from '@/features/auth/types/oidc-provider.type';
 import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
-import type { AccessTokenPayload } from '@/global/auth/types/jwt-payload.type';
 
 /**
  * 인증/로그인/토큰 발급/갱신 비즈니스 로직
@@ -60,8 +58,8 @@ import type { AccessTokenPayload } from '@/global/auth/types/jwt-payload.type';
 export class AuthService {
   /**
    * @param config ConfigService
-   * @param jwt JwtService
    * @param oidc OidcClientService
+   * @param tokens TokenService
    * @param accounts AccountRepository
    * @param sellerCredentials SellerCredentialRepository
    * @param refreshSessions RefreshSessionRepository
@@ -70,8 +68,9 @@ export class AuthService {
    */
   constructor(
     private readonly config: ConfigService,
-    private readonly jwt: JwtService,
     private readonly oidc: OidcClientService,
+    @Inject(TOKEN_SERVICE)
+    private readonly tokens: ITokenService,
     @Inject(ACCOUNT_REPOSITORY)
     private readonly accounts: IAccountRepository,
     @Inject(SELLER_CREDENTIAL_REPOSITORY)
@@ -106,9 +105,9 @@ export class AuthService {
       nonce,
       codeVerifier,
       returnTo: safeReturnTo,
-      cookieDomain: this.getCookieDomain(),
-      secure: this.isCookieSecure(),
-      sameSite: this.getCookieSameSite(),
+      cookieDomain: AuthCookieOptions.getCookieDomain(this.config),
+      secure: AuthCookieOptions.isCookieSecure(this.config),
+      sameSite: AuthCookieOptions.getCookieSameSite(this.config),
     });
 
     return { redirectUrl: authorizationUrl };
@@ -152,7 +151,7 @@ export class AuthService {
     const account = await this.upsertAccountFromOidc(provider, userInfo);
 
     // 5. refresh 쿠키 발급 + access token 생성
-    const { accessToken } = await this.issueAuthTokens({
+    const { accessToken } = await this.tokens.issueAuthTokens({
       accountId: account.id,
       req,
       res,
@@ -161,9 +160,9 @@ export class AuthService {
     // 6. OIDC 임시 쿠키 삭제
     AuthCookie.clearOidcTempCookies(
       res,
-      this.getCookieDomain(),
-      this.isCookieSecure(),
-      this.getCookieSameSite(),
+      AuthCookieOptions.getCookieDomain(this.config),
+      AuthCookieOptions.isCookieSecure(this.config),
+      AuthCookieOptions.getCookieSameSite(this.config),
     );
 
     return { returnTo, accessToken };
@@ -213,7 +212,7 @@ export class AuthService {
       now,
     );
 
-    const { accessToken } = await this.issueAuthTokens({
+    const { accessToken } = await this.tokens.issueAuthTokens({
       accountId: credential.seller_account_id,
       req: args.req,
       res: args.res,
@@ -232,7 +231,7 @@ export class AuthService {
    * @param res Response
    */
   async refresh(req: Request, res: Response): Promise<{ accessToken: string }> {
-    const { accessToken } = await this.rotateRefresh(req, res);
+    const { accessToken } = await this.tokens.rotateRefresh(req, res);
     return { accessToken };
   }
 
@@ -259,11 +258,11 @@ export class AuthService {
       throw new ForbiddenException('Account is not active.');
     }
 
-    const accessToken = this.signAccessToken(accountId);
+    const accessToken = this.tokens.signAccessToken(accountId);
     return {
       accessToken,
       tokenType: 'Bearer',
-      expiresInSeconds: this.getAccessExpiresSeconds(),
+      expiresInSeconds: this.tokens.getAccessExpiresSeconds(),
     };
   }
 
@@ -277,7 +276,10 @@ export class AuthService {
     req: Request,
     res: Response,
   ): Promise<{ accessToken: string; accountStatus: AccountStatus }> {
-    const { accessToken, accountId } = await this.rotateRefresh(req, res);
+    const { accessToken, accountId } = await this.tokens.rotateRefresh(
+      req,
+      res,
+    );
     const seller =
       await this.sellerCredentials.findSellerCredentialByAccountId(accountId);
     if (!seller || seller.seller_account.account_type !== AccountType.SELLER) {
@@ -304,7 +306,7 @@ export class AuthService {
     if (!refreshToken)
       throw new UnauthorizedException('Missing refresh token.');
 
-    const tokenHash = this.sha256Hex(refreshToken);
+    const tokenHash = this.tokens.sha256Hex(refreshToken);
     const session =
       await this.refreshSessions.findActiveRefreshSessionByHash(tokenHash);
     if (!session) throw new UnauthorizedException('Invalid refresh token.');
@@ -318,12 +320,7 @@ export class AuthService {
 
     await this.refreshSessions.revokeRefreshSession(session.id);
 
-    AuthCookie.clearRefreshCookie(
-      res,
-      this.getCookieDomain(),
-      this.isCookieSecure(),
-      this.getCookieSameSite(),
-    );
+    this.tokens.clearRefreshCookie(res);
   }
 
   /**
@@ -340,18 +337,13 @@ export class AuthService {
       | undefined;
 
     if (refreshToken) {
-      const tokenHash = this.sha256Hex(refreshToken);
+      const tokenHash = this.tokens.sha256Hex(refreshToken);
       const session =
         await this.refreshSessions.findActiveRefreshSessionByHash(tokenHash);
       if (session) await this.refreshSessions.revokeRefreshSession(session.id);
     }
 
-    AuthCookie.clearRefreshCookie(
-      res,
-      this.getCookieDomain(),
-      this.isCookieSecure(),
-      this.getCookieSameSite(),
-    );
+    this.tokens.clearRefreshCookie(res);
   }
 
   /**
@@ -415,8 +407,8 @@ export class AuthService {
       afterJson: {
         changedAt: now.toISOString(),
       },
-      ipAddress: this.getIp(args.req),
-      userAgent: this.getUserAgent(args.req),
+      ipAddress: getIp(args.req),
+      userAgent: getUserAgent(args.req),
     });
   }
 
@@ -630,202 +622,5 @@ export class AuthService {
       'http://localhost:4000';
 
     return `${backendBase}/auth/oidc/${provider}/callback`;
-  }
-
-  /**
-   * refresh 토큰을 회전하고 access token을 재발급한다.
-   *
-   * @param req Request
-   * @param res Response
-   */
-  private async rotateRefresh(
-    req: Request,
-    res: Response,
-  ): Promise<{ accessToken: string; accountId: bigint }> {
-    const refreshToken = req.cookies?.[AUTH_COOKIE.REFRESH] as
-      | string
-      | undefined;
-
-    if (!refreshToken) {
-      throw new UnauthorizedException('Missing refresh token.');
-    }
-
-    const tokenHash = this.sha256Hex(refreshToken);
-    const session =
-      await this.refreshSessions.findActiveRefreshSessionByHash(tokenHash);
-    if (!session) throw new UnauthorizedException('Invalid refresh token.');
-
-    const newRefreshToken = this.generateRefreshToken();
-    const newTokenHash = this.sha256Hex(newRefreshToken);
-
-    const refreshDays = this.getRefreshDays();
-    const newExpiresAt = new Date(Date.now() + refreshDays * 86400 * 1000);
-
-    await this.refreshSessions.rotateRefreshSession({
-      currentSessionId: session.id,
-      accountId: session.account_id,
-      newTokenHash,
-      userAgent: this.getUserAgent(req),
-      ipAddress: this.getIp(req),
-      newExpiresAt,
-    });
-
-    const accessToken = this.signAccessToken(session.account_id);
-
-    AuthCookie.setRefreshCookie(res, {
-      refreshToken: newRefreshToken,
-      refreshMaxAgeMs: refreshDays * 86400 * 1000,
-      cookieDomain: this.getCookieDomain(),
-      secure: this.isCookieSecure(),
-      sameSite: this.getCookieSameSite(),
-    });
-
-    return {
-      accessToken,
-      accountId: session.account_id,
-    };
-  }
-
-  /**
-   * access token을 서명한다.
-   *
-   * @param accountId account id
-   */
-  private signAccessToken(accountId: bigint): string {
-    const now = Math.floor(Date.now() / 1000);
-    const exp = now + this.getAccessExpiresSeconds();
-
-    const payload: AccessTokenPayload = {
-      sub: accountId.toString(),
-      typ: 'access',
-      iat: now,
-      exp,
-    };
-
-    return this.jwt.sign(payload);
-  }
-
-  /**
-   * refresh 쿠키를 발급하고 refresh 세션을 저장한다.
-   *
-   * @param args 발급 파라미터
-   */
-  private async issueAuthTokens(args: {
-    accountId: bigint;
-    req: Request;
-    res: Response;
-  }): Promise<{ accessToken: string }> {
-    const accessToken = this.signAccessToken(args.accountId);
-
-    const refreshToken = this.generateRefreshToken();
-    const refreshHash = this.sha256Hex(refreshToken);
-
-    const refreshDays = this.getRefreshDays();
-    const expiresAt = new Date(Date.now() + refreshDays * 86400 * 1000);
-
-    await this.refreshSessions.createRefreshSession({
-      accountId: args.accountId,
-      tokenHash: refreshHash,
-      userAgent: this.getUserAgent(args.req),
-      ipAddress: this.getIp(args.req),
-      expiresAt,
-    });
-
-    AuthCookie.setRefreshCookie(args.res, {
-      refreshToken,
-      refreshMaxAgeMs: refreshDays * 86400 * 1000,
-      cookieDomain: this.getCookieDomain(),
-      secure: this.isCookieSecure(),
-      sameSite: this.getCookieSameSite(),
-    });
-
-    return { accessToken };
-  }
-
-  /**
-   * refresh token 랜덤 문자열을 생성한다.
-   */
-  private generateRefreshToken(): string {
-    // 32 bytes -> 64 hex
-    return randomBytes(32).toString('hex');
-  }
-
-  /**
-   * sha256 hex를 만든다.
-   *
-   * @param raw raw string
-   */
-  private sha256Hex(raw: string): string {
-    return createHash('sha256').update(raw).digest('hex');
-  }
-
-  /**
-   * Access Token 만료(초)를 반환한다.
-   */
-  private getAccessExpiresSeconds(): number {
-    return getEnvAsNumber(this.config, 'JWT_ACCESS_EXPIRES_SECONDS', 900);
-  }
-
-  /**
-   * Refresh 만료(일)를 반환한다.
-   */
-  private getRefreshDays(): number {
-    return getEnvAsNumber(this.config, 'AUTH_REFRESH_EXPIRES_DAYS', 30);
-  }
-
-  /**
-   * 쿠키 도메인을 반환한다.
-   */
-  private getCookieDomain(): string | undefined {
-    const v = this.config.get<string>('AUTH_COOKIE_DOMAIN');
-    const trimmed = v?.trim();
-    return trimmed && trimmed.length > 0 ? trimmed : undefined;
-  }
-
-  /**
-   * 쿠키 secure 옵션을 반환한다.
-   */
-  private isCookieSecure(): boolean {
-    const envValue = this.config.get<string>('AUTH_COOKIE_SECURE');
-    if (envValue !== undefined) {
-      return getEnvAsBoolean(this.config, 'AUTH_COOKIE_SECURE', false);
-    }
-    // 기본값: production이면 true
-    return (this.config.get<string>('NODE_ENV') ?? '') === 'production';
-  }
-
-  /**
-   * 쿠키 sameSite 옵션을 반환한다.
-   * 환경변수 AUTH_COOKIE_SAMESITE로 설정 가능 (lax | strict | none).
-   * 기본값: 'lax'
-   */
-  private getCookieSameSite(): CookieSameSite {
-    const v = this.config
-      .get<string>('AUTH_COOKIE_SAMESITE')
-      ?.trim()
-      .toLowerCase();
-    if (v === 'none' || v === 'strict' || v === 'lax') {
-      return v;
-    }
-    return 'lax';
-  }
-
-  /**
-   * Request에서 user-agent를 추출한다.
-   *
-   * @param req Request
-   */
-  private getUserAgent(req: Request): string | undefined {
-    const ua = req.headers['user-agent'];
-    return typeof ua === 'string' ? ua.slice(0, 512) : undefined;
-  }
-
-  /**
-   * Request에서 IP를 추출한다.
-   *
-   * @param req Request
-   */
-  private getIp(req: Request): string | undefined {
-    return typeof req.ip === 'string' ? req.ip : undefined;
   }
 }

--- a/src/features/auth/helpers/auth-cookie-options.helper.ts
+++ b/src/features/auth/helpers/auth-cookie-options.helper.ts
@@ -1,0 +1,46 @@
+import type { ConfigService } from '@nestjs/config';
+
+import { getEnvAsBoolean } from '@/common/helpers/config.helper';
+import type { CookieSameSite } from '@/features/auth/helpers/auth-cookie.helper';
+
+/**
+ * Auth 쿠키 옵션 (domain / secure / sameSite) 을 ConfigService 에서 읽어주는 헬퍼.
+ *
+ * Token / OIDC / Logout 등 여러 서비스가 동일 옵션을 사용하므로 한곳에 모은다.
+ * 자체 DI 금지 (CLAUDE.md common/helpers 규칙과 동일 패턴).
+ */
+export class AuthCookieOptions {
+  /**
+   * 쿠키 도메인을 반환한다.
+   */
+  static getCookieDomain(config: ConfigService): string | undefined {
+    const v = config.get<string>('AUTH_COOKIE_DOMAIN');
+    const trimmed = v?.trim();
+    return trimmed && trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  /**
+   * 쿠키 secure 옵션을 반환한다.
+   *
+   * 기본값: NODE_ENV === 'production' 이면 true.
+   */
+  static isCookieSecure(config: ConfigService): boolean {
+    const envValue = config.get<string>('AUTH_COOKIE_SECURE');
+    if (envValue !== undefined) {
+      return getEnvAsBoolean(config, 'AUTH_COOKIE_SECURE', false);
+    }
+    return (config.get<string>('NODE_ENV') ?? '') === 'production';
+  }
+
+  /**
+   * 쿠키 sameSite 옵션을 반환한다.
+   * AUTH_COOKIE_SAMESITE (lax | strict | none) 으로 override 가능. 기본값 'lax'.
+   */
+  static getCookieSameSite(config: ConfigService): CookieSameSite {
+    const v = config.get<string>('AUTH_COOKIE_SAMESITE')?.trim().toLowerCase();
+    if (v === 'none' || v === 'strict' || v === 'lax') {
+      return v;
+    }
+    return 'lax';
+  }
+}

--- a/src/features/auth/helpers/auth-request-meta.helper.ts
+++ b/src/features/auth/helpers/auth-request-meta.helper.ts
@@ -1,0 +1,18 @@
+import type { Request } from 'express';
+
+/**
+ * Request 에서 user-agent 를 추출한다 (audit/refresh session 메타용).
+ *
+ * 길이 512 자에서 자른다.
+ */
+export function getUserAgent(req: Request): string | undefined {
+  const ua = req.headers['user-agent'];
+  return typeof ua === 'string' ? ua.slice(0, 512) : undefined;
+}
+
+/**
+ * Request 에서 IP 를 추출한다.
+ */
+export function getIp(req: Request): string | undefined {
+  return typeof req.ip === 'string' ? req.ip : undefined;
+}

--- a/src/features/auth/services/token.service.interface.ts
+++ b/src/features/auth/services/token.service.interface.ts
@@ -1,0 +1,60 @@
+import type { Request, Response } from 'express';
+
+/**
+ * Token Service 토큰 (Nest DI 주입용).
+ */
+export const TOKEN_SERVICE = Symbol('TOKEN_SERVICE');
+
+/**
+ * 인증 토큰 (access JWT + refresh) 의 발급/회전/검증/쿠키 관리를 담당하는 서비스 인터페이스.
+ *
+ * AuthService 는 비즈니스 흐름(OIDC 콜백·판매자 로그인·로그아웃 등) 에서 본 서비스를 조립해 사용한다.
+ */
+export interface ITokenService {
+  /**
+   * access token 을 서명한다.
+   */
+  signAccessToken(accountId: bigint): string;
+
+  /**
+   * Access Token 만료(초) 를 반환한다.
+   */
+  getAccessExpiresSeconds(): number;
+
+  /**
+   * Refresh session 을 생성하고 access token + refresh 쿠키를 발급한다.
+   */
+  issueAuthTokens(args: {
+    accountId: bigint;
+    req: Request;
+    res: Response;
+  }): Promise<{ accessToken: string }>;
+
+  /**
+   * refresh 쿠키를 회전한다.
+   *
+   * - 쿠키에서 refresh token 추출 → hash → 활성 세션 조회
+   * - 새 refresh token 생성 → DB 회전 + 새 쿠키 발급
+   * - 새 access token 발급
+   *
+   * @returns accessToken + accountId (Seller 검증 등 후속 로직에 사용)
+   */
+  rotateRefresh(
+    req: Request,
+    res: Response,
+  ): Promise<{ accessToken: string; accountId: bigint }>;
+
+  /**
+   * sha256 hex 해시.
+   *
+   * AuthService 의 logout 흐름에서 쿠키의 raw refresh token 을 hash 하여 세션 조회에 사용한다.
+   */
+  sha256Hex(raw: string): string;
+
+  /**
+   * refresh 쿠키를 삭제한다.
+   *
+   * 도메인/secure/sameSite 옵션을 내부에서 설정한다 (호출자는 res 만 넘김).
+   */
+  clearRefreshCookie(res: Response): void;
+}

--- a/src/features/auth/services/token.service.spec.ts
+++ b/src/features/auth/services/token.service.spec.ts
@@ -1,0 +1,200 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Test, type TestingModule } from '@nestjs/testing';
+import type { Request, Response } from 'express';
+
+import {
+  REFRESH_SESSION_REPOSITORY,
+  type IRefreshSessionRepository,
+} from '@/features/auth/repositories/refresh-session.repository.interface';
+import { TokenService } from '@/features/auth/services/token.service';
+
+describe('TokenService', () => {
+  let service: TokenService;
+  let config: jest.Mocked<ConfigService>;
+  let jwt: jest.Mocked<JwtService>;
+  let refreshSessions: jest.Mocked<IRefreshSessionRepository>;
+
+  const mockReq = {
+    headers: { 'user-agent': 'Mozilla/5.0 TokenSpec' },
+    ip: '127.0.0.1',
+    cookies: {},
+  } as unknown as Request;
+
+  const mockRes = {
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+  } as unknown as Response;
+
+  beforeEach(async () => {
+    config = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    jwt = {
+      sign: jest.fn(() => 'signed-token'),
+    } as unknown as jest.Mocked<JwtService>;
+
+    refreshSessions = {
+      createRefreshSession: jest.fn(),
+      findActiveRefreshSessionByHash: jest.fn(),
+      rotateRefreshSession: jest.fn(),
+      revokeRefreshSession: jest.fn(),
+      revokeAllRefreshSessions: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TokenService,
+        { provide: ConfigService, useValue: config },
+        { provide: JwtService, useValue: jwt },
+        {
+          provide: REFRESH_SESSION_REPOSITORY,
+          useValue: refreshSessions,
+        },
+      ],
+    }).compile();
+
+    service = module.get(TokenService);
+    (mockRes.cookie as jest.Mock).mockClear();
+    (mockRes.clearCookie as jest.Mock).mockClear();
+  });
+
+  describe('signAccessToken', () => {
+    it('payload(sub/typ/iat/exp) 로 access token 을 서명한다', () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'JWT_ACCESS_EXPIRES_SECONDS') return '900';
+        return undefined;
+      });
+
+      const result = service.signAccessToken(BigInt(42));
+
+      expect(result).toBe('signed-token');
+      expect(jwt.sign).toHaveBeenCalledTimes(1);
+      const payload = jwt.sign.mock.calls[0][0] as {
+        sub: string;
+        typ: string;
+      };
+      expect(payload.sub).toBe('42');
+      expect(payload.typ).toBe('access');
+    });
+  });
+
+  describe('getAccessExpiresSeconds', () => {
+    it('기본값 900', () => {
+      config.get.mockReturnValue(undefined);
+      expect(service.getAccessExpiresSeconds()).toBe(900);
+    });
+
+    it('env override 적용', () => {
+      config.get.mockImplementation((key: string) =>
+        key === 'JWT_ACCESS_EXPIRES_SECONDS' ? '300' : undefined,
+      );
+      expect(service.getAccessExpiresSeconds()).toBe(300);
+    });
+  });
+
+  describe('sha256Hex', () => {
+    it('알려진 입력에 대해 안정적인 hex 값을 반환한다', () => {
+      const a = service.sha256Hex('hello');
+      const b = service.sha256Hex('hello');
+      expect(a).toBe(b);
+      expect(a).toHaveLength(64);
+    });
+  });
+
+  describe('issueAuthTokens', () => {
+    it('refresh session 을 저장하고 access token + refresh 쿠키를 발급한다', async () => {
+      config.get.mockImplementation((key: string) => {
+        if (key === 'JWT_ACCESS_EXPIRES_SECONDS') return '900';
+        if (key === 'AUTH_REFRESH_EXPIRES_DAYS') return '30';
+        if (key === 'AUTH_COOKIE_DOMAIN') return undefined;
+        if (key === 'AUTH_COOKIE_SECURE') return 'false';
+        return undefined;
+      });
+
+      const result = await service.issueAuthTokens({
+        accountId: BigInt(1),
+        req: mockReq,
+        res: mockRes,
+      });
+
+      expect(result).toEqual({ accessToken: 'signed-token' });
+      expect(refreshSessions.createRefreshSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: BigInt(1),
+          userAgent: 'Mozilla/5.0 TokenSpec',
+          ipAddress: '127.0.0.1',
+        }),
+      );
+      expect(mockRes.cookie).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('rotateRefresh', () => {
+    it('refresh 쿠키가 없으면 UnauthorizedException(Missing)', async () => {
+      const reqNoCookie = { cookies: {} } as unknown as Request;
+
+      await expect(service.rotateRefresh(reqNoCookie, mockRes)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.rotateRefresh(reqNoCookie, mockRes)).rejects.toThrow(
+        'Missing refresh token.',
+      );
+    });
+
+    it('활성 세션이 없으면 UnauthorizedException(Invalid)', async () => {
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'raw-token' },
+      } as unknown as Request;
+
+      refreshSessions.findActiveRefreshSessionByHash.mockResolvedValue(null);
+
+      await expect(
+        service.rotateRefresh(reqWithCookie, mockRes),
+      ).rejects.toThrow('Invalid refresh token.');
+    });
+
+    it('정상 회전 시 새 access + accountId 를 반환하고 새 refresh 쿠키를 발급한다', async () => {
+      const reqWithCookie = {
+        cookies: { caquick_rt: 'raw-token' },
+        headers: { 'user-agent': 'ua' },
+        ip: '1.2.3.4',
+      } as unknown as Request;
+
+      config.get.mockImplementation((key: string) => {
+        if (key === 'AUTH_REFRESH_EXPIRES_DAYS') return '30';
+        if (key === 'AUTH_COOKIE_SECURE') return 'false';
+        return undefined;
+      });
+
+      refreshSessions.findActiveRefreshSessionByHash.mockResolvedValue({
+        id: BigInt(7),
+        account_id: BigInt(10),
+      } as never);
+
+      refreshSessions.rotateRefreshSession.mockResolvedValue({} as never);
+
+      const result = await service.rotateRefresh(reqWithCookie, mockRes);
+
+      expect(result.accountId).toBe(BigInt(10));
+      expect(result.accessToken).toBe('signed-token');
+      expect(refreshSessions.rotateRefreshSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentSessionId: BigInt(7),
+          accountId: BigInt(10),
+        }),
+      );
+      expect(mockRes.cookie).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearRefreshCookie', () => {
+    it('refresh 쿠키를 삭제한다', () => {
+      config.get.mockReturnValue(undefined);
+      service.clearRefreshCookie(mockRes);
+      expect(mockRes.clearCookie).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/features/auth/services/token.service.ts
+++ b/src/features/auth/services/token.service.ts
@@ -1,0 +1,166 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import type { Request, Response } from 'express';
+
+import { getEnvAsNumber } from '@/common/helpers/config.helper';
+import { AuthCookieOptions } from '@/features/auth/helpers/auth-cookie-options.helper';
+import { AuthCookie } from '@/features/auth/helpers/auth-cookie.helper';
+import {
+  getIp,
+  getUserAgent,
+} from '@/features/auth/helpers/auth-request-meta.helper';
+import {
+  REFRESH_SESSION_REPOSITORY,
+  type IRefreshSessionRepository,
+} from '@/features/auth/repositories/refresh-session.repository.interface';
+import type { ITokenService } from '@/features/auth/services/token.service.interface';
+import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
+import type { AccessTokenPayload } from '@/global/auth/types/jwt-payload.type';
+
+/**
+ * 인증 토큰 발급/회전/검증 + refresh 쿠키 관리 서비스.
+ *
+ * AuthService 의 토큰 관련 책임을 분리한 결과물.
+ */
+@Injectable()
+export class TokenService implements ITokenService {
+  /**
+   * @param config ConfigService
+   * @param jwt JwtService
+   * @param refreshSessions RefreshSessionRepository
+   */
+  constructor(
+    private readonly config: ConfigService,
+    private readonly jwt: JwtService,
+    @Inject(REFRESH_SESSION_REPOSITORY)
+    private readonly refreshSessions: IRefreshSessionRepository,
+  ) {}
+
+  signAccessToken(accountId: bigint): string {
+    const now = Math.floor(Date.now() / 1000);
+    const exp = now + this.getAccessExpiresSeconds();
+
+    const payload: AccessTokenPayload = {
+      sub: accountId.toString(),
+      typ: 'access',
+      iat: now,
+      exp,
+    };
+
+    return this.jwt.sign(payload);
+  }
+
+  getAccessExpiresSeconds(): number {
+    return getEnvAsNumber(this.config, 'JWT_ACCESS_EXPIRES_SECONDS', 900);
+  }
+
+  async issueAuthTokens(args: {
+    accountId: bigint;
+    req: Request;
+    res: Response;
+  }): Promise<{ accessToken: string }> {
+    const accessToken = this.signAccessToken(args.accountId);
+
+    const refreshToken = this.generateRefreshToken();
+    const refreshHash = this.sha256Hex(refreshToken);
+
+    const refreshDays = this.getRefreshDays();
+    const expiresAt = new Date(Date.now() + refreshDays * 86400 * 1000);
+
+    await this.refreshSessions.createRefreshSession({
+      accountId: args.accountId,
+      tokenHash: refreshHash,
+      userAgent: getUserAgent(args.req),
+      ipAddress: getIp(args.req),
+      expiresAt,
+    });
+
+    AuthCookie.setRefreshCookie(args.res, {
+      refreshToken,
+      refreshMaxAgeMs: refreshDays * 86400 * 1000,
+      cookieDomain: AuthCookieOptions.getCookieDomain(this.config),
+      secure: AuthCookieOptions.isCookieSecure(this.config),
+      sameSite: AuthCookieOptions.getCookieSameSite(this.config),
+    });
+
+    return { accessToken };
+  }
+
+  async rotateRefresh(
+    req: Request,
+    res: Response,
+  ): Promise<{ accessToken: string; accountId: bigint }> {
+    const refreshToken = req.cookies?.[AUTH_COOKIE.REFRESH] as
+      | string
+      | undefined;
+
+    if (!refreshToken) {
+      throw new UnauthorizedException('Missing refresh token.');
+    }
+
+    const tokenHash = this.sha256Hex(refreshToken);
+    const session =
+      await this.refreshSessions.findActiveRefreshSessionByHash(tokenHash);
+    if (!session) throw new UnauthorizedException('Invalid refresh token.');
+
+    const newRefreshToken = this.generateRefreshToken();
+    const newTokenHash = this.sha256Hex(newRefreshToken);
+
+    const refreshDays = this.getRefreshDays();
+    const newExpiresAt = new Date(Date.now() + refreshDays * 86400 * 1000);
+
+    await this.refreshSessions.rotateRefreshSession({
+      currentSessionId: session.id,
+      accountId: session.account_id,
+      newTokenHash,
+      userAgent: getUserAgent(req),
+      ipAddress: getIp(req),
+      newExpiresAt,
+    });
+
+    const accessToken = this.signAccessToken(session.account_id);
+
+    AuthCookie.setRefreshCookie(res, {
+      refreshToken: newRefreshToken,
+      refreshMaxAgeMs: refreshDays * 86400 * 1000,
+      cookieDomain: AuthCookieOptions.getCookieDomain(this.config),
+      secure: AuthCookieOptions.isCookieSecure(this.config),
+      sameSite: AuthCookieOptions.getCookieSameSite(this.config),
+    });
+
+    return {
+      accessToken,
+      accountId: session.account_id,
+    };
+  }
+
+  sha256Hex(raw: string): string {
+    return createHash('sha256').update(raw).digest('hex');
+  }
+
+  clearRefreshCookie(res: Response): void {
+    AuthCookie.clearRefreshCookie(
+      res,
+      AuthCookieOptions.getCookieDomain(this.config),
+      AuthCookieOptions.isCookieSecure(this.config),
+      AuthCookieOptions.getCookieSameSite(this.config),
+    );
+  }
+
+  /**
+   * refresh token 랜덤 문자열을 생성한다. (32 bytes → 64 hex)
+   */
+  private generateRefreshToken(): string {
+    return randomBytes(32).toString('hex');
+  }
+
+  /**
+   * Refresh 만료(일) 를 반환한다.
+   */
+  private getRefreshDays(): number {
+    return getEnvAsNumber(this.config, 'AUTH_REFRESH_EXPIRES_DAYS', 30);
+  }
+}


### PR DESCRIPTION
## Summary

- AuthService 의 토큰 발급·회전·해싱·쿠키 책임을 신규 **TokenService** 로 분리.
- 중복되던 cookie option / request meta 헬퍼 (AuthCookieOptions / getUserAgent/getIp) 도 함께 추출하여
  AuthService 와 TokenService 가 공유.

## Scope

- **신규**
  - \`src/features/auth/helpers/auth-cookie-options.helper.ts\` — cookie domain / secure / sameSite getters
  - \`src/features/auth/helpers/auth-request-meta.helper.ts\` — getUserAgent, getIp (pure)
  - TokenService (interface + impl + spec, TOKEN_SERVICE Symbol 토큰)
    - public: signAccessToken, getAccessExpiresSeconds, issueAuthTokens, rotateRefresh, sha256Hex, clearRefreshCookie
    - private: generateRefreshToken, getRefreshDays
- **변경**
  - AuthService: JwtService 직접 의존 제거, 토큰 관련 8 곳을 \`this.tokens.*\` 로 위임,
    extracted 5+ private helper 제거. AuthService 줄 수: 824 → 약 580.
  - AuthModule: TokenService 등록
  - 영향 spec 2 개 (auth.service / auth.seller.service) 에 TokenService 를 실 인스턴스로 주입.
    기존 refreshSessions/jwt mock 으로 회귀 없음.

## P0-1 진행 상황

- ✅ 단계 1: RefreshSessionRepository
- ✅ 단계 2: AuditLogRepository
- ✅ 단계 3: AccountRepository / SellerCredentialRepository
- ✅ 단계 4: TokenService **(본 PR)**
- ⏳ 단계 5: OidcLoginService 추출
- ⏳ 단계 6: SellerCredentialService + logout 통합
- ⏳ 단계 7: AuthService 잔여 정리 (facade 축소 또는 제거)

## Impact

- FE: 없음 (REST 엔드포인트·응답·에러 형태 동일)
- DB: 변경 없음
- Coverage: 1177 tests pass (TokenService spec 9 신규), 전 임계 통과

## Test plan

- [x] yarn validate 로컬 통과
- [x] token.service.spec.ts 신규 단위테스트 (sign / hash / issue / rotate / clear)
- [x] auth.service / auth.seller.service spec 회귀 없음 (실 TokenService + 기존 repo mock)
- [ ] CI 통과 확인