### PR TITLE
refactor(auth): SellerCredentialService 추출 + 판매자 흐름 분리 (P0-1 단계 6)

### DIFF
--- a/src/features/auth/auth.module.ts
+++ b/src/features/auth/auth.module.ts
@@ -12,6 +12,8 @@ import { SELLER_CREDENTIAL_REPOSITORY } from '@/features/auth/repositories/selle
 import { OidcClientService } from '@/features/auth/services/oidc-client.service';
 import { OidcLoginService } from '@/features/auth/services/oidc-login.service';
 import { OIDC_LOGIN_SERVICE } from '@/features/auth/services/oidc-login.service.interface';
+import { SellerCredentialService } from '@/features/auth/services/seller-credential.service';
+import { SELLER_CREDENTIAL_SERVICE } from '@/features/auth/services/seller-credential.service.interface';
 import { TokenService } from '@/features/auth/services/token.service';
 import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
 import { JwtBearerStrategy } from '@/features/auth/strategies/jwt-bearer.strategy';
@@ -32,6 +34,10 @@ import { AuthGlobalModule } from '@/global/auth/auth-global.module';
     {
       provide: OIDC_LOGIN_SERVICE,
       useClass: OidcLoginService,
+    },
+    {
+      provide: SELLER_CREDENTIAL_SERVICE,
+      useClass: SellerCredentialService,
     },
     {
       provide: TOKEN_SERVICE,

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -1,29 +1,12 @@
 import {
-  BadRequestException,
   ForbiddenException,
   Inject,
   Injectable,
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
-import {
-  AccountType,
-  AuditActionType,
-  AuditTargetType,
-  type AccountStatus,
-} from '@prisma/client';
-import argon2 from 'argon2';
 import type { Request, Response } from 'express';
 
-import { ClockService } from '@/common/providers/clock.service';
-import {
-  AUDIT_LOG_REPOSITORY,
-  type IAuditLogRepository,
-} from '@/features/audit-log';
-import {
-  getIp,
-  getUserAgent,
-} from '@/features/auth/helpers/auth-request-meta.helper';
 import {
   ACCOUNT_REPOSITORY,
   type IAccountRepository,
@@ -33,100 +16,34 @@ import {
   type IRefreshSessionRepository,
 } from '@/features/auth/repositories/refresh-session.repository.interface';
 import {
-  SELLER_CREDENTIAL_REPOSITORY,
-  type ISellerCredentialRepository,
-} from '@/features/auth/repositories/seller-credential.repository.interface';
-import {
   TOKEN_SERVICE,
   type ITokenService,
 } from '@/features/auth/services/token.service.interface';
 import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
 
 /**
- * 인증/로그인/토큰 발급/갱신 비즈니스 로직
+ * 인증/로그인/토큰 발급/갱신 비즈니스 로직 (일반 유저 흐름).
+ *
+ * 판매자 자격증명 흐름은 SellerCredentialService 가, OIDC 흐름은 OidcLoginService 가 담당한다.
  */
 @Injectable()
 export class AuthService {
   /**
    * @param tokens TokenService
    * @param accounts AccountRepository
-   * @param sellerCredentials SellerCredentialRepository
    * @param refreshSessions RefreshSessionRepository
-   * @param auditLogs AuditLogRepository
-   * @param clock ClockService
    */
   constructor(
     @Inject(TOKEN_SERVICE)
     private readonly tokens: ITokenService,
     @Inject(ACCOUNT_REPOSITORY)
     private readonly accounts: IAccountRepository,
-    @Inject(SELLER_CREDENTIAL_REPOSITORY)
-    private readonly sellerCredentials: ISellerCredentialRepository,
     @Inject(REFRESH_SESSION_REPOSITORY)
     private readonly refreshSessions: IRefreshSessionRepository,
-    @Inject(AUDIT_LOG_REPOSITORY)
-    private readonly auditLogs: IAuditLogRepository,
-    private readonly clock: ClockService,
   ) {}
 
   /**
-   * 판매자 username/password 로그인
-   *
-   * @param username 판매자 username
-   * @param password 판매자 password
-   * @param req Request
-   * @param res Response
-   */
-  async sellerLogin(args: {
-    username: string;
-    password: string;
-    req: Request;
-    res: Response;
-  }): Promise<{ accessToken: string; accountStatus: AccountStatus }> {
-    const username = args.username.trim();
-    const password = args.password;
-
-    if (!username || !password.trim()) {
-      throw new UnauthorizedException('Invalid seller credentials.');
-    }
-
-    const credential =
-      await this.sellerCredentials.findSellerCredentialByUsername(username);
-    if (!credential)
-      throw new UnauthorizedException('Invalid seller credentials.');
-
-    if (credential.seller_account.account_type !== AccountType.SELLER) {
-      throw new UnauthorizedException('Invalid seller credentials.');
-    }
-
-    const isPasswordValid = await argon2.verify(
-      credential.password_hash,
-      password,
-    );
-    if (!isPasswordValid) {
-      throw new UnauthorizedException('Invalid seller credentials.');
-    }
-
-    const now = this.clock.now();
-    await this.sellerCredentials.updateSellerLastLogin(
-      credential.seller_account_id,
-      now,
-    );
-
-    const { accessToken } = await this.tokens.issueAuthTokens({
-      accountId: credential.seller_account_id,
-      req: args.req,
-      res: args.res,
-    });
-
-    return {
-      accessToken,
-      accountStatus: credential.seller_account.status,
-    };
-  }
-
-  /**
-   * Refresh 토큰으로 access를 재발급하고 refresh를 회전한다.
+   * Refresh 토큰으로 access 를 재발급하고 refresh 를 회전한다.
    *
    * @param req Request
    * @param res Response
@@ -168,63 +85,6 @@ export class AuthService {
   }
 
   /**
-   * 판매자 refresh 재발급
-   *
-   * @param req Request
-   * @param res Response
-   */
-  async refreshSeller(
-    req: Request,
-    res: Response,
-  ): Promise<{ accessToken: string; accountStatus: AccountStatus }> {
-    const { accessToken, accountId } = await this.tokens.rotateRefresh(
-      req,
-      res,
-    );
-    const seller =
-      await this.sellerCredentials.findSellerCredentialByAccountId(accountId);
-    if (!seller || seller.seller_account.account_type !== AccountType.SELLER) {
-      throw new UnauthorizedException('Invalid seller refresh token.');
-    }
-
-    return {
-      accessToken,
-      accountStatus: seller.seller_account.status,
-    };
-  }
-
-  /**
-   * 판매자 로그아웃
-   *
-   * @param req Request
-   * @param res Response
-   */
-  async logoutSeller(req: Request, res: Response): Promise<void> {
-    const refreshToken = req.cookies?.[AUTH_COOKIE.REFRESH] as
-      | string
-      | undefined;
-
-    if (!refreshToken)
-      throw new UnauthorizedException('Missing refresh token.');
-
-    const tokenHash = this.tokens.sha256Hex(refreshToken);
-    const session =
-      await this.refreshSessions.findActiveRefreshSessionByHash(tokenHash);
-    if (!session) throw new UnauthorizedException('Invalid refresh token.');
-
-    const seller = await this.sellerCredentials.findSellerCredentialByAccountId(
-      session.account_id,
-    );
-    if (!seller || seller.seller_account.account_type !== AccountType.SELLER) {
-      throw new UnauthorizedException('Invalid seller refresh token.');
-    }
-
-    await this.refreshSessions.revokeRefreshSession(session.id);
-
-    this.tokens.clearRefreshCookie(res);
-  }
-
-  /**
    * 로그아웃:
    * - refresh 세션 revoke
    * - refresh 쿠키 삭제
@@ -245,72 +105,6 @@ export class AuthService {
     }
 
     this.tokens.clearRefreshCookie(res);
-  }
-
-  /**
-   * 판매자 비밀번호를 변경한다.
-   *
-   * @param args 변경 파라미터
-   */
-  async changeSellerPassword(args: {
-    accountId: bigint;
-    currentPassword: string;
-    newPassword: string;
-    req: Request;
-  }): Promise<void> {
-    const credential =
-      await this.sellerCredentials.findSellerCredentialByAccountId(
-        args.accountId,
-      );
-    if (!credential) throw new UnauthorizedException('Seller not found.');
-    if (credential.seller_account.account_type !== AccountType.SELLER) {
-      throw new ForbiddenException('Only SELLER account is allowed.');
-    }
-
-    const { currentPassword, newPassword } = args;
-
-    const isCurrentPasswordValid = await argon2.verify(
-      credential.password_hash,
-      currentPassword,
-    );
-    if (!isCurrentPasswordValid) {
-      throw new UnauthorizedException('Current password is invalid.');
-    }
-
-    const isSamePassword = await argon2.verify(
-      credential.password_hash,
-      newPassword,
-    );
-    if (isSamePassword) {
-      throw new BadRequestException(
-        'New password must be different from current password.',
-      );
-    }
-
-    const now = this.clock.now();
-    const newHash = await argon2.hash(newPassword, {
-      type: argon2.argon2id,
-    });
-
-    await this.sellerCredentials.updateSellerPasswordHash({
-      sellerAccountId: args.accountId,
-      passwordHash: newHash,
-      now,
-    });
-    await this.refreshSessions.revokeAllRefreshSessions(args.accountId, now);
-
-    await this.auditLogs.createAuditLog({
-      actorAccountId: args.accountId,
-      storeId: credential.seller_account.store?.id ?? null,
-      targetType: AuditTargetType.CHANGE_PASSWORD,
-      targetId: args.accountId,
-      action: AuditActionType.UPDATE,
-      afterJson: {
-        changedAt: now.toISOString(),
-      },
-      ipAddress: getIp(args.req),
-      userAgent: getUserAgent(args.req),
-    });
   }
 
   /**

--- a/src/features/auth/controllers/auth.controller.spec.ts
+++ b/src/features/auth/controllers/auth.controller.spec.ts
@@ -8,6 +8,10 @@ import {
   OIDC_LOGIN_SERVICE,
   type IOidcLoginService,
 } from '@/features/auth/services/oidc-login.service.interface';
+import {
+  SELLER_CREDENTIAL_SERVICE,
+  type ISellerCredentialService,
+} from '@/features/auth/services/seller-credential.service.interface';
 import type { JwtUser } from '@/global/auth';
 
 function mockRes(): Response {
@@ -23,15 +27,12 @@ describe('AuthController', () => {
   let controller: AuthController;
   let auth: jest.Mocked<AuthService>;
   let oidcLogin: jest.Mocked<IOidcLoginService>;
+  let sellerAuth: jest.Mocked<ISellerCredentialService>;
 
   beforeEach(async () => {
     auth = {
       refresh: jest.fn(),
       logout: jest.fn(),
-      sellerLogin: jest.fn(),
-      refreshSeller: jest.fn(),
-      logoutSeller: jest.fn(),
-      changeSellerPassword: jest.fn(),
       issueDevAccessToken: jest.fn(),
     } as unknown as jest.Mocked<AuthService>;
 
@@ -40,11 +41,19 @@ describe('AuthController', () => {
       handleOidcCallback: jest.fn(),
     };
 
+    sellerAuth = {
+      sellerLogin: jest.fn(),
+      refreshSeller: jest.fn(),
+      logoutSeller: jest.fn(),
+      changeSellerPassword: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
         { provide: AuthService, useValue: auth },
         { provide: OIDC_LOGIN_SERVICE, useValue: oidcLogin },
+        { provide: SELLER_CREDENTIAL_SERVICE, useValue: sellerAuth },
       ],
     }).compile();
 
@@ -130,7 +139,7 @@ describe('AuthController', () => {
   it('sellerLogin은 accessToken + accountStatus를 응답한다', async () => {
     const res = mockRes();
     const req = {} as Request;
-    auth.sellerLogin.mockResolvedValue({
+    sellerAuth.sellerLogin.mockResolvedValue({
       accessToken: 'seller-access',
       accountStatus: 'ACTIVE',
     });
@@ -141,7 +150,7 @@ describe('AuthController', () => {
       res,
     );
 
-    expect(auth.sellerLogin).toHaveBeenCalledWith({
+    expect(sellerAuth.sellerLogin).toHaveBeenCalledWith({
       username: 'seller',
       password: 'pw1234!A',
       req,
@@ -158,14 +167,14 @@ describe('AuthController', () => {
   it('sellerRefresh는 accessToken + accountStatus를 응답한다', async () => {
     const res = mockRes();
     const req = {} as Request;
-    auth.refreshSeller.mockResolvedValue({
+    sellerAuth.refreshSeller.mockResolvedValue({
       accessToken: 'rotated',
       accountStatus: 'ACTIVE',
     });
 
     await controller.sellerRefresh(req, res);
 
-    expect(auth.refreshSeller).toHaveBeenCalledWith(req, res);
+    expect(sellerAuth.refreshSeller).toHaveBeenCalledWith(req, res);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       accessToken: 'rotated',
@@ -180,7 +189,7 @@ describe('AuthController', () => {
 
     await controller.sellerLogout(req, res);
 
-    expect(auth.logoutSeller).toHaveBeenCalledWith(req, res);
+    expect(sellerAuth.logoutSeller).toHaveBeenCalledWith(req, res);
     expect(res.status).toHaveBeenCalledWith(204);
     expect(res.send).toHaveBeenCalled();
   });
@@ -197,7 +206,7 @@ describe('AuthController', () => {
       res,
     );
 
-    expect(auth.changeSellerPassword).toHaveBeenCalledWith({
+    expect(sellerAuth.changeSellerPassword).toHaveBeenCalledWith({
       accountId: BigInt(42),
       currentPassword: 'old!Pass1',
       newPassword: 'New!Pass1',

--- a/src/features/auth/controllers/auth.controller.ts
+++ b/src/features/auth/controllers/auth.controller.ts
@@ -33,6 +33,10 @@ import {
   OIDC_LOGIN_SERVICE,
   type IOidcLoginService,
 } from '@/features/auth/services/oidc-login.service.interface';
+import {
+  SELLER_CREDENTIAL_SERVICE,
+  type ISellerCredentialService,
+} from '@/features/auth/services/seller-credential.service.interface';
 import { parseOidcProvider } from '@/features/auth/types/oidc-provider.type';
 import { CurrentUser, JwtAuthGuard, type JwtUser } from '@/global/auth';
 
@@ -47,11 +51,14 @@ export class AuthController {
   /**
    * @param auth AuthService
    * @param oidcLogin OidcLoginService
+   * @param sellerAuth SellerCredentialService
    */
   constructor(
     private readonly auth: AuthService,
     @Inject(OIDC_LOGIN_SERVICE)
     private readonly oidcLogin: IOidcLoginService,
+    @Inject(SELLER_CREDENTIAL_SERVICE)
+    private readonly sellerAuth: ISellerCredentialService,
   ) {}
 
   /**
@@ -213,7 +220,7 @@ export class AuthController {
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {
-    const { accessToken, accountStatus } = await this.auth.sellerLogin({
+    const { accessToken, accountStatus } = await this.sellerAuth.sellerLogin({
       username: body.username,
       password: body.password,
       req,
@@ -256,7 +263,7 @@ export class AuthController {
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {
-    const { accessToken, accountStatus } = await this.auth.refreshSeller(
+    const { accessToken, accountStatus } = await this.sellerAuth.refreshSeller(
       req,
       res,
     );
@@ -280,7 +287,7 @@ export class AuthController {
   @ApiNoContentResponse({ description: '판매자 로그아웃 완료' })
   @Post('seller/logout')
   async sellerLogout(@Req() req: Request, @Res() res: Response): Promise<void> {
-    await this.auth.logoutSeller(req, res);
+    await this.sellerAuth.logoutSeller(req, res);
     res.status(204).send();
   }
 
@@ -356,7 +363,7 @@ export class AuthController {
     @Res() res: Response,
   ): Promise<void> {
     const accountId = parseAccountId(user);
-    await this.auth.changeSellerPassword({
+    await this.sellerAuth.changeSellerPassword({
       accountId,
       currentPassword: body.currentPassword,
       newPassword: body.newPassword,

--- a/src/features/auth/services/seller-credential.service.interface.ts
+++ b/src/features/auth/services/seller-credential.service.interface.ts
@@ -1,0 +1,47 @@
+import type { AccountStatus } from '@prisma/client';
+import type { Request, Response } from 'express';
+
+/**
+ * SellerCredentialService 토큰 (Nest DI 주입용).
+ */
+export const SELLER_CREDENTIAL_SERVICE = Symbol('SELLER_CREDENTIAL_SERVICE');
+
+/**
+ * 판매자 자격정보 기반 로그인 / 토큰 회전 / 로그아웃 / 비밀번호 변경 흐름을 담당하는 서비스 인터페이스.
+ *
+ * 일반 로그인/로그아웃 (OIDC + 일반 refresh) 흐름은 AuthService 가 담당한다.
+ */
+export interface ISellerCredentialService {
+  /**
+   * 판매자 username/password 로그인.
+   */
+  sellerLogin(args: {
+    username: string;
+    password: string;
+    req: Request;
+    res: Response;
+  }): Promise<{ accessToken: string; accountStatus: AccountStatus }>;
+
+  /**
+   * 판매자 refresh 재발급.
+   */
+  refreshSeller(
+    req: Request,
+    res: Response,
+  ): Promise<{ accessToken: string; accountStatus: AccountStatus }>;
+
+  /**
+   * 판매자 로그아웃 (refresh 쿠키 필수, SELLER 타입 검증).
+   */
+  logoutSeller(req: Request, res: Response): Promise<void>;
+
+  /**
+   * 판매자 비밀번호 변경 + 전 세션 revoke + audit log.
+   */
+  changeSellerPassword(args: {
+    accountId: bigint;
+    currentPassword: string;
+    newPassword: string;
+    req: Request;
+  }): Promise<void>;
+}

--- a/src/features/auth/services/seller-credential.service.spec.ts
+++ b/src/features/auth/services/seller-credential.service.spec.ts
@@ -15,11 +15,6 @@ import {
   AUDIT_LOG_REPOSITORY,
   type IAuditLogRepository,
 } from '@/features/audit-log';
-import { AuthService } from '@/features/auth/auth.service';
-import {
-  ACCOUNT_REPOSITORY,
-  type IAccountRepository,
-} from '@/features/auth/repositories/account.repository.interface';
 import {
   REFRESH_SESSION_REPOSITORY,
   type IRefreshSessionRepository,
@@ -28,12 +23,12 @@ import {
   SELLER_CREDENTIAL_REPOSITORY,
   type ISellerCredentialRepository,
 } from '@/features/auth/repositories/seller-credential.repository.interface';
+import { SellerCredentialService } from '@/features/auth/services/seller-credential.service';
 import { TokenService } from '@/features/auth/services/token.service';
 import { TOKEN_SERVICE } from '@/features/auth/services/token.service.interface';
 
-describe('AuthService (seller)', () => {
-  let service: AuthService;
-  let accounts: jest.Mocked<IAccountRepository>;
+describe('SellerCredentialService', () => {
+  let service: SellerCredentialService;
   let sellerCredentials: jest.Mocked<ISellerCredentialRepository>;
   let refreshSessions: jest.Mocked<IRefreshSessionRepository>;
   let auditLogs: jest.Mocked<IAuditLogRepository>;
@@ -51,14 +46,6 @@ describe('AuthService (seller)', () => {
   } as unknown as Response;
 
   beforeEach(async () => {
-    accounts = {
-      findIdentityByProviderSubject: jest.fn(),
-      findAccountByEmail: jest.fn(),
-      upsertUserByOidcIdentity: jest.fn(),
-      findAccountForJwt: jest.fn(),
-      findAccountForMe: jest.fn(),
-    };
-
     sellerCredentials = {
       findSellerCredentialByUsername: jest.fn(),
       findSellerCredentialByAccountId: jest.fn(),
@@ -84,7 +71,7 @@ describe('AuthService (seller)', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
-        AuthService,
+        SellerCredentialService,
         { provide: ConfigService, useValue: mockConfig },
         {
           provide: JwtService,
@@ -93,10 +80,6 @@ describe('AuthService (seller)', () => {
         {
           provide: TOKEN_SERVICE,
           useClass: TokenService,
-        },
-        {
-          provide: ACCOUNT_REPOSITORY,
-          useValue: accounts,
         },
         {
           provide: SELLER_CREDENTIAL_REPOSITORY,
@@ -114,7 +97,7 @@ describe('AuthService (seller)', () => {
       ],
     }).compile();
 
-    service = module.get<AuthService>(AuthService);
+    service = module.get<SellerCredentialService>(SellerCredentialService);
   });
 
   afterEach(() => {

--- a/src/features/auth/services/seller-credential.service.ts
+++ b/src/features/auth/services/seller-credential.service.ts
@@ -1,0 +1,220 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import {
+  AccountType,
+  AuditActionType,
+  AuditTargetType,
+  type AccountStatus,
+} from '@prisma/client';
+import argon2 from 'argon2';
+import type { Request, Response } from 'express';
+
+import { ClockService } from '@/common/providers/clock.service';
+import {
+  AUDIT_LOG_REPOSITORY,
+  type IAuditLogRepository,
+} from '@/features/audit-log';
+import {
+  getIp,
+  getUserAgent,
+} from '@/features/auth/helpers/auth-request-meta.helper';
+import {
+  REFRESH_SESSION_REPOSITORY,
+  type IRefreshSessionRepository,
+} from '@/features/auth/repositories/refresh-session.repository.interface';
+import {
+  SELLER_CREDENTIAL_REPOSITORY,
+  type ISellerCredentialRepository,
+} from '@/features/auth/repositories/seller-credential.repository.interface';
+import type { ISellerCredentialService } from '@/features/auth/services/seller-credential.service.interface';
+import {
+  TOKEN_SERVICE,
+  type ITokenService,
+} from '@/features/auth/services/token.service.interface';
+import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
+
+/**
+ * 판매자 자격정보 기반 로그인/refresh/logout/changePassword 전담 서비스.
+ *
+ * AuthService 의 판매자 흐름 4 종을 분리한 결과물.
+ */
+@Injectable()
+export class SellerCredentialService implements ISellerCredentialService {
+  /**
+   * @param tokens TokenService
+   * @param sellerCredentials SellerCredentialRepository
+   * @param refreshSessions RefreshSessionRepository
+   * @param auditLogs AuditLogRepository
+   * @param clock ClockService
+   */
+  constructor(
+    @Inject(TOKEN_SERVICE)
+    private readonly tokens: ITokenService,
+    @Inject(SELLER_CREDENTIAL_REPOSITORY)
+    private readonly sellerCredentials: ISellerCredentialRepository,
+    @Inject(REFRESH_SESSION_REPOSITORY)
+    private readonly refreshSessions: IRefreshSessionRepository,
+    @Inject(AUDIT_LOG_REPOSITORY)
+    private readonly auditLogs: IAuditLogRepository,
+    private readonly clock: ClockService,
+  ) {}
+
+  async sellerLogin(args: {
+    username: string;
+    password: string;
+    req: Request;
+    res: Response;
+  }): Promise<{ accessToken: string; accountStatus: AccountStatus }> {
+    const username = args.username.trim();
+    const password = args.password;
+
+    if (!username || !password.trim()) {
+      throw new UnauthorizedException('Invalid seller credentials.');
+    }
+
+    const credential =
+      await this.sellerCredentials.findSellerCredentialByUsername(username);
+    if (!credential)
+      throw new UnauthorizedException('Invalid seller credentials.');
+
+    if (credential.seller_account.account_type !== AccountType.SELLER) {
+      throw new UnauthorizedException('Invalid seller credentials.');
+    }
+
+    const isPasswordValid = await argon2.verify(
+      credential.password_hash,
+      password,
+    );
+    if (!isPasswordValid) {
+      throw new UnauthorizedException('Invalid seller credentials.');
+    }
+
+    const now = this.clock.now();
+    await this.sellerCredentials.updateSellerLastLogin(
+      credential.seller_account_id,
+      now,
+    );
+
+    const { accessToken } = await this.tokens.issueAuthTokens({
+      accountId: credential.seller_account_id,
+      req: args.req,
+      res: args.res,
+    });
+
+    return {
+      accessToken,
+      accountStatus: credential.seller_account.status,
+    };
+  }
+
+  async refreshSeller(
+    req: Request,
+    res: Response,
+  ): Promise<{ accessToken: string; accountStatus: AccountStatus }> {
+    const { accessToken, accountId } = await this.tokens.rotateRefresh(
+      req,
+      res,
+    );
+    const seller =
+      await this.sellerCredentials.findSellerCredentialByAccountId(accountId);
+    if (!seller || seller.seller_account.account_type !== AccountType.SELLER) {
+      throw new UnauthorizedException('Invalid seller refresh token.');
+    }
+
+    return {
+      accessToken,
+      accountStatus: seller.seller_account.status,
+    };
+  }
+
+  async logoutSeller(req: Request, res: Response): Promise<void> {
+    const refreshToken = req.cookies?.[AUTH_COOKIE.REFRESH] as
+      | string
+      | undefined;
+
+    if (!refreshToken)
+      throw new UnauthorizedException('Missing refresh token.');
+
+    const tokenHash = this.tokens.sha256Hex(refreshToken);
+    const session =
+      await this.refreshSessions.findActiveRefreshSessionByHash(tokenHash);
+    if (!session) throw new UnauthorizedException('Invalid refresh token.');
+
+    const seller = await this.sellerCredentials.findSellerCredentialByAccountId(
+      session.account_id,
+    );
+    if (!seller || seller.seller_account.account_type !== AccountType.SELLER) {
+      throw new UnauthorizedException('Invalid seller refresh token.');
+    }
+
+    await this.refreshSessions.revokeRefreshSession(session.id);
+
+    this.tokens.clearRefreshCookie(res);
+  }
+
+  async changeSellerPassword(args: {
+    accountId: bigint;
+    currentPassword: string;
+    newPassword: string;
+    req: Request;
+  }): Promise<void> {
+    const credential =
+      await this.sellerCredentials.findSellerCredentialByAccountId(
+        args.accountId,
+      );
+    if (!credential) throw new UnauthorizedException('Seller not found.');
+    if (credential.seller_account.account_type !== AccountType.SELLER) {
+      throw new ForbiddenException('Only SELLER account is allowed.');
+    }
+
+    const { currentPassword, newPassword } = args;
+
+    const isCurrentPasswordValid = await argon2.verify(
+      credential.password_hash,
+      currentPassword,
+    );
+    if (!isCurrentPasswordValid) {
+      throw new UnauthorizedException('Current password is invalid.');
+    }
+
+    const isSamePassword = await argon2.verify(
+      credential.password_hash,
+      newPassword,
+    );
+    if (isSamePassword) {
+      throw new BadRequestException(
+        'New password must be different from current password.',
+      );
+    }
+
+    const now = this.clock.now();
+    const newHash = await argon2.hash(newPassword, {
+      type: argon2.argon2id,
+    });
+
+    await this.sellerCredentials.updateSellerPasswordHash({
+      sellerAccountId: args.accountId,
+      passwordHash: newHash,
+      now,
+    });
+    await this.refreshSessions.revokeAllRefreshSessions(args.accountId, now);
+
+    await this.auditLogs.createAuditLog({
+      actorAccountId: args.accountId,
+      storeId: credential.seller_account.store?.id ?? null,
+      targetType: AuditTargetType.CHANGE_PASSWORD,
+      targetId: args.accountId,
+      action: AuditActionType.UPDATE,
+      afterJson: {
+        changedAt: now.toISOString(),
+      },
+      ipAddress: getIp(args.req),
+      userAgent: getUserAgent(args.req),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- AuthService 의 판매자 자격증명 기반 흐름 4 종을 신규 **SellerCredentialService** 로 분리.
- AuthController 가 직접 호출. AuthService 는 일반 유저 흐름만 보유.
- AuthService 줄 수: 약 290 → 약 80 으로 축소.

## Scope

- **신규**
  - SellerCredentialService (interface + impl, SELLER_CREDENTIAL_SERVICE Symbol)
  - 메서드: sellerLogin / refreshSeller / logoutSeller / changeSellerPassword
- **제거 (AuthService)**
  - 위 4 개 메서드
  - 부수: ClockService / argon2 / SellerCredentialRepository / AuditLogRepository /
    Audit · Prisma enum / AccountStatus 타입 의존 제거
- **변경**
  - AuthController: sellerAuth 의존 추가, /auth/seller/* 4 개 라우트가 sellerAuth.* 호출
  - AuthModule: SellerCredentialService 등록
  - 스펙 이전: \`auth.seller.service.spec.ts\` → \`services/seller-credential.service.spec.ts\`
    (대상 클래스 변경 + accounts mock 제거, 그 외 케이스 그대로)
  - AuthController spec: 판매자 라우트 mock 을 sellerAuth 로 분리

## logout / logoutSeller "통합"에 대한 해석

플랜의 표현은 "logout / logoutSeller 통합" 이지만, 두 흐름은 책임이 다릅니다.
- \`logout\`: 일반 사용자. refresh 쿠키 옵셔널 (없어도 200).
- \`logoutSeller\`: 판매자. refresh 쿠키 필수 + SELLER 타입 검증.

완전 통합은 책임 정합성을 깨뜨리므로, **각자 도메인 서비스에 거주시키는 형태** 로 정리했습니다.
공통 로직(쿠키 추출 + 해시 + 세션 조회) 의 5 라인 중복은 그대로 두었습니다 — 별도 헬퍼화는
가치 대비 추상화 비용이 크다고 판단.

## P0-1 진행 상황

- ✅ 단계 1: RefreshSessionRepository
- ✅ 단계 2: AuditLogRepository
- ✅ 단계 3: AccountRepository / SellerCredentialRepository
- ✅ 단계 4: TokenService
- ✅ 단계 5: OidcLoginService
- ✅ 단계 6: SellerCredentialService **(본 PR)**
- ⏳ 단계 7: AuthService 잔여 정리 (refresh / logout / issueDevAccessToken / me 만 남음)

## Impact

- FE: 없음 (REST 엔드포인트·응답·에러 형태 동일)
- DB: 변경 없음
- Coverage: pre-push validate gate 통과

## Test plan

- [x] pre-push gate (yarn validate) 로컬 통과
- [x] seller-credential.service.spec.ts (sellerLogin / refreshSeller / logoutSeller /
      changeSellerPassword 전 케이스) 회귀 없음
- [x] auth.controller.spec 판매자 라우트가 sellerAuth mock 으로 동작
- [ ] CI 통과 확인