### PR TITLE
fix(filter): GraphQL 에러 중복 로깅 제거 (#117 follow-up)

### DIFF
--- a/src/global/interceptors/gql-logging.interceptor.spec.ts
+++ b/src/global/interceptors/gql-logging.interceptor.spec.ts
@@ -115,34 +115,27 @@ describe('GqlLoggingInterceptor', () => {
     });
   });
 
-  it('에러 시 txError 로그에 에러 메시지가 포함된다', (done) => {
+  it('에러 시 txError 는 호출되지 않는다 (GraphQLExceptionFilter 가 담당)', (done) => {
     const ctx = mockGqlContext('Query');
     interceptor.intercept(ctx, mockErrorHandler(new Error('fail'))).subscribe({
       error: () => {
-        expect(logger.txError).toHaveBeenCalledWith(
-          expect.objectContaining({
-            error: expect.objectContaining({ message: 'fail' }),
-            processingTimeInMs: expect.any(Number),
-          }),
-        );
+        // 중복 로깅 방지: HTTP path 의 HttpExceptionFilter 와 동일 패턴으로
+        // 에러 로깅 owner 는 GraphQLExceptionFilter.
+        expect(logger.txError).not.toHaveBeenCalled();
         done();
       },
     });
   });
 
-  it('에러가 Error 인스턴스가 아니면 "Unknown error" + stack undefined로 로깅', (done) => {
+  it('에러 시에도 setResponseTimeHeader 는 호출된다 (응답 시간 추적 유지)', (done) => {
     const ctx = mockGqlContext('Query');
-    const notAnError = 'just a string thrown';
-    const handler = {
-      handle: () => throwError(() => notAnError),
-    } as CallHandler;
-
-    interceptor.intercept(ctx, handler).subscribe({
+    const args = ctx.getArgs();
+    const gqlContext = args[2] as { res: { setHeader: jest.Mock } };
+    interceptor.intercept(ctx, mockErrorHandler(new Error('boom'))).subscribe({
       error: () => {
-        expect(logger.txError).toHaveBeenCalledWith(
-          expect.objectContaining({
-            error: { message: 'Unknown error', stack: undefined },
-          }),
+        expect(gqlContext.res.setHeader).toHaveBeenCalledWith(
+          'x-response-time-ms',
+          expect.any(String),
         );
         done();
       },

--- a/src/global/interceptors/gql-logging.interceptor.ts
+++ b/src/global/interceptors/gql-logging.interceptor.ts
@@ -31,7 +31,9 @@ export class GqlLoggingInterceptor implements NestInterceptor {
 
   /**
    * GraphQL 실행 컨텍스트에서 메타데이터를 수집하고,
-   * 성공/에러 모두에 대해 트랜잭션 로그를 남긴다.
+   * 성공 시 트랜잭션 로그(tx) 를 남긴다.
+   * 에러 로깅은 GraphQLExceptionFilter 가 담당 (HTTP path 의 HttpExceptionFilter 와 동일 패턴).
+   * 단, 에러 응답에도 response time header 가 누락되지 않도록 setResponseTimeHeader 는 본 인터셉터에서 유지.
    */
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const type = context.getType<GqlContextType>();
@@ -72,18 +74,10 @@ export class GqlLoggingInterceptor implements NestInterceptor {
 
           setResponseTimeHeader(res, duration);
         },
-        error: (error: unknown) => {
+        error: () => {
+          // 에러 로깅은 GraphQLExceptionFilter 가 담당 (중복 방지).
+          // 본 인터셉터에서는 응답 시간 헤더만 누락 없이 기록한다.
           const duration = calculateDuration(startTime);
-
-          this.logger.txError({
-            ...baseLog,
-            processingTimeInMs: duration,
-            error: {
-              message: error instanceof Error ? error.message : 'Unknown error',
-              stack: error instanceof Error ? error.stack : undefined,
-            },
-          });
-
           setResponseTimeHeader(res, duration);
         },
       }),


### PR DESCRIPTION
## Summary

#117 (P1-3 GraphQL 전용 예외 필터) Codex 리뷰 후속. GraphQL 에러가 `GqlLoggingInterceptor.tap.error` 와 `GraphQLExceptionFilter.format` 양쪽에서 `txError` 를 호출해 동일 요청/에러에 대한 중복 로그가 발생하던 문제 수정.

## Scope

- **`gql-logging.interceptor.ts`**
  - `tap.error` 콜백에서 `this.logger.txError({...})` 호출 제거
  - `setResponseTimeHeader(res, duration)` 호출은 유지 (에러 응답에서도 응답 시간 헤더 누락 방지)
  - 결과: 에러 로깅 owner 가 `GraphQLExceptionFilter` 단일화 — HTTP path (`HttpLoggingInterceptor` + `HttpExceptionFilter`) 와 동일 패턴
- **`gql-logging.interceptor.spec.ts`**
  - 기존 "에러 시 txError 로그에 메시지 포함" / "Error 인스턴스 아닐 때 Unknown error 로깅" 케이스 제거
  - 신규 케이스 2개 추가
    - "에러 시 txError 는 호출되지 않는다 (GraphQLExceptionFilter 가 담당)" — 중복 로깅 회귀 가드
    - "에러 시에도 setResponseTimeHeader 는 호출된다" — 응답 시간 헤더 보존 가드

## 원인 분석

| Path | 인터셉터 (성공 tx) | 인터셉터 (에러 txError) | 필터 (txError) |
|---|---|---|---|
| HTTP | ✅ HttpLoggingInterceptor | ❌ (없음) | ✅ HttpExceptionFilter |
| GraphQL (Before) | ✅ GqlLoggingInterceptor | ⚠️ **중복** | ✅ GraphQLExceptionFilter |
| GraphQL (After) | ✅ GqlLoggingInterceptor | ❌ (제거) | ✅ GraphQLExceptionFilter |

## Impact

- FE: 없음 (응답 형태/내용 불변)
- DB: 변경 없음
- 운영 로그: GraphQL 에러 요청당 `txError` 1 건 → 1 건 (중복 0). 에러 카운터·알람 inflation 해소
- Coverage: pre-push validate gate 통과 (전체 1191 테스트)

## Test plan

- [x] `gql-logging.interceptor.spec` — 에러 시 `txError` 미호출 + `setResponseTimeHeader` 호출 검증
- [x] `graphql-exception.filter.spec` — 기존 16 케이스 그대로 통과 (필터의 `txError` 로깅 보존)
- [x] pre-push gate (yarn validate) 로컬 통과
- [ ] CI 통과 확인
