### PR TITLE
refactor: throw new Error 도메인 오류 정리 (P1-2)

### DIFF
--- a/src/common/utils/id-parser.ts
+++ b/src/common/utils/id-parser.ts
@@ -1,17 +1,18 @@
 import { BadRequestException } from '@nestjs/common';
 
 export function parseId(raw: string): bigint {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    throw new BadRequestException('Invalid id.');
+  }
+  let id: bigint;
   try {
-    const trimmed = raw.trim();
-    if (trimmed === '') {
-      throw new Error('empty');
-    }
-    const id = BigInt(trimmed);
-    if (id < 0n) {
-      throw new Error('negative');
-    }
-    return id;
+    id = BigInt(trimmed);
   } catch {
     throw new BadRequestException('Invalid id.');
   }
+  if (id < 0n) {
+    throw new BadRequestException('Invalid id.');
+  }
+  return id;
 }

--- a/src/features/auth/types/oidc-provider.type.spec.ts
+++ b/src/features/auth/types/oidc-provider.type.spec.ts
@@ -1,3 +1,5 @@
+import { BadRequestException } from '@nestjs/common';
+
 import { parseOidcProvider } from '@/features/auth/types/oidc-provider.type';
 
 describe('parseOidcProvider', () => {
@@ -9,17 +11,20 @@ describe('parseOidcProvider', () => {
     expect(parseOidcProvider('kakao')).toBe('kakao');
   });
 
-  it('지원하지 않는 provider이면 에러를 던진다', () => {
+  it('지원하지 않는 provider이면 BadRequestException을 던진다', () => {
+    expect(() => parseOidcProvider('facebook')).toThrow(BadRequestException);
     expect(() => parseOidcProvider('facebook')).toThrow(
       'Unsupported OIDC provider: facebook',
     );
   });
 
-  it('빈 문자열이면 에러를 던진다', () => {
+  it('빈 문자열이면 BadRequestException을 던진다', () => {
+    expect(() => parseOidcProvider('')).toThrow(BadRequestException);
     expect(() => parseOidcProvider('')).toThrow('Unsupported OIDC provider: ');
   });
 
   it('대소문자를 구분한다', () => {
+    expect(() => parseOidcProvider('Google')).toThrow(BadRequestException);
     expect(() => parseOidcProvider('Google')).toThrow(
       'Unsupported OIDC provider: Google',
     );

--- a/src/features/auth/types/oidc-provider.type.ts
+++ b/src/features/auth/types/oidc-provider.type.ts
@@ -1,3 +1,5 @@
+import { BadRequestException } from '@nestjs/common';
+
 /**
  * 지원하는 OIDC Provider 타입
  */
@@ -6,10 +8,14 @@ export type OidcProvider = 'google' | 'kakao';
 /**
  * OIDC Provider 파라미터를 검증하고 타입으로 변환한다.
  *
+ * 호출 컨텍스트: HTTP request path (auth.controller 콜백, oidc-login.service).
+ * 따라서 잘못된 값은 도메인 입력 오류로 분류해 4xx 로 반환한다.
+ *
  * @param raw provider 문자열
  * @returns provider 타입
+ * @throws BadRequestException 지원하지 않는 provider 인 경우
  */
 export function parseOidcProvider(raw: string): OidcProvider {
   if (raw === 'google' || raw === 'kakao') return raw;
-  throw new Error(`Unsupported OIDC provider: ${raw}`);
+  throw new BadRequestException(`Unsupported OIDC provider: ${raw}`);
 }

--- a/src/global/auth/parse-account-id.ts
+++ b/src/global/auth/parse-account-id.ts
@@ -3,20 +3,21 @@ import { BadRequestException } from '@nestjs/common';
 import type { JwtUser } from '@/global/auth/types/jwt-payload.type';
 
 export function parseAccountId(user: JwtUser): bigint {
+  const raw =
+    typeof user.accountId === 'string'
+      ? user.accountId.trim()
+      : String(user.accountId ?? '');
+  if (raw === '') {
+    throw new BadRequestException('Invalid account id.');
+  }
+  let id: bigint;
   try {
-    const raw =
-      typeof user.accountId === 'string'
-        ? user.accountId.trim()
-        : String(user.accountId ?? '');
-    if (raw === '') {
-      throw new Error('empty');
-    }
-    const id = BigInt(raw);
-    if (id < 0n) {
-      throw new Error('negative');
-    }
-    return id;
+    id = BigInt(raw);
   } catch {
     throw new BadRequestException('Invalid account id.');
   }
+  if (id < 0n) {
+    throw new BadRequestException('Invalid account id.');
+  }
+  return id;
 }


### PR DESCRIPTION
## Summary

도메인 입력 오류 (request path) 를 `throw new Error` 대신 HttpException 으로 변환한다.
boot-time fail-fast (config / JWT_ACCESS_SECRET 누락 등) 는 운영 의도(500) 와 일치하므로 그대로 유지.

## Scope

- **변경 1: 동작 차이 있음 (FE 협의 #3 대상)**
  - `src/features/auth/types/oidc-provider.type.ts`
  - 잘못된 provider 슬러그 → `throw new Error` → **`BadRequestException`**
  - 호출 컨텍스트: `auth.controller.ts:97` OIDC 콜백, `oidc-login.service.ts:51,75`
  - Before: 500 Internal Server Error
  - After: 400 Bad Request (`Unsupported OIDC provider: <raw>`)
- **변경 2: 동작 차이 없음 (스타일 정리)**
  - `src/common/utils/id-parser.ts`
  - `src/global/auth/parse-account-id.ts`
  - 같은 함수 내 try/catch 제어흐름용 `throw new Error('empty'/'negative')` 제거
  - `BadRequestException` 직접 throw 로 단순화. 외부 응답은 이미 400 으로 동일.
- **변경 3: 유지 (boot-time fail-fast)**
  - `src/config/{oidc,auth,docs,s3,database}.config.ts`
  - `src/common/helpers/config.helper.ts` (`mustGetEnv`)
  - `src/global/auth/auth-global.module.ts` (JwtModule factory)
  - `src/features/auth/strategies/jwt-bearer.strategy.ts` (생성자)
  - 위는 모두 부팅 시점에 process exit 의도. CLAUDE.md "운영 환경에서 JWT 시크릿 누락 시 서버가 뜨면 안 됨 (fail-fast)" 와 일치.

## FE 협의 #3 — 액션 요청

**대상 경로**: `/auth/oidc/<provider>/...` (구체적으로 invalid provider slug 가 들어온 경우)

| | Before | After |
|---|---|---|
| HTTP status | 500 | **400** |
| body | Internal server error | `{ statusCode: 400, message: "Unsupported OIDC provider: <raw>" }` |

- 위 경로에 대한 **500 retry 로직이 있다면 제거** (이제 4xx 로 변환됨, retry 무의미)
- 다른 OIDC 엔드포인트 동작은 동일

## Impact

- FE: **있음 (정상화)** — 협의 #3 안내 위 표
- DB: 변경 없음
- Coverage: pre-push validate gate 통과 (전체 1174 테스트)

## Test plan

- [x] oidc-provider.type.spec — `BadRequestException` assertion 추가
- [x] id-parser.spec / parse-account-id.spec — 기존 `BadRequestException` assertion 그대로 통과
- [x] pre-push gate (yarn validate) 로컬 통과
- [ ] CI 통과 확인
- [ ] FE 에 협의 #3 안내 (머지 직전)