### PR TITLE
refactor(auth): OidcLoginService 추출 (P0-1 단계 5)

### DIFF
--- a/src/features/auth/auth.module.ts
+++ b/src/features/auth/auth.module.ts
@@ -10,6 +10,8 @@ import { REFRESH_SESSION_REPOSITORY } from '@/features/auth/repositories/refresh
 import { SellerCredentialRepository } from '@/features/auth/repositories/seller-credential.repository';
 import { SELLER_CREDENTIAL_REPOSITORY } from '@/features/auth/repositories/seller-credential.repository.interface';
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
+import { OidcLoginService } from '@/features/auth/services/oidc-login.service';
+import { OIDC_LOGIN_SERVICE } from '@/features/auth/services/oidc-login.service.interface';
 import { TokenService } from '@/features/auth/services/token.service';
 import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
 import { JwtBearerStrategy } from '@/features/auth/strategies/jwt-bearer.strategy';
@@ -27,6 +29,10 @@ import { AuthGlobalModule } from '@/global/auth/auth-global.module';
   providers: [
     AuthService,
     OidcClientService,
+    {
+      provide: OIDC_LOGIN_SERVICE,
+      useClass: OidcLoginService,
+    },
     {
       provide: TOKEN_SERVICE,
       useClass: TokenService,

--- a/src/features/auth/auth.seller.service.spec.ts
+++ b/src/features/auth/auth.seller.service.spec.ts
@@ -28,7 +28,6 @@ import {
   SELLER_CREDENTIAL_REPOSITORY,
   type ISellerCredentialRepository,
 } from '@/features/auth/repositories/seller-credential.repository.interface';
-import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 import { TokenService } from '@/features/auth/services/token.service';
 import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
 
@@ -91,7 +90,6 @@ describe('AuthService (seller)', () => {
           provide: JwtService,
           useValue: { sign: jest.fn(() => 'mock-access-token') },
         },
-        { provide: OidcClientService, useValue: {} },
         {
           provide: TOKEN_SERVICE,
           useClass: TokenService,

--- a/src/features/auth/auth.service.spec.ts
+++ b/src/features/auth/auth.service.spec.ts
@@ -26,7 +26,6 @@ import {
   SELLER_CREDENTIAL_REPOSITORY,
   type ISellerCredentialRepository,
 } from '@/features/auth/repositories/seller-credential.repository.interface';
-import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 import { TokenService } from '@/features/auth/services/token.service';
 import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
 import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
@@ -35,7 +34,6 @@ describe('AuthService', () => {
   let service: AuthService;
   let mockConfig: jest.Mocked<ConfigService>;
   let mockJwt: jest.Mocked<JwtService>;
-  let mockOidc: jest.Mocked<OidcClientService>;
   let mockAccounts: jest.Mocked<IAccountRepository>;
   let mockSellerCredentials: jest.Mocked<ISellerCredentialRepository>;
   let mockRefreshSessions: jest.Mocked<IRefreshSessionRepository>;
@@ -49,12 +47,6 @@ describe('AuthService', () => {
     mockJwt = {
       sign: jest.fn(),
     } as unknown as jest.Mocked<JwtService>;
-
-    mockOidc = {
-      buildAuthorizationUrl: jest.fn(),
-      exchangeCode: jest.fn(),
-      toIdentityProvider: jest.fn(),
-    } as unknown as jest.Mocked<OidcClientService>;
 
     mockAccounts = {
       findIdentityByProviderSubject: jest.fn(),
@@ -88,7 +80,6 @@ describe('AuthService', () => {
         AuthService,
         { provide: ConfigService, useValue: mockConfig },
         { provide: JwtService, useValue: mockJwt },
-        { provide: OidcClientService, useValue: mockOidc },
         {
           provide: TOKEN_SERVICE,
           useClass: TokenService,
@@ -116,203 +107,8 @@ describe('AuthService', () => {
     service = module.get<AuthService>(AuthService);
   });
 
-  describe('startOidcLogin', () => {
-    it('OIDC 로그인 URL을 생성하고 임시 쿠키를 설정해야 한다', async () => {
-      // Arrange
-      const mockRes = {
-        cookie: jest.fn(),
-      } as unknown as Response;
-
-      mockConfig.get.mockImplementation((key: string) => {
-        if (key === 'FRONTEND_BASE_URL') return 'http://localhost:3000';
-        if (key === 'AUTH_COOKIE_DOMAIN') return undefined;
-        if (key === 'AUTH_COOKIE_SECURE') return 'false';
-        return undefined;
-      });
-
-      mockOidc.buildAuthorizationUrl.mockResolvedValue({
-        authorizationUrl: 'https://accounts.google.com/auth',
-        state: 'mock-state',
-        nonce: 'mock-nonce',
-        codeVerifier: 'mock-verifier',
-      });
-
-      // Act
-      const result = await service.startOidcLogin(
-        'google',
-        'http://localhost:3000/dashboard',
-        mockRes,
-      );
-
-      // Assert
-      expect(result).toEqual({
-        redirectUrl: 'https://accounts.google.com/auth',
-      });
-      expect(mockOidc.buildAuthorizationUrl).toHaveBeenCalledWith('google');
-      expect(mockRes.cookie).toHaveBeenCalledTimes(4); // state, nonce, codeVerifier, returnTo
-    });
-
-    it('returnTo가 허용되지 않은 도메인이면 기본값을 사용해야 한다', async () => {
-      // Arrange
-      const mockRes = {
-        cookie: jest.fn(),
-      } as unknown as Response;
-
-      mockConfig.get.mockImplementation((key: string) => {
-        if (key === 'FRONTEND_BASE_URL') return 'http://localhost:3000';
-        return undefined;
-      });
-
-      mockOidc.buildAuthorizationUrl.mockResolvedValue({
-        authorizationUrl: 'https://accounts.google.com/auth',
-        state: 'state',
-        nonce: 'nonce',
-        codeVerifier: 'verifier',
-      });
-
-      // Act
-      await service.startOidcLogin('google', 'https://malicious.com', mockRes);
-
-      // Assert
-      // returnTo 쿠키가 기본값으로 설정되어야 함
-      const returnToCookie = (mockRes.cookie as jest.Mock).mock.calls.find(
-        (call) => call[0] === 'caquick_oidc_return_to',
-      );
-      expect(returnToCookie).toBeDefined();
-      expect(returnToCookie![1]).toBe('http://localhost:3000');
-    });
-  });
-
-  describe('handleOidcCallback', () => {
-    it('OIDC 콜백을 성공적으로 처리하고 인증 쿠키를 발급해야 한다', async () => {
-      // Arrange
-      const mockReq = {
-        cookies: {
-          caquick_oidc_state: 'expected-state',
-          caquick_oidc_nonce: 'expected-nonce',
-          caquick_oidc_cv: 'expected-verifier',
-          caquick_oidc_return_to: 'http://localhost:3000/dashboard',
-        },
-        query: {
-          code: 'auth-code',
-          state: 'expected-state',
-        },
-        headers: {
-          'user-agent': 'Mozilla/5.0',
-        },
-        ip: '127.0.0.1',
-      } as unknown as Request;
-
-      const mockRes = {
-        cookie: jest.fn(),
-        clearCookie: jest.fn(),
-      } as unknown as Response;
-
-      mockConfig.get.mockImplementation((key: string) => {
-        if (key === 'BACKEND_BASE_URL') return 'http://localhost:4000';
-        if (key === 'JWT_ACCESS_EXPIRES_SECONDS') return '900';
-        if (key === 'AUTH_REFRESH_EXPIRES_DAYS') return '30';
-        if (key === 'AUTH_COOKIE_DOMAIN') return undefined;
-        if (key === 'AUTH_COOKIE_SECURE') return 'false';
-        if (key === 'NODE_ENV') return 'development';
-        return undefined;
-      });
-
-      mockOidc.exchangeCode.mockResolvedValue({
-        claims: () => ({
-          sub: 'google-user-123',
-          email: 'test@example.com',
-          email_verified: true,
-          name: 'Test User',
-          picture: 'https://example.com/photo.jpg',
-        }),
-      } as never);
-
-      mockOidc.toIdentityProvider.mockReturnValue('GOOGLE');
-
-      mockAccounts.upsertUserByOidcIdentity.mockResolvedValue({
-        account: {
-          id: BigInt(1),
-          email: 'test@example.com',
-          name: 'Test User',
-        } as never,
-      });
-
-      mockRefreshSessions.createRefreshSession.mockResolvedValue({} as never);
-      mockJwt.sign.mockReturnValue('mock-access-token');
-
-      // Act
-      const result = await service.handleOidcCallback(
-        'google',
-        mockReq,
-        mockRes,
-      );
-
-      // Assert
-      expect(result).toEqual({
-        returnTo: 'http://localhost:3000/dashboard',
-        accessToken: 'mock-access-token',
-      });
-      expect(mockOidc.exchangeCode).toHaveBeenCalled();
-      expect(mockAccounts.upsertUserByOidcIdentity).toHaveBeenCalledWith({
-        provider: 'GOOGLE',
-        providerSubject: 'google-user-123',
-        providerEmail: 'test@example.com',
-        emailVerified: true,
-        providerDisplayName: 'Test User',
-        providerProfileImageUrl: 'https://example.com/photo.jpg',
-      });
-      expect(mockRes.cookie).toHaveBeenCalledWith(
-        AUTH_COOKIE.REFRESH,
-        expect.any(String),
-        expect.any(Object),
-      );
-      expect(mockRes.clearCookie).toHaveBeenCalledTimes(4); // OIDC 임시 쿠키 4개
-    });
-
-    it('OIDC 세션 쿠키가 없으면 UnauthorizedException을 던져야 한다', async () => {
-      // Arrange
-      const mockReq = {
-        cookies: {},
-      } as unknown as Request;
-
-      const mockRes = {} as Response;
-
-      // Act & Assert
-      await expect(
-        service.handleOidcCallback('google', mockReq, mockRes),
-      ).rejects.toThrow(UnauthorizedException);
-      await expect(
-        service.handleOidcCallback('google', mockReq, mockRes),
-      ).rejects.toThrow('OIDC session is missing.');
-    });
-
-    it('OIDC subject가 없으면 UnauthorizedException을 던져야 한다', async () => {
-      // Arrange
-      const mockReq = {
-        cookies: {
-          caquick_oidc_state: 'state',
-          caquick_oidc_nonce: 'nonce',
-          caquick_oidc_cv: 'verifier',
-        },
-        query: { code: 'code', state: 'state' },
-        headers: {},
-      } as unknown as Request;
-
-      const mockRes = {} as Response;
-
-      mockConfig.get.mockReturnValue('http://localhost:4000');
-
-      mockOidc.exchangeCode.mockResolvedValue({
-        claims: () => ({}), // sub 없음
-      } as never);
-
-      // Act & Assert
-      await expect(
-        service.handleOidcCallback('google', mockReq, mockRes),
-      ).rejects.toThrow('OIDC subject is missing.');
-    });
-  });
+  // OIDC 흐름 (startOidcLogin / handleOidcCallback) 은 OidcLoginService 로 분리.
+  // 해당 케이스는 oidc-login.service.spec.ts 에서 다룬다.
 
   describe('refresh', () => {
     it('refresh 토큰을 성공적으로 회전시켜야 한다', async () => {
@@ -533,47 +329,6 @@ describe('AuthService', () => {
       expect(result.birthDate).toBeNull();
       expect(result.phoneNumber).toBeNull();
       expect(result.needsProfile).toBe(true);
-    });
-  });
-
-  describe('startOidcLogin returnTo 분기 (빈 값/공백)', () => {
-    it('returnTo가 undefined이면 기본 프론트 URL을 사용한다', async () => {
-      const mockRes = { cookie: jest.fn() } as unknown as Response;
-      mockConfig.get.mockImplementation((key: string) => {
-        if (key === 'FRONTEND_BASE_URL') return 'http://front.example';
-        return undefined;
-      });
-      mockOidc.buildAuthorizationUrl.mockResolvedValue({
-        authorizationUrl: 'https://a',
-        state: 's',
-        nonce: 'n',
-        codeVerifier: 'v',
-      });
-
-      await service.startOidcLogin('google', undefined, mockRes);
-
-      const returnToCookie = (mockRes.cookie as jest.Mock).mock.calls.find(
-        (c) => c[0] === 'caquick_oidc_return_to',
-      );
-      expect(returnToCookie![1]).toBe('http://front.example');
-    });
-
-    it('FRONTEND_BASE_URL이 미설정이면 http://localhost:3000으로 fallback', async () => {
-      const mockRes = { cookie: jest.fn() } as unknown as Response;
-      mockConfig.get.mockImplementation(() => undefined);
-      mockOidc.buildAuthorizationUrl.mockResolvedValue({
-        authorizationUrl: 'https://a',
-        state: 's',
-        nonce: 'n',
-        codeVerifier: 'v',
-      });
-
-      await service.startOidcLogin('google', '   ', mockRes);
-
-      const returnToCookie = (mockRes.cookie as jest.Mock).mock.calls.find(
-        (c) => c[0] === 'caquick_oidc_return_to',
-      );
-      expect(returnToCookie![1]).toBe('http://localhost:3000');
     });
   });
 

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -6,7 +6,6 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import {
   AccountType,
   AuditActionType,
@@ -21,9 +20,6 @@ import {
   AUDIT_LOG_REPOSITORY,
   type IAuditLogRepository,
 } from '@/features/audit-log';
-import { ALLOWED_RETURN_TO_DOMAINS } from '@/features/auth/constants/auth.constants';
-import { AuthCookieOptions } from '@/features/auth/helpers/auth-cookie-options.helper';
-import { AuthCookie } from '@/features/auth/helpers/auth-cookie.helper';
 import {
   getIp,
   getUserAgent,
@@ -40,15 +36,10 @@ import {
   SELLER_CREDENTIAL_REPOSITORY,
   type ISellerCredentialRepository,
 } from '@/features/auth/repositories/seller-credential.repository.interface';
-import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 import {
   TOKEN_SERVICE,
   type ITokenService,
 } from '@/features/auth/services/token.service.interface';
-import {
-  parseOidcProvider,
-  type OidcProvider,
-} from '@/features/auth/types/oidc-provider.type';
 import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
 
 /**
@@ -57,8 +48,6 @@ import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
 @Injectable()
 export class AuthService {
   /**
-   * @param config ConfigService
-   * @param oidc OidcClientService
    * @param tokens TokenService
    * @param accounts AccountRepository
    * @param sellerCredentials SellerCredentialRepository
@@ -67,8 +56,6 @@ export class AuthService {
    * @param clock ClockService
    */
   constructor(
-    private readonly config: ConfigService,
-    private readonly oidc: OidcClientService,
     @Inject(TOKEN_SERVICE)
     private readonly tokens: ITokenService,
     @Inject(ACCOUNT_REPOSITORY)
@@ -81,92 +68,6 @@ export class AuthService {
     private readonly auditLogs: IAuditLogRepository,
     private readonly clock: ClockService,
   ) {}
-
-  /**
-   * OIDC 로그인 시작(리다이렉트 URL 생성 + 임시 쿠키 세팅)
-   *
-   * @param rawProvider provider param
-   * @param returnTo FE 리다이렉트 목적지
-   * @param res Response
-   */
-  async startOidcLogin(
-    rawProvider: string,
-    returnTo: string | undefined,
-    res: Response,
-  ): Promise<{ redirectUrl: string }> {
-    const provider = parseOidcProvider(rawProvider);
-    const safeReturnTo = this.normalizeReturnTo(returnTo);
-
-    const { authorizationUrl, state, nonce, codeVerifier } =
-      await this.oidc.buildAuthorizationUrl(provider);
-
-    AuthCookie.setOidcTempCookies(res, {
-      state,
-      nonce,
-      codeVerifier,
-      returnTo: safeReturnTo,
-      cookieDomain: AuthCookieOptions.getCookieDomain(this.config),
-      secure: AuthCookieOptions.isCookieSecure(this.config),
-      sameSite: AuthCookieOptions.getCookieSameSite(this.config),
-    });
-
-    return { redirectUrl: authorizationUrl };
-  }
-
-  /**
-   * OIDC 콜백 처리:
-   * - state/nonce 검증
-   * - code 교환
-   * - Account/Identity upsert
-   * - refresh 쿠키 발급 및 access token 반환
-   *
-   * @param rawProvider provider param
-   * @param req Request
-   * @param res Response
-   */
-  async handleOidcCallback(
-    rawProvider: string,
-    req: Request,
-    res: Response,
-  ): Promise<{ returnTo: string; accessToken: string }> {
-    const provider = parseOidcProvider(rawProvider);
-
-    // 1. OIDC 임시 쿠키 검증 및 추출
-    const { expectedState, expectedNonce, codeVerifier, returnTo } =
-      this.extractOidcTempCookies(req);
-
-    // 2. code를 token으로 교환
-    const tokenSet = await this.exchangeOidcCode(
-      provider,
-      req,
-      expectedState,
-      expectedNonce,
-      codeVerifier,
-    );
-
-    // 3. claims에서 사용자 정보 추출
-    const userInfo = this.extractUserInfoFromClaims(tokenSet.claims());
-
-    // 4. 계정 생성/업데이트
-    const account = await this.upsertAccountFromOidc(provider, userInfo);
-
-    // 5. refresh 쿠키 발급 + access token 생성
-    const { accessToken } = await this.tokens.issueAuthTokens({
-      accountId: account.id,
-      req,
-      res,
-    });
-
-    // 6. OIDC 임시 쿠키 삭제
-    AuthCookie.clearOidcTempCookies(
-      res,
-      AuthCookieOptions.getCookieDomain(this.config),
-      AuthCookieOptions.isCookieSecure(this.config),
-      AuthCookieOptions.getCookieSameSite(this.config),
-    );
-
-    return { returnTo, accessToken };
-  }
 
   /**
    * 판매자 username/password 로그인
@@ -438,189 +339,5 @@ export class AuthService {
       phoneNumber: profile?.phone_number ?? null,
       needsProfile,
     };
-  }
-
-  /**
-   * OIDC 임시 쿠키를 추출하고 검증한다.
-   *
-   * @param req Request
-   */
-  private extractOidcTempCookies(req: Request): {
-    expectedState: string;
-    expectedNonce: string;
-    codeVerifier: string;
-    returnTo: string;
-  } {
-    const expectedState = req.cookies?.[AUTH_COOKIE.OIDC_STATE] as
-      | string
-      | undefined;
-    const expectedNonce = req.cookies?.[AUTH_COOKIE.OIDC_NONCE] as
-      | string
-      | undefined;
-    const codeVerifier = req.cookies?.[AUTH_COOKIE.OIDC_CODE_VERIFIER] as
-      | string
-      | undefined;
-    const returnTo =
-      (req.cookies?.[AUTH_COOKIE.OIDC_RETURN_TO] as string | undefined) ??
-      this.normalizeReturnTo(undefined);
-
-    if (!expectedState || !expectedNonce || !codeVerifier) {
-      throw new UnauthorizedException('OIDC session is missing.');
-    }
-
-    return { expectedState, expectedNonce, codeVerifier, returnTo };
-  }
-
-  /**
-   * OIDC code를 token으로 교환한다.
-   *
-   * @param provider provider
-   * @param req Request
-   * @param expectedState state
-   * @param expectedNonce nonce
-   * @param codeVerifier code verifier
-   */
-  private async exchangeOidcCode(
-    provider: OidcProvider,
-    req: Request,
-    expectedState: string,
-    expectedNonce: string,
-    codeVerifier: string,
-  ) {
-    const callbackParams = this.pickCallbackParams(req);
-    const redirectUri = this.getCallbackRedirectUri(provider);
-
-    return this.oidc.exchangeCode(provider, {
-      redirectUri,
-      callbackParams,
-      state: expectedState,
-      nonce: expectedNonce,
-      codeVerifier,
-    });
-  }
-
-  /**
-   * OIDC claims에서 사용자 정보를 추출한다.
-   *
-   * @param claims OIDC claims
-   */
-  private extractUserInfoFromClaims(claims: Record<string, unknown>): {
-    subject: string;
-    email?: string;
-    emailVerified: boolean;
-    displayName?: string;
-    picture?: string;
-  } {
-    const subject = typeof claims.sub === 'string' ? claims.sub : null;
-    if (!subject) throw new UnauthorizedException('OIDC subject is missing.');
-
-    const email = typeof claims.email === 'string' ? claims.email : undefined;
-    const emailVerified = claims.email_verified === true;
-
-    const displayName =
-      (typeof claims.name === 'string' ? claims.name : undefined) ??
-      (typeof claims.nickname === 'string' ? claims.nickname : undefined);
-
-    const picture =
-      typeof claims.picture === 'string' ? claims.picture : undefined;
-
-    return { subject, email, emailVerified, displayName, picture };
-  }
-
-  /**
-   * OIDC 사용자 정보로 계정을 생성/업데이트한다.
-   *
-   * @param provider provider
-   * @param userInfo 사용자 정보
-   */
-  private async upsertAccountFromOidc(
-    provider: OidcProvider,
-    userInfo: {
-      subject: string;
-      email?: string;
-      emailVerified: boolean;
-      displayName?: string;
-      picture?: string;
-    },
-  ) {
-    const identityProvider = this.oidc.toIdentityProvider(provider);
-
-    const { account } = await this.accounts.upsertUserByOidcIdentity({
-      provider: identityProvider,
-      providerSubject: userInfo.subject,
-      providerEmail: userInfo.email,
-      emailVerified: userInfo.emailVerified,
-      providerDisplayName: userInfo.displayName,
-      providerProfileImageUrl: userInfo.picture,
-    });
-
-    if (!account) throw new UnauthorizedException('Account upsert failed.');
-
-    return account;
-  }
-
-  /**
-   * returnTo 값을 안전하게 정규화한다(오픈리다이렉트 방지).
-   *
-   * @param raw returnTo
-   */
-  private normalizeReturnTo(raw: string | undefined): string {
-    const frontend =
-      this.config.get<string>('FRONTEND_BASE_URL')?.trim() ??
-      'http://localhost:3000';
-
-    if (!raw || raw.trim().length === 0) return frontend;
-
-    // 같은 site로만 허용(정확히는 prefix 기반)
-    const allowed = [frontend, ...ALLOWED_RETURN_TO_DOMAINS];
-    const ok = allowed.some((prefix) => raw.startsWith(prefix));
-    return ok ? raw : frontend;
-  }
-
-  /**
-   * callback params(code/state 등)를 안전하게 추출한다.
-   *
-   * @param req Request
-   */
-  private pickCallbackParams(req: Request): Record<string, string | string[]> {
-    const q = req.query as Record<string, unknown>;
-    const result: Record<string, string | string[]> = {};
-
-    const isStringArray = (val: unknown): val is string[] =>
-      Array.isArray(val) && val.every((x) => typeof x === 'string');
-
-    const pick = (key: string): void => {
-      const v = q[key];
-
-      if (typeof v === 'string') {
-        result[key] = v;
-        return;
-      }
-
-      if (isStringArray(v)) {
-        result[key] = v;
-      }
-    };
-
-    pick('code');
-    pick('state');
-    pick('iss');
-    pick('error');
-    pick('error_description');
-
-    return result;
-  }
-
-  /**
-   * provider별 callback redirect uri를 반환한다.
-   *
-   * @param provider provider
-   */
-  private getCallbackRedirectUri(provider: OidcProvider): string {
-    const backendBase =
-      this.config.get<string>('BACKEND_BASE_URL')?.trim() ??
-      'http://localhost:4000';
-
-    return `${backendBase}/auth/oidc/${provider}/callback`;
   }
 }

--- a/src/features/auth/controllers/auth.controller.spec.ts
+++ b/src/features/auth/controllers/auth.controller.spec.ts
@@ -4,6 +4,10 @@ import type { Request, Response } from 'express';
 
 import { AuthService } from '@/features/auth/auth.service';
 import { AuthController } from '@/features/auth/controllers/auth.controller';
+import {
+  OIDC_LOGIN_SERVICE,
+  type IOidcLoginService,
+} from '@/features/auth/services/oidc-login.service.interface';
 import type { JwtUser } from '@/global/auth';
 
 function mockRes(): Response {
@@ -18,11 +22,10 @@ function mockRes(): Response {
 describe('AuthController', () => {
   let controller: AuthController;
   let auth: jest.Mocked<AuthService>;
+  let oidcLogin: jest.Mocked<IOidcLoginService>;
 
   beforeEach(async () => {
     auth = {
-      startOidcLogin: jest.fn(),
-      handleOidcCallback: jest.fn(),
       refresh: jest.fn(),
       logout: jest.fn(),
       sellerLogin: jest.fn(),
@@ -32,9 +35,17 @@ describe('AuthController', () => {
       issueDevAccessToken: jest.fn(),
     } as unknown as jest.Mocked<AuthService>;
 
+    oidcLogin = {
+      startOidcLogin: jest.fn(),
+      handleOidcCallback: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
-      providers: [{ provide: AuthService, useValue: auth }],
+      providers: [
+        { provide: AuthService, useValue: auth },
+        { provide: OIDC_LOGIN_SERVICE, useValue: oidcLogin },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
@@ -45,13 +56,13 @@ describe('AuthController', () => {
       redirect: jest.fn(),
     } as unknown as Response;
 
-    auth.startOidcLogin.mockResolvedValue({
+    oidcLogin.startOidcLogin.mockResolvedValue({
       redirectUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
     });
 
     await controller.start('google', 'https://caquick.site/login', res);
 
-    expect(auth.startOidcLogin).toHaveBeenCalledWith(
+    expect(oidcLogin.startOidcLogin).toHaveBeenCalledWith(
       'google',
       'https://caquick.site/login',
       res,
@@ -73,14 +84,18 @@ describe('AuthController', () => {
       redirect: jest.fn(),
     } as unknown as Response;
 
-    auth.handleOidcCallback.mockResolvedValue({
+    oidcLogin.handleOidcCallback.mockResolvedValue({
       returnTo: 'https://caquick.site/mypage',
       accessToken: 'access-token',
     });
 
     await controller.callback('google', req, res);
 
-    expect(auth.handleOidcCallback).toHaveBeenCalledWith('google', req, res);
+    expect(oidcLogin.handleOidcCallback).toHaveBeenCalledWith(
+      'google',
+      req,
+      res,
+    );
     expect(res.redirect).toHaveBeenCalledWith('https://caquick.site/mypage');
   });
 

--- a/src/features/auth/controllers/auth.controller.ts
+++ b/src/features/auth/controllers/auth.controller.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   ForbiddenException,
   Get,
+  Inject,
   Param,
   Post,
   Query,
@@ -28,6 +29,10 @@ import { AuthService } from '@/features/auth/auth.service';
 import { DevIssueTokenInput } from '@/features/auth/dto/inputs/dev-issue-token.input';
 import { SellerChangePasswordInput } from '@/features/auth/dto/inputs/seller-change-password.input';
 import { SellerLoginInput } from '@/features/auth/dto/inputs/seller-login.input';
+import {
+  OIDC_LOGIN_SERVICE,
+  type IOidcLoginService,
+} from '@/features/auth/services/oidc-login.service.interface';
 import { parseOidcProvider } from '@/features/auth/types/oidc-provider.type';
 import { CurrentUser, JwtAuthGuard, type JwtUser } from '@/global/auth';
 
@@ -41,8 +46,13 @@ import { CurrentUser, JwtAuthGuard, type JwtUser } from '@/global/auth';
 export class AuthController {
   /**
    * @param auth AuthService
+   * @param oidcLogin OidcLoginService
    */
-  constructor(private readonly auth: AuthService) {}
+  constructor(
+    private readonly auth: AuthService,
+    @Inject(OIDC_LOGIN_SERVICE)
+    private readonly oidcLogin: IOidcLoginService,
+  ) {}
 
   /**
    * OIDC 로그인 시작
@@ -79,7 +89,7 @@ export class AuthController {
     // provider 검증(잘못된 값이면 즉시 에러)
     parseOidcProvider(provider);
 
-    const { redirectUrl } = await this.auth.startOidcLogin(
+    const { redirectUrl } = await this.oidcLogin.startOidcLogin(
       provider,
       returnTo,
       res,
@@ -115,7 +125,11 @@ export class AuthController {
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {
-    const { returnTo } = await this.auth.handleOidcCallback(provider, req, res);
+    const { returnTo } = await this.oidcLogin.handleOidcCallback(
+      provider,
+      req,
+      res,
+    );
     res.redirect(returnTo);
   }
 

--- a/src/features/auth/services/oidc-login.service.interface.ts
+++ b/src/features/auth/services/oidc-login.service.interface.ts
@@ -1,0 +1,46 @@
+import type { Request, Response } from 'express';
+
+/**
+ * OidcLoginService 토큰 (Nest DI 주입용).
+ */
+export const OIDC_LOGIN_SERVICE = Symbol('OIDC_LOGIN_SERVICE');
+
+/**
+ * OIDC 로그인 흐름 (start / callback) 을 담당하는 서비스 인터페이스.
+ *
+ * AuthController 가 이를 직접 호출한다. AuthService 와는 동등한 도메인 서비스 레이어.
+ */
+export interface IOidcLoginService {
+  /**
+   * OIDC 로그인 시작:
+   * - 인가 URL 생성
+   * - state / nonce / codeVerifier / returnTo 를 임시 쿠키로 세팅
+   *
+   * @param rawProvider provider param (검증되지 않은 raw 문자열)
+   * @param returnTo 로그인 완료 후 FE 리다이렉트 목적지 (옵션)
+   * @param res Response
+   */
+  startOidcLogin(
+    rawProvider: string,
+    returnTo: string | undefined,
+    res: Response,
+  ): Promise<{ redirectUrl: string }>;
+
+  /**
+   * OIDC 콜백 처리:
+   * - state / nonce 검증
+   * - code → token 교환
+   * - Account / Identity upsert
+   * - refresh 쿠키 발급 + access token 반환
+   * - OIDC 임시 쿠키 삭제
+   *
+   * @param rawProvider provider param
+   * @param req Request
+   * @param res Response
+   */
+  handleOidcCallback(
+    rawProvider: string,
+    req: Request,
+    res: Response,
+  ): Promise<{ returnTo: string; accessToken: string }>;
+}

--- a/src/features/auth/services/oidc-login.service.spec.ts
+++ b/src/features/auth/services/oidc-login.service.spec.ts
@@ -1,0 +1,324 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { Test, type TestingModule } from '@nestjs/testing';
+import type { Request, Response } from 'express';
+
+import {
+  ACCOUNT_REPOSITORY,
+  type IAccountRepository,
+} from '@/features/auth/repositories/account.repository.interface';
+import {
+  REFRESH_SESSION_REPOSITORY,
+  type IRefreshSessionRepository,
+} from '@/features/auth/repositories/refresh-session.repository.interface';
+import { OidcClientService } from '@/features/auth/services/oidc-client.service';
+import { OidcLoginService } from '@/features/auth/services/oidc-login.service';
+import { TokenService } from '@/features/auth/services/token.service';
+import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
+import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
+
+describe('OidcLoginService', () => {
+  let service: OidcLoginService;
+  let mockConfig: jest.Mocked<ConfigService>;
+  let mockOidc: jest.Mocked<OidcClientService>;
+  let mockAccounts: jest.Mocked<IAccountRepository>;
+  let mockRefreshSessions: jest.Mocked<IRefreshSessionRepository>;
+  let mockJwt: jest.Mocked<JwtService>;
+
+  beforeEach(async () => {
+    mockConfig = {
+      get: jest.fn(),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    mockOidc = {
+      buildAuthorizationUrl: jest.fn(),
+      exchangeCode: jest.fn(),
+      toIdentityProvider: jest.fn(),
+    } as unknown as jest.Mocked<OidcClientService>;
+
+    mockAccounts = {
+      findIdentityByProviderSubject: jest.fn(),
+      findAccountByEmail: jest.fn(),
+      upsertUserByOidcIdentity: jest.fn(),
+      findAccountForJwt: jest.fn(),
+      findAccountForMe: jest.fn(),
+    };
+
+    mockRefreshSessions = {
+      findActiveRefreshSessionByHash: jest.fn(),
+      rotateRefreshSession: jest.fn(),
+      revokeRefreshSession: jest.fn(),
+      revokeAllRefreshSessions: jest.fn(),
+      createRefreshSession: jest.fn(),
+    };
+
+    mockJwt = {
+      sign: jest.fn(() => 'mock-access-token'),
+    } as unknown as jest.Mocked<JwtService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OidcLoginService,
+        { provide: ConfigService, useValue: mockConfig },
+        { provide: JwtService, useValue: mockJwt },
+        { provide: OidcClientService, useValue: mockOidc },
+        {
+          provide: TOKEN_SERVICE,
+          useClass: TokenService,
+        },
+        {
+          provide: ACCOUNT_REPOSITORY,
+          useValue: mockAccounts,
+        },
+        {
+          provide: REFRESH_SESSION_REPOSITORY,
+          useValue: mockRefreshSessions,
+        },
+      ],
+    }).compile();
+
+    service = module.get(OidcLoginService);
+  });
+
+  describe('startOidcLogin', () => {
+    it('OIDC 로그인 URL을 생성하고 임시 쿠키를 설정해야 한다', async () => {
+      const mockRes = { cookie: jest.fn() } as unknown as Response;
+
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'FRONTEND_BASE_URL') return 'http://localhost:3000';
+        if (key === 'AUTH_COOKIE_DOMAIN') return undefined;
+        if (key === 'AUTH_COOKIE_SECURE') return 'false';
+        return undefined;
+      });
+
+      mockOidc.buildAuthorizationUrl.mockResolvedValue({
+        authorizationUrl: 'https://accounts.google.com/auth',
+        state: 'mock-state',
+        nonce: 'mock-nonce',
+        codeVerifier: 'mock-verifier',
+      });
+
+      const result = await service.startOidcLogin(
+        'google',
+        'http://localhost:3000/dashboard',
+        mockRes,
+      );
+
+      expect(result).toEqual({
+        redirectUrl: 'https://accounts.google.com/auth',
+      });
+      expect(mockOidc.buildAuthorizationUrl).toHaveBeenCalledWith('google');
+      expect(mockRes.cookie).toHaveBeenCalledTimes(4);
+    });
+
+    it('returnTo가 허용되지 않은 도메인이면 기본값을 사용해야 한다', async () => {
+      const mockRes = { cookie: jest.fn() } as unknown as Response;
+
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'FRONTEND_BASE_URL') return 'http://localhost:3000';
+        return undefined;
+      });
+
+      mockOidc.buildAuthorizationUrl.mockResolvedValue({
+        authorizationUrl: 'https://accounts.google.com/auth',
+        state: 'state',
+        nonce: 'nonce',
+        codeVerifier: 'verifier',
+      });
+
+      await service.startOidcLogin('google', 'https://malicious.com', mockRes);
+
+      const returnToCookie = (mockRes.cookie as jest.Mock).mock.calls.find(
+        (call) => call[0] === 'caquick_oidc_return_to',
+      );
+      expect(returnToCookie).toBeDefined();
+      expect(returnToCookie![1]).toBe('http://localhost:3000');
+    });
+
+    it('returnTo가 undefined이면 기본 프론트 URL을 사용한다', async () => {
+      const mockRes = { cookie: jest.fn() } as unknown as Response;
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'FRONTEND_BASE_URL') return 'http://front.example';
+        return undefined;
+      });
+      mockOidc.buildAuthorizationUrl.mockResolvedValue({
+        authorizationUrl: 'https://a',
+        state: 's',
+        nonce: 'n',
+        codeVerifier: 'v',
+      });
+
+      await service.startOidcLogin('google', undefined, mockRes);
+
+      const returnToCookie = (mockRes.cookie as jest.Mock).mock.calls.find(
+        (c) => c[0] === 'caquick_oidc_return_to',
+      );
+      expect(returnToCookie![1]).toBe('http://front.example');
+    });
+
+    it('FRONTEND_BASE_URL이 미설정이면 http://localhost:3000으로 fallback', async () => {
+      const mockRes = { cookie: jest.fn() } as unknown as Response;
+      mockConfig.get.mockImplementation(() => undefined);
+      mockOidc.buildAuthorizationUrl.mockResolvedValue({
+        authorizationUrl: 'https://a',
+        state: 's',
+        nonce: 'n',
+        codeVerifier: 'v',
+      });
+
+      await service.startOidcLogin('google', '   ', mockRes);
+
+      const returnToCookie = (mockRes.cookie as jest.Mock).mock.calls.find(
+        (c) => c[0] === 'caquick_oidc_return_to',
+      );
+      expect(returnToCookie![1]).toBe('http://localhost:3000');
+    });
+  });
+
+  describe('handleOidcCallback', () => {
+    it('OIDC 콜백을 성공적으로 처리하고 인증 쿠키를 발급해야 한다', async () => {
+      const mockReq = {
+        cookies: {
+          caquick_oidc_state: 'expected-state',
+          caquick_oidc_nonce: 'expected-nonce',
+          caquick_oidc_cv: 'expected-verifier',
+          caquick_oidc_return_to: 'http://localhost:3000/dashboard',
+        },
+        query: {
+          code: 'auth-code',
+          state: 'expected-state',
+        },
+        headers: {
+          'user-agent': 'Mozilla/5.0',
+        },
+        ip: '127.0.0.1',
+      } as unknown as Request;
+
+      const mockRes = {
+        cookie: jest.fn(),
+        clearCookie: jest.fn(),
+      } as unknown as Response;
+
+      mockConfig.get.mockImplementation((key: string) => {
+        if (key === 'BACKEND_BASE_URL') return 'http://localhost:4000';
+        if (key === 'JWT_ACCESS_EXPIRES_SECONDS') return '900';
+        if (key === 'AUTH_REFRESH_EXPIRES_DAYS') return '30';
+        if (key === 'AUTH_COOKIE_DOMAIN') return undefined;
+        if (key === 'AUTH_COOKIE_SECURE') return 'false';
+        if (key === 'NODE_ENV') return 'development';
+        return undefined;
+      });
+
+      mockOidc.exchangeCode.mockResolvedValue({
+        claims: () => ({
+          sub: 'google-user-123',
+          email: 'test@example.com',
+          email_verified: true,
+          name: 'Test User',
+          picture: 'https://example.com/photo.jpg',
+        }),
+      } as never);
+
+      mockOidc.toIdentityProvider.mockReturnValue('GOOGLE');
+
+      mockAccounts.upsertUserByOidcIdentity.mockResolvedValue({
+        account: {
+          id: BigInt(1),
+          email: 'test@example.com',
+          name: 'Test User',
+        } as never,
+      });
+
+      mockRefreshSessions.createRefreshSession.mockResolvedValue({} as never);
+
+      const result = await service.handleOidcCallback(
+        'google',
+        mockReq,
+        mockRes,
+      );
+
+      expect(result).toEqual({
+        returnTo: 'http://localhost:3000/dashboard',
+        accessToken: 'mock-access-token',
+      });
+      expect(mockOidc.exchangeCode).toHaveBeenCalled();
+      expect(mockAccounts.upsertUserByOidcIdentity).toHaveBeenCalledWith({
+        provider: 'GOOGLE',
+        providerSubject: 'google-user-123',
+        providerEmail: 'test@example.com',
+        emailVerified: true,
+        providerDisplayName: 'Test User',
+        providerProfileImageUrl: 'https://example.com/photo.jpg',
+      });
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        AUTH_COOKIE.REFRESH,
+        expect.any(String),
+        expect.any(Object),
+      );
+      expect(mockRes.clearCookie).toHaveBeenCalledTimes(4);
+    });
+
+    it('OIDC 세션 쿠키가 없으면 UnauthorizedException을 던져야 한다', async () => {
+      const mockReq = { cookies: {} } as unknown as Request;
+      const mockRes = {} as Response;
+
+      await expect(
+        service.handleOidcCallback('google', mockReq, mockRes),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.handleOidcCallback('google', mockReq, mockRes),
+      ).rejects.toThrow('OIDC session is missing.');
+    });
+
+    it('OIDC subject가 없으면 UnauthorizedException을 던져야 한다', async () => {
+      const mockReq = {
+        cookies: {
+          caquick_oidc_state: 'state',
+          caquick_oidc_nonce: 'nonce',
+          caquick_oidc_cv: 'verifier',
+        },
+        query: { code: 'code', state: 'state' },
+        headers: {},
+      } as unknown as Request;
+
+      const mockRes = {} as Response;
+
+      mockConfig.get.mockReturnValue('http://localhost:4000');
+
+      mockOidc.exchangeCode.mockResolvedValue({
+        claims: () => ({}),
+      } as never);
+
+      await expect(
+        service.handleOidcCallback('google', mockReq, mockRes),
+      ).rejects.toThrow('OIDC subject is missing.');
+    });
+
+    it('upsertUserByOidcIdentity가 account=null을 반환하면 UnauthorizedException', async () => {
+      const mockReq = {
+        cookies: {
+          caquick_oidc_state: 'state',
+          caquick_oidc_nonce: 'nonce',
+          caquick_oidc_cv: 'verifier',
+        },
+        query: { code: 'code', state: 'state' },
+        headers: {},
+      } as unknown as Request;
+      const mockRes = {} as Response;
+
+      mockConfig.get.mockReturnValue('http://localhost:4000');
+      mockOidc.exchangeCode.mockResolvedValue({
+        claims: () => ({ sub: 'sub' }),
+      } as never);
+      mockOidc.toIdentityProvider.mockReturnValue('GOOGLE');
+      mockAccounts.upsertUserByOidcIdentity.mockResolvedValue({
+        account: null,
+      });
+
+      await expect(
+        service.handleOidcCallback('google', mockReq, mockRes),
+      ).rejects.toThrow('Account upsert failed.');
+    });
+  });
+});

--- a/src/features/auth/services/oidc-login.service.ts
+++ b/src/features/auth/services/oidc-login.service.ts
@@ -1,0 +1,271 @@
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { Request, Response } from 'express';
+
+import { ALLOWED_RETURN_TO_DOMAINS } from '@/features/auth/constants/auth.constants';
+import { AuthCookieOptions } from '@/features/auth/helpers/auth-cookie-options.helper';
+import { AuthCookie } from '@/features/auth/helpers/auth-cookie.helper';
+import {
+  ACCOUNT_REPOSITORY,
+  type IAccountRepository,
+} from '@/features/auth/repositories/account.repository.interface';
+import { OidcClientService } from '@/features/auth/services/oidc-client.service';
+import type { IOidcLoginService } from '@/features/auth/services/oidc-login.service.interface';
+import {
+  TOKEN_SERVICE,
+  type ITokenService,
+} from '@/features/auth/services/token.service.interface';
+import {
+  parseOidcProvider,
+  type OidcProvider,
+} from '@/features/auth/types/oidc-provider.type';
+import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
+
+/**
+ * OIDC 로그인 흐름 (start / callback) 전담 서비스.
+ *
+ * AuthService 의 OIDC 책임 추출 결과물. Token 발급은 TokenService 에 위임한다.
+ */
+@Injectable()
+export class OidcLoginService implements IOidcLoginService {
+  /**
+   * @param config ConfigService
+   * @param oidc OidcClientService
+   * @param tokens TokenService
+   * @param accounts AccountRepository
+   */
+  constructor(
+    private readonly config: ConfigService,
+    private readonly oidc: OidcClientService,
+    @Inject(TOKEN_SERVICE)
+    private readonly tokens: ITokenService,
+    @Inject(ACCOUNT_REPOSITORY)
+    private readonly accounts: IAccountRepository,
+  ) {}
+
+  async startOidcLogin(
+    rawProvider: string,
+    returnTo: string | undefined,
+    res: Response,
+  ): Promise<{ redirectUrl: string }> {
+    const provider = parseOidcProvider(rawProvider);
+    const safeReturnTo = this.normalizeReturnTo(returnTo);
+
+    const { authorizationUrl, state, nonce, codeVerifier } =
+      await this.oidc.buildAuthorizationUrl(provider);
+
+    AuthCookie.setOidcTempCookies(res, {
+      state,
+      nonce,
+      codeVerifier,
+      returnTo: safeReturnTo,
+      cookieDomain: AuthCookieOptions.getCookieDomain(this.config),
+      secure: AuthCookieOptions.isCookieSecure(this.config),
+      sameSite: AuthCookieOptions.getCookieSameSite(this.config),
+    });
+
+    return { redirectUrl: authorizationUrl };
+  }
+
+  async handleOidcCallback(
+    rawProvider: string,
+    req: Request,
+    res: Response,
+  ): Promise<{ returnTo: string; accessToken: string }> {
+    const provider = parseOidcProvider(rawProvider);
+
+    const { expectedState, expectedNonce, codeVerifier, returnTo } =
+      this.extractOidcTempCookies(req);
+
+    const tokenSet = await this.exchangeOidcCode(
+      provider,
+      req,
+      expectedState,
+      expectedNonce,
+      codeVerifier,
+    );
+
+    const userInfo = this.extractUserInfoFromClaims(tokenSet.claims());
+
+    const account = await this.upsertAccountFromOidc(provider, userInfo);
+
+    const { accessToken } = await this.tokens.issueAuthTokens({
+      accountId: account.id,
+      req,
+      res,
+    });
+
+    AuthCookie.clearOidcTempCookies(
+      res,
+      AuthCookieOptions.getCookieDomain(this.config),
+      AuthCookieOptions.isCookieSecure(this.config),
+      AuthCookieOptions.getCookieSameSite(this.config),
+    );
+
+    return { returnTo, accessToken };
+  }
+
+  /**
+   * OIDC 임시 쿠키를 추출하고 검증한다.
+   */
+  private extractOidcTempCookies(req: Request): {
+    expectedState: string;
+    expectedNonce: string;
+    codeVerifier: string;
+    returnTo: string;
+  } {
+    const expectedState = req.cookies?.[AUTH_COOKIE.OIDC_STATE] as
+      | string
+      | undefined;
+    const expectedNonce = req.cookies?.[AUTH_COOKIE.OIDC_NONCE] as
+      | string
+      | undefined;
+    const codeVerifier = req.cookies?.[AUTH_COOKIE.OIDC_CODE_VERIFIER] as
+      | string
+      | undefined;
+    const returnTo =
+      (req.cookies?.[AUTH_COOKIE.OIDC_RETURN_TO] as string | undefined) ??
+      this.normalizeReturnTo(undefined);
+
+    if (!expectedState || !expectedNonce || !codeVerifier) {
+      throw new UnauthorizedException('OIDC session is missing.');
+    }
+
+    return { expectedState, expectedNonce, codeVerifier, returnTo };
+  }
+
+  /**
+   * OIDC code 를 token 으로 교환한다.
+   */
+  private async exchangeOidcCode(
+    provider: OidcProvider,
+    req: Request,
+    expectedState: string,
+    expectedNonce: string,
+    codeVerifier: string,
+  ) {
+    const callbackParams = this.pickCallbackParams(req);
+    const redirectUri = this.getCallbackRedirectUri(provider);
+
+    return this.oidc.exchangeCode(provider, {
+      redirectUri,
+      callbackParams,
+      state: expectedState,
+      nonce: expectedNonce,
+      codeVerifier,
+    });
+  }
+
+  /**
+   * OIDC claims 에서 사용자 정보를 추출한다.
+   */
+  private extractUserInfoFromClaims(claims: Record<string, unknown>): {
+    subject: string;
+    email?: string;
+    emailVerified: boolean;
+    displayName?: string;
+    picture?: string;
+  } {
+    const subject = typeof claims.sub === 'string' ? claims.sub : null;
+    if (!subject) throw new UnauthorizedException('OIDC subject is missing.');
+
+    const email = typeof claims.email === 'string' ? claims.email : undefined;
+    const emailVerified = claims.email_verified === true;
+
+    const displayName =
+      (typeof claims.name === 'string' ? claims.name : undefined) ??
+      (typeof claims.nickname === 'string' ? claims.nickname : undefined);
+
+    const picture =
+      typeof claims.picture === 'string' ? claims.picture : undefined;
+
+    return { subject, email, emailVerified, displayName, picture };
+  }
+
+  /**
+   * OIDC 사용자 정보로 계정을 생성/업데이트한다.
+   */
+  private async upsertAccountFromOidc(
+    provider: OidcProvider,
+    userInfo: {
+      subject: string;
+      email?: string;
+      emailVerified: boolean;
+      displayName?: string;
+      picture?: string;
+    },
+  ) {
+    const identityProvider = this.oidc.toIdentityProvider(provider);
+
+    const { account } = await this.accounts.upsertUserByOidcIdentity({
+      provider: identityProvider,
+      providerSubject: userInfo.subject,
+      providerEmail: userInfo.email,
+      emailVerified: userInfo.emailVerified,
+      providerDisplayName: userInfo.displayName,
+      providerProfileImageUrl: userInfo.picture,
+    });
+
+    if (!account) throw new UnauthorizedException('Account upsert failed.');
+
+    return account;
+  }
+
+  /**
+   * returnTo 값을 안전하게 정규화한다 (오픈 리다이렉트 방지).
+   */
+  private normalizeReturnTo(raw: string | undefined): string {
+    const frontend =
+      this.config.get<string>('FRONTEND_BASE_URL')?.trim() ??
+      'http://localhost:3000';
+
+    if (!raw || raw.trim().length === 0) return frontend;
+
+    const allowed = [frontend, ...ALLOWED_RETURN_TO_DOMAINS];
+    const ok = allowed.some((prefix) => raw.startsWith(prefix));
+    return ok ? raw : frontend;
+  }
+
+  /**
+   * callback params (code / state 등) 를 안전하게 추출한다.
+   */
+  private pickCallbackParams(req: Request): Record<string, string | string[]> {
+    const q = req.query as Record<string, unknown>;
+    const result: Record<string, string | string[]> = {};
+
+    const isStringArray = (val: unknown): val is string[] =>
+      Array.isArray(val) && val.every((x) => typeof x === 'string');
+
+    const pick = (key: string): void => {
+      const v = q[key];
+
+      if (typeof v === 'string') {
+        result[key] = v;
+        return;
+      }
+
+      if (isStringArray(v)) {
+        result[key] = v;
+      }
+    };
+
+    pick('code');
+    pick('state');
+    pick('iss');
+    pick('error');
+    pick('error_description');
+
+    return result;
+  }
+
+  /**
+   * provider 별 callback redirect uri 를 반환한다.
+   */
+  private getCallbackRedirectUri(provider: OidcProvider): string {
+    const backendBase =
+      this.config.get<string>('BACKEND_BASE_URL')?.trim() ??
+      'http://localhost:4000';
+
+    return `${backendBase}/auth/oidc/${provider}/callback`;
+  }
+}


### PR DESCRIPTION
## Summary

- AuthService 의 OIDC 로그인 시작·콜백·계정 upsert 흐름을 신규 **OidcLoginService** 로 분리.
- AuthController 가 OidcLoginService 를 직접 호출 (AuthService 위임/facade 단계 생략).
- AuthService 줄 수: 약 580 → 약 290 으로 추가 축소.

## Scope

- **신규**
  - OidcLoginService (interface + impl + spec, OIDC_LOGIN_SERVICE Symbol)
  - public: startOidcLogin, handleOidcCallback
  - 관련 private 7 종 헬퍼 동반 (returnTo 정규화 / code 교환 / claims 파싱 / Account upsert 등)
- **제거 (AuthService)**
  - startOidcLogin, handleOidcCallback 두 public 메서드 + OIDC private 7 개
  - ConfigService / OidcClientService / AuthCookie / AuthCookieOptions 의존 제거
- **변경**
  - AuthController: OidcLoginService 직접 주입, OIDC 라우트 2 개가 oidcLogin 호출
  - AuthModule: OidcLoginService 등록
  - auth.service.spec: OIDC 케이스 6 개 제거 (oidc-login.service.spec 으로 이전)
  - auth.controller.spec: OIDC mock 을 oidcLogin 으로 분리

## P0-1 진행 상황

- ✅ 단계 1: RefreshSessionRepository
- ✅ 단계 2: AuditLogRepository
- ✅ 단계 3: AccountRepository / SellerCredentialRepository
- ✅ 단계 4: TokenService
- ✅ 단계 5: OidcLoginService **(본 PR)**
- ⏳ 단계 6: SellerCredentialService + logout 통합
- ⏳ 단계 7: AuthService 잔여 정리 (facade 축소 또는 제거)

## Impact

- FE: 없음 (REST 엔드포인트·응답·에러 형태 동일)
- DB: 변경 없음
- Coverage: 전 임계 통과 (pre-push validate gate 통과)

## Test plan

- [x] pre-push gate (yarn validate) 로컬 통과
- [x] oidc-login.service.spec 신규 (start / callback / 예외 / fallback 케이스)
- [x] auth.controller.spec OIDC mock 분리 후 회귀 없음
- [ ] CI 통과 확인