### PR TITLE
refactor(auth): AuthService 잔여 정리 + me() dead code 제거 (P0-1 단계 7 / 완료)

### DIFF
--- a/src/features/auth/auth.service.spec.ts
+++ b/src/features/auth/auth.service.spec.ts
@@ -53,7 +53,6 @@ describe('AuthService', () => {
       findAccountByEmail: jest.fn(),
       upsertUserByOidcIdentity: jest.fn(),
       findAccountForJwt: jest.fn(),
-      findAccountForMe: jest.fn(),
     };
 
     mockSellerCredentials = {
@@ -249,86 +248,6 @@ describe('AuthService', () => {
       // Assert
       expect(mockRefreshSessions.revokeRefreshSession).not.toHaveBeenCalled();
       expect(mockRes.clearCookie).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('me', () => {
-    it('사용자 정보를 성공적으로 반환해야 한다', async () => {
-      // Arrange
-      mockAccounts.findAccountForMe.mockResolvedValue({
-        id: BigInt(1),
-        email: 'test@example.com',
-        name: 'Test User',
-        user_profile: {
-          nickname: 'testuser',
-          profile_image_url: 'https://example.com/photo.jpg',
-          birth_date: new Date('1990-01-01'),
-          phone_number: '010-1234-5678',
-        },
-      } as never);
-
-      // Act
-      const result = await service.me(BigInt(1));
-
-      // Assert
-      expect(result).toEqual({
-        accountId: '1',
-        email: 'test@example.com',
-        name: 'Test User',
-        nickname: 'testuser',
-        profileImageUrl: 'https://example.com/photo.jpg',
-        birthDate: '1990-01-01',
-        phoneNumber: '010-1234-5678',
-        needsProfile: false,
-      });
-    });
-
-    it('프로필 정보가 불완전하면 needsProfile이 true여야 한다', async () => {
-      // Arrange
-      mockAccounts.findAccountForMe.mockResolvedValue({
-        id: BigInt(1),
-        email: 'test@example.com',
-        name: 'Test User',
-        user_profile: {
-          nickname: 'testuser',
-          profile_image_url: null,
-          birth_date: null, // 누락
-          phone_number: null, // 누락
-        },
-      } as never);
-
-      // Act
-      const result = await service.me(BigInt(1));
-
-      // Assert
-      expect(result.needsProfile).toBe(true);
-    });
-
-    it('계정을 찾을 수 없으면 UnauthorizedException을 던져야 한다', async () => {
-      // Arrange
-      mockAccounts.findAccountForMe.mockResolvedValue(null);
-
-      // Act & Assert
-      await expect(service.me(BigInt(999))).rejects.toThrow(
-        'Account not found.',
-      );
-    });
-
-    it('user_profile이 아예 null이면 모든 프로필 필드가 null + needsProfile=true', async () => {
-      mockAccounts.findAccountForMe.mockResolvedValue({
-        id: BigInt(1),
-        email: null,
-        name: null,
-        user_profile: null,
-      } as never);
-
-      const result = await service.me(BigInt(1));
-
-      expect(result.nickname).toBeNull();
-      expect(result.profileImageUrl).toBeNull();
-      expect(result.birthDate).toBeNull();
-      expect(result.phoneNumber).toBeNull();
-      expect(result.needsProfile).toBe(true);
     });
   });
 

--- a/src/features/auth/auth.service.ts
+++ b/src/features/auth/auth.service.ts
@@ -3,7 +3,6 @@ import {
   Inject,
   Injectable,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 
@@ -22,9 +21,12 @@ import {
 import { AUTH_COOKIE } from '@/global/auth/constants/auth-cookie.constants';
 
 /**
- * 인증/로그인/토큰 발급/갱신 비즈니스 로직 (일반 유저 흐름).
+ * 인증 도메인 진입 서비스 (일반 유저용 refresh / logout / dev token 발급).
  *
- * 판매자 자격증명 흐름은 SellerCredentialService 가, OIDC 흐름은 OidcLoginService 가 담당한다.
+ * 다른 흐름은 별도 서비스가 담당:
+ * - OIDC 시작/콜백: OidcLoginService
+ * - 판매자 자격증명 (login / refresh / logout / changePassword): SellerCredentialService
+ * - GraphQL `me` 조회: UserProfileService
  */
 @Injectable()
 export class AuthService {
@@ -105,33 +107,5 @@ export class AuthService {
     }
 
     this.tokens.clearRefreshCookie(res);
-  }
-
-  /**
-   * 현재 로그인 사용자 정보를 반환한다.
-   *
-   * @param accountId accountId(BigInt)
-   */
-  async me(accountId: bigint) {
-    const account = await this.accounts.findAccountForMe(accountId);
-    if (!account) throw new UnauthorizedException('Account not found.');
-
-    const profile = account.user_profile;
-
-    const needsProfile =
-      !profile?.birth_date || !profile?.phone_number || !profile?.nickname;
-
-    return {
-      accountId: account.id.toString(),
-      email: account.email,
-      name: account.name,
-      nickname: profile?.nickname ?? null,
-      profileImageUrl: profile?.profile_image_url ?? null,
-      birthDate: profile?.birth_date
-        ? profile.birth_date.toISOString().slice(0, 10)
-        : null,
-      phoneNumber: profile?.phone_number ?? null,
-      needsProfile,
-    };
   }
 }

--- a/src/features/auth/repositories/account.repository.interface.ts
+++ b/src/features/auth/repositories/account.repository.interface.ts
@@ -69,9 +69,4 @@ export interface IAccountRepository {
    * access token 검증용으로 계정을 조회한다.
    */
   findAccountForJwt(accountId: bigint): Promise<AccountForJwt | null>;
-
-  /**
-   * accountId 기준으로 유저를 조회한다(soft-delete 제외).
-   */
-  findAccountForMe(accountId: bigint): Promise<AccountWithProfile | null>;
 }

--- a/src/features/auth/repositories/account.repository.spec.ts
+++ b/src/features/auth/repositories/account.repository.spec.ts
@@ -197,16 +197,4 @@ describe('AccountRepository (real DB)', () => {
       expect(found!.account_type).toBe('USER');
     });
   });
-
-  describe('findAccountForMe', () => {
-    it('계정 + user_profile을 반환한다', async () => {
-      const account = await createAccount(prisma);
-      await createUserProfile(prisma, { account_id: account.id });
-
-      const found = await repo.findAccountForMe(account.id);
-
-      expect(found).not.toBeNull();
-      expect(found!.user_profile).not.toBeNull();
-    });
-  });
 });

--- a/src/features/auth/repositories/account.repository.ts
+++ b/src/features/auth/repositories/account.repository.ts
@@ -246,13 +246,4 @@ export class AccountRepository implements IAccountRepository {
       },
     });
   }
-
-  async findAccountForMe(
-    accountId: bigint,
-  ): Promise<AccountWithProfile | null> {
-    return this.prisma.account.findFirst({
-      where: { id: accountId },
-      include: { user_profile: true },
-    });
-  }
 }

--- a/src/features/auth/services/oidc-login.service.spec.ts
+++ b/src/features/auth/services/oidc-login.service.spec.ts
@@ -42,7 +42,6 @@ describe('OidcLoginService', () => {
       findAccountByEmail: jest.fn(),
       upsertUserByOidcIdentity: jest.fn(),
       findAccountForJwt: jest.fn(),
-      findAccountForMe: jest.fn(),
     };
 
     mockRefreshSessions = {


### PR DESCRIPTION
## Summary

P0-1 의 마지막 단계. AuthService 의 잔여 책임을 정리하고 dead code 를 제거.
이 PR 머지로 **P0-1 (Auth God-class 해체) 전 단계 완료**.

## Scope

- **dead code 제거**
  - \`AuthService.me()\` — 호출자 0 (GraphQL me query 는 UserProfileService.me 가 담당)
  - \`AccountRepository.findAccountForMe()\` — me() 에서만 사용 → 따라서 dead
- **정리**
  - AuthService docstring 갱신: "일반 유저 흐름" 책임 명확화, 다른 흐름은 별도 서비스로 위임 명시
  - 불필요한 imports 제거 (\`UnauthorizedException\` 등)
  - oidc-login.service.spec / auth.service.spec / account.repository.spec mock 정리

## P0-1 최종 결과

| Before | After |
|---|---|
| AuthService 824줄 / 10 public | **AuthService 60줄 / 3 public** (refresh / logout / issueDevAccessToken) |
| AuthRepository 530줄 / 15 메서드 | **제거** — 4 Repository 로 분리 |
| Auth feature: 1 Service / 1 Repository | **4 Service / 4 Repository** (interface + DI Token 패턴) |
| DI Token 패턴 0 건 | **7 건** (RefreshSession / AuditLog / Account / SellerCredential Repo + Token / OidcLogin / SellerCredential Service) |

각 단계 PR: #106 → #107 → #108 → #109 → #110 → #111 → 본 PR

## Impact

- FE: 없음 (REST 엔드포인트·응답·에러 형태 동일)
- DB: 변경 없음
- Coverage: pre-push validate gate 통과

## Test plan

- [x] pre-push gate (yarn validate) 로컬 통과
- [x] AuthService.me 호출처 0 건 확인 후 제거
- [x] AccountRepository.findAccountForMe 호출처 0 건 확인 후 제거
- [ ] CI 통과 확인