### PR TITLE
fix(audit): client IP trust-proxy 정합 + 감사 로그 IP 배선 (ALS 요청 컨텍스트)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,6 +28,10 @@ import { AuthGlobalModule } from '@/global/auth/auth-global.module';
 import { GraphqlGlobalModule } from '@/global/graphql/graphql.module';
 import { LoggerModule } from '@/global/logger/logger.module';
 import { DocsAccessMiddleware } from '@/global/middlewares/docs-access.middleware';
+import {
+  RequestContextMiddleware,
+  RequestContextModule,
+} from '@/global/request-context';
 import { StorageModule } from '@/global/storage/storage.module';
 import { PrismaModule } from '@/prisma';
 
@@ -44,6 +48,7 @@ import { PrismaModule } from '@/prisma';
     }),
     CommonModule,
     PrismaModule,
+    RequestContextModule,
     LoggerModule,
     AuthGlobalModule,
     GraphqlGlobalModule,
@@ -88,6 +93,11 @@ import { PrismaModule } from '@/prisma';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {
+    // 모든 요청(REST·GraphQL)에 대해 요청 컨텍스트(client IP/UA)를 가장 먼저 연다.
+    consumer
+      .apply(RequestContextMiddleware)
+      .forRoutes({ path: '*path', method: RequestMethod.ALL });
+
     consumer
       .apply(DocsAccessMiddleware)
       .forRoutes(

--- a/src/common/utils/http-meta.spec.ts
+++ b/src/common/utils/http-meta.spec.ts
@@ -35,23 +35,25 @@ describe('http-meta', () => {
   });
 
   describe('clientIpOf', () => {
-    it('X-Forwarded-For 첫 번째 IP를 반환한다', () => {
-      expect(
-        clientIpOf(mockReq({ 'x-forwarded-for': '1.2.3.4, 5.6.7.8' })),
-      ).toBe('1.2.3.4');
-    });
-
-    it('X-Forwarded-For가 없으면 X-Real-IP를 반환한다', () => {
-      expect(clientIpOf(mockReq({ 'x-real-ip': '10.0.0.1' }))).toBe('10.0.0.1');
-    });
-
-    it('둘 다 없으면 req.ip를 반환한다', () => {
+    it('req.ip (trust proxy 가 계산한 값) 를 반환한다', () => {
       expect(clientIpOf(mockReq({}, { ip: '192.168.0.1' }))).toBe(
         '192.168.0.1',
       );
     });
 
-    it('모두 없으면 socket.remoteAddress를 반환한다', () => {
+    it('raw X-Forwarded-For 를 신뢰하지 않고 req.ip 를 반환한다 (spoofing 방어)', () => {
+      // 클라이언트가 XFF 를 위조해도 Express 가 계산한 req.ip 만 사용한다.
+      expect(
+        clientIpOf(
+          mockReq(
+            { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' },
+            { ip: '203.0.113.9' },
+          ),
+        ),
+      ).toBe('203.0.113.9');
+    });
+
+    it('req.ip 가 없으면 socket.remoteAddress 를 반환한다', () => {
       expect(clientIpOf(mockReq())).toBe('127.0.0.1');
     });
 
@@ -81,25 +83,29 @@ describe('http-meta', () => {
   });
 
   describe('tryClientIp (DB persistence 용 — 추출 실패 시 undefined)', () => {
-    it('X-Forwarded-For 첫 번째 IP를 반환한다', () => {
-      expect(
-        tryClientIp(mockReq({ 'x-forwarded-for': '1.2.3.4, 5.6.7.8' })),
-      ).toBe('1.2.3.4');
-    });
-
-    it('X-Real-IP 를 반환한다', () => {
-      expect(tryClientIp(mockReq({ 'x-real-ip': '10.0.0.1' }))).toBe(
-        '10.0.0.1',
-      );
-    });
-
-    it('req.ip 를 반환한다', () => {
+    it('req.ip (trust proxy 가 계산한 값) 를 반환한다', () => {
       expect(tryClientIp(mockReq({}, { ip: '192.168.0.1' }))).toBe(
         '192.168.0.1',
       );
     });
 
-    it('socket.remoteAddress 를 반환한다', () => {
+    it('raw X-Forwarded-For 를 신뢰하지 않고 req.ip 를 반환한다 (spoofing 방어)', () => {
+      // 위조된 XFF 가 있어도 Express 가 계산한 req.ip 만 채택한다.
+      expect(
+        tryClientIp(
+          mockReq({ 'x-forwarded-for': '1.2.3.4' }, { ip: '203.0.113.9' }),
+        ),
+      ).toBe('203.0.113.9');
+    });
+
+    it('raw X-Real-IP 를 신뢰하지 않는다 (spoofing 방어)', () => {
+      // X-Real-IP 만 있고 req.ip 가 없으면 헤더가 아니라 socket fallback 으로 간다.
+      expect(tryClientIp(mockReq({ 'x-real-ip': '10.0.0.1' }))).toBe(
+        '127.0.0.1',
+      );
+    });
+
+    it('req.ip 가 없으면 socket.remoteAddress 를 반환한다', () => {
       expect(tryClientIp(mockReq())).toBe('127.0.0.1');
     });
 

--- a/src/common/utils/http-meta.ts
+++ b/src/common/utils/http-meta.ts
@@ -11,24 +11,19 @@ export function tryUserAgent(req: Request): string | undefined {
 }
 
 /**
- * Client IP 를 추출한다 (X-Forwarded-For → X-Real-IP → req.ip → socket.remoteAddress 순).
- * 추출 실패 시 undefined (DB nullable persistence 용).
+ * Client IP 를 추출한다.
  *
- * 운영 환경에서 정확한 client IP 를 얻으려면 main.ts 의 trust proxy 설정 필요
- * (Express 가 X-Forwarded-For 를 신뢰해서 req.ip 에 반영).
+ * Express 의 `trust proxy` 설정(main.ts, `TRUST_PROXY_HOPS`)으로 계산된 `req.ip` 를
+ * 단일 진실 소스로 사용한다. trust proxy 가 설정되면 Express 가 X-Forwarded-For 를
+ * hop 수만큼 신뢰해 실제 client IP 를 `req.ip` 에 반영하고, 미설정 시 socket 주소를 쓴다.
+ *
+ * raw `X-Forwarded-For` / `X-Real-IP` 헤더를 **직접 신뢰하지 않는다** — 클라이언트가
+ * 임의로 위조할 수 있어 trust proxy 검증을 우회하기 때문(IP spoofing). hop 수 적용은
+ * 전적으로 Express 에 위임한다.
+ *
+ * 추출 실패 시 undefined (DB nullable persistence 용).
  */
 export function tryClientIp(req: Request): string | undefined {
-  const forwardedFor = req.headers['x-forwarded-for'];
-  if (typeof forwardedFor === 'string' && forwardedFor.trim().length > 0) {
-    const forwardedIp = forwardedFor.split(',').map((ip) => ip.trim())[0];
-    if (forwardedIp) return forwardedIp;
-  }
-
-  const realIp = req.headers['x-real-ip'];
-  if (typeof realIp === 'string' && realIp.trim().length > 0) {
-    return realIp;
-  }
-
   const ip = req.ip ?? req.socket?.remoteAddress;
   return typeof ip === 'string' && ip.length > 0 ? ip : undefined;
 }

--- a/src/features/audit-log/repositories/audit-log.repository.spec.ts
+++ b/src/features/audit-log/repositories/audit-log.repository.spec.ts
@@ -154,5 +154,44 @@ describe('AuditLogRepository (real DB)', () => {
       expect(logs[0].ip_address).toBeNull();
       expect(logs[0].user_agent).toBeNull();
     });
+
+    it('malformed·overlong IP 는 컬럼에 쓰지 않고 null 로 저장한다 (insert 실패 방지)', async () => {
+      const account = await createAccount(prisma);
+      // ip_address VarChar(64) 초과 + 비정상 형식. trust proxy 가 넘길 수 있는 위험값.
+      const overlong = `not-an-ip-${'x'.repeat(80)}`;
+
+      await requestContext.run({ clientIp: overlong }, async () => {
+        await repo.createAuditLog({
+          actorAccountId: account.id,
+          targetType: AuditTargetType.STORE,
+          targetId: account.id,
+          action: AuditActionType.UPDATE,
+        });
+      });
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0].ip_address).toBeNull();
+    });
+
+    it('IPv6 client IP 도 유효하면 그대로 저장한다', async () => {
+      const account = await createAccount(prisma);
+
+      await requestContext.run({ clientIp: '2001:db8::1' }, async () => {
+        await repo.createAuditLog({
+          actorAccountId: account.id,
+          targetType: AuditTargetType.STORE,
+          targetId: account.id,
+          action: AuditActionType.UPDATE,
+        });
+      });
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs[0].ip_address).toBe('2001:db8::1');
+    });
   });
 });

--- a/src/features/audit-log/repositories/audit-log.repository.spec.ts
+++ b/src/features/audit-log/repositories/audit-log.repository.spec.ts
@@ -2,6 +2,7 @@ import type { PrismaClient } from '@prisma/client';
 import { AuditActionType, AuditTargetType } from '@prisma/client';
 
 import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
+import { RequestContextService } from '@/global/request-context';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
 import { createAccount } from '@/test/factories';
@@ -9,6 +10,7 @@ import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.bui
 
 describe('AuditLogRepository (real DB)', () => {
   let repo: AuditLogRepository;
+  let requestContext: RequestContextService;
   let prisma: PrismaClient;
 
   beforeAll(async () => {
@@ -16,6 +18,7 @@ describe('AuditLogRepository (real DB)', () => {
       providers: [AuditLogRepository],
     });
     repo = module.get(AuditLogRepository);
+    requestContext = module.get(RequestContextService);
     prisma = p;
   });
 
@@ -87,6 +90,69 @@ describe('AuditLogRepository (real DB)', () => {
         where: { actor_account_id: account.id },
       });
       expect(logs[0].store_id).toBe(storeId);
+    });
+
+    it('ipAddress/userAgent 를 명시하지 않으면 요청 컨텍스트(ALS)에서 보강한다', async () => {
+      const account = await createAccount(prisma);
+
+      await requestContext.run(
+        { clientIp: '203.0.113.7', userAgent: 'ctx-agent' },
+        async () => {
+          await repo.createAuditLog({
+            actorAccountId: account.id,
+            targetType: AuditTargetType.STORE,
+            targetId: account.id,
+            action: AuditActionType.UPDATE,
+          });
+        },
+      );
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs[0].ip_address).toBe('203.0.113.7');
+      expect(logs[0].user_agent).toBe('ctx-agent');
+    });
+
+    it('명시된 ipAddress/userAgent 가 요청 컨텍스트보다 우선한다', async () => {
+      const account = await createAccount(prisma);
+
+      await requestContext.run(
+        { clientIp: '203.0.113.7', userAgent: 'ctx-agent' },
+        async () => {
+          await repo.createAuditLog({
+            actorAccountId: account.id,
+            targetType: AuditTargetType.STORE,
+            targetId: account.id,
+            action: AuditActionType.UPDATE,
+            ipAddress: '10.0.0.1',
+            userAgent: 'explicit-agent',
+          });
+        },
+      );
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs[0].ip_address).toBe('10.0.0.1');
+      expect(logs[0].user_agent).toBe('explicit-agent');
+    });
+
+    it('요청 컨텍스트 밖에서는 ip/ua 가 null 로 저장된다', async () => {
+      const account = await createAccount(prisma);
+
+      await repo.createAuditLog({
+        actorAccountId: account.id,
+        targetType: AuditTargetType.STORE,
+        targetId: account.id,
+        action: AuditActionType.UPDATE,
+      });
+
+      const logs = await prisma.auditLog.findMany({
+        where: { actor_account_id: account.id },
+      });
+      expect(logs[0].ip_address).toBeNull();
+      expect(logs[0].user_agent).toBeNull();
     });
   });
 });

--- a/src/features/audit-log/repositories/audit-log.repository.ts
+++ b/src/features/audit-log/repositories/audit-log.repository.ts
@@ -7,19 +7,28 @@ import {
 } from '@prisma/client';
 
 import type { IAuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository.interface';
+import { RequestContextService } from '@/global/request-context';
 import { PrismaService } from '@/prisma';
 
 /**
  * AuditLog Repository 구체 구현.
  *
  * `audit_log` 테이블 write 전용. read 가 필요하면 별도 메서드를 추가한다.
+ *
+ * ip/ua 는 단일 write 진입점에서 요청 컨텍스트(ALS)로부터 자동 보강한다 —
+ * 도메인 서비스가 transport 메타데이터를 인자로 들고 다니지 않게 한다.
+ * 명시적으로 전달된 `args.ipAddress`/`args.userAgent` 가 있으면 그쪽이 우선한다.
  */
 @Injectable()
 export class AuditLogRepository implements IAuditLogRepository {
   /**
    * @param prisma PrismaService
+   * @param requestContext 요청 컨텍스트(ALS) — ip/ua 자동 보강용
    */
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly requestContext: RequestContextService,
+  ) {}
 
   async createAuditLog(args: {
     actorAccountId: bigint;
@@ -32,6 +41,7 @@ export class AuditLogRepository implements IAuditLogRepository {
     ipAddress?: string;
     userAgent?: string;
   }): Promise<AuditLog> {
+    const ctx = this.requestContext.get();
     return this.prisma.auditLog.create({
       data: {
         actor_account_id: args.actorAccountId,
@@ -42,8 +52,8 @@ export class AuditLogRepository implements IAuditLogRepository {
         before_json:
           args.beforeJson === null ? Prisma.JsonNull : args.beforeJson,
         after_json: args.afterJson === null ? Prisma.JsonNull : args.afterJson,
-        ip_address: args.ipAddress ?? null,
-        user_agent: args.userAgent ?? null,
+        ip_address: args.ipAddress ?? ctx?.clientIp ?? null,
+        user_agent: args.userAgent ?? ctx?.userAgent ?? null,
       },
     });
   }

--- a/src/features/audit-log/repositories/audit-log.repository.ts
+++ b/src/features/audit-log/repositories/audit-log.repository.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net';
+
 import { Injectable } from '@nestjs/common';
 import {
   type AuditActionType,
@@ -9,6 +11,9 @@ import {
 import type { IAuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository.interface';
 import { RequestContextService } from '@/global/request-context';
 import { PrismaService } from '@/prisma';
+
+/** `audit_log.user_agent` 컬럼 길이(VarChar(512)) 상한. */
+const MAX_USER_AGENT_LENGTH = 512;
 
 /**
  * AuditLog Repository 구체 구현.
@@ -52,9 +57,36 @@ export class AuditLogRepository implements IAuditLogRepository {
         before_json:
           args.beforeJson === null ? Prisma.JsonNull : args.beforeJson,
         after_json: args.afterJson === null ? Prisma.JsonNull : args.afterJson,
-        ip_address: args.ipAddress ?? ctx?.clientIp ?? null,
-        user_agent: args.userAgent ?? ctx?.userAgent ?? null,
+        ip_address: normalizeIpForPersistence(args.ipAddress ?? ctx?.clientIp),
+        user_agent: normalizeUserAgentForPersistence(
+          args.userAgent ?? ctx?.userAgent,
+        ),
       },
     });
   }
+}
+
+/**
+ * 감사 로그 컬럼(`ip_address` VarChar(64))에 저장 가능한 IP 로 정규화한다.
+ *
+ * trust proxy 환경에서 `req.ip` 는 프록시가 넘긴 값을 반영하므로, malformed·overlong
+ * 값이 그대로 들어오면 컬럼 길이 초과로 insert 가 실패할 수 있다. 유효한 IPv4/IPv6 가
+ * 아니면 null 로 떨어뜨려, 감사 로그에 쓰레기 IP 가 쌓이거나 mutation 이 깨지는 것을 막는다.
+ */
+function normalizeIpForPersistence(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  return isIP(value) !== 0 ? value : null;
+}
+
+/**
+ * 감사 로그 컬럼(`user_agent` VarChar(512))에 저장 가능한 UA 로 정규화한다.
+ * 컬럼 길이 초과 방지를 위해 512 자로 자른다.
+ */
+function normalizeUserAgentForPersistence(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  return value.slice(0, MAX_USER_AGENT_LENGTH);
 }

--- a/src/global/request-context/index.ts
+++ b/src/global/request-context/index.ts
@@ -1,0 +1,6 @@
+/**
+ * 요청 컨텍스트(ALS) 인프라 Export
+ */
+export * from '@/global/request-context/request-context.service';
+export * from '@/global/request-context/request-context.middleware';
+export * from '@/global/request-context/request-context.module';

--- a/src/global/request-context/request-context.middleware.spec.ts
+++ b/src/global/request-context/request-context.middleware.spec.ts
@@ -1,0 +1,86 @@
+import type { NextFunction, Request, Response } from 'express';
+
+import { RequestContextMiddleware } from '@/global/request-context/request-context.middleware';
+import { RequestContextService } from '@/global/request-context/request-context.service';
+
+function mockReq(overrides: Partial<Request> = {}): Request {
+  return {
+    headers: {},
+    socket: { remoteAddress: '127.0.0.1' },
+    ...overrides,
+  } as unknown as Request;
+}
+
+describe('RequestContextMiddleware', () => {
+  let requestContext: RequestContextService;
+  let middleware: RequestContextMiddleware;
+
+  beforeEach(() => {
+    requestContext = new RequestContextService();
+    middleware = new RequestContextMiddleware(requestContext);
+  });
+
+  it('next() 콜백 실행 시점에 req.ip/UA 가 컨텍스트에 적재된다', () => {
+    const req = mockReq({
+      ip: '203.0.113.9',
+      headers: { 'user-agent': 'jest-agent' },
+    } as Partial<Request>);
+
+    let seenIp: string | undefined;
+    let seenUa: string | undefined;
+    const next: NextFunction = () => {
+      seenIp = requestContext.getClientIp();
+      seenUa = requestContext.getUserAgent();
+    };
+
+    middleware.use(req, {} as Response, next);
+
+    expect(seenIp).toBe('203.0.113.9');
+    expect(seenUa).toBe('jest-agent');
+  });
+
+  it('위조된 X-Forwarded-For 가 있어도 req.ip 만 적재한다 (spoofing 방어)', () => {
+    const req = mockReq({
+      ip: '203.0.113.9',
+      headers: { 'x-forwarded-for': '1.2.3.4' },
+    } as Partial<Request>);
+
+    let seenIp: string | undefined;
+    middleware.use(req, {} as Response, () => {
+      seenIp = requestContext.getClientIp();
+    });
+
+    expect(seenIp).toBe('203.0.113.9');
+  });
+
+  it('async 핸들러(await)를 넘어도 컨텍스트가 유지된다', async () => {
+    const req = mockReq({
+      ip: '198.51.100.7',
+      headers: {},
+    } as Partial<Request>);
+
+    let seenIp: string | undefined;
+    await new Promise<void>((resolve) => {
+      middleware.use(req, {} as Response, () => {
+        void (async () => {
+          await Promise.resolve();
+          seenIp = requestContext.getClientIp();
+          resolve();
+        })();
+      });
+    });
+
+    expect(seenIp).toBe('198.51.100.7');
+  });
+
+  it('IP/UA 추출 실패 시 undefined 가 적재된다', () => {
+    const req = mockReq({ headers: {}, socket: {} } as Partial<Request>);
+
+    let seen: { clientIp?: string; userAgent?: string } | undefined;
+    middleware.use(req, {} as Response, () => {
+      seen = requestContext.get();
+    });
+
+    expect(seen).toEqual({ clientIp: undefined, userAgent: undefined });
+  });
+});

--- a/src/global/request-context/request-context.middleware.ts
+++ b/src/global/request-context/request-context.middleware.ts
@@ -1,0 +1,29 @@
+import { Injectable, type NestMiddleware } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+
+import { tryClientIp, tryUserAgent } from '@/common/utils/http-meta';
+import { RequestContextService } from '@/global/request-context/request-context.service';
+
+/**
+ * 요청 진입 시 client IP / User-Agent 를 요청 컨텍스트(ALS)에 적재한다.
+ *
+ * REST·GraphQL 모두 Express 미들웨어를 거치므로 한 곳에서 모든 요청을 덮는다.
+ * `next()` 를 `run()` 콜백 안에서 호출해야 이후 핸들러 체인이 컨텍스트 안에서
+ * 실행된다(ALS 전파의 전제).
+ *
+ * IP 추출은 `tryClientIp`(trust proxy 기반) 단일 소스에 위임한다.
+ */
+@Injectable()
+export class RequestContextMiddleware implements NestMiddleware {
+  constructor(private readonly requestContext: RequestContextService) {}
+
+  use(req: Request, _res: Response, next: NextFunction): void {
+    this.requestContext.run(
+      {
+        clientIp: tryClientIp(req),
+        userAgent: tryUserAgent(req),
+      },
+      () => next(),
+    );
+  }
+}

--- a/src/global/request-context/request-context.module.ts
+++ b/src/global/request-context/request-context.module.ts
@@ -1,0 +1,16 @@
+import { Global, Module } from '@nestjs/common';
+
+import { RequestContextService } from '@/global/request-context/request-context.service';
+
+/**
+ * 요청 컨텍스트(ALS) 전역 모듈.
+ *
+ * `RequestContextService` 를 전역 export 하여 어느 feature 에서도 주입받을 수 있게 한다.
+ * 미들웨어 적용은 `AppModule.configure()` 가 담당한다.
+ */
+@Global()
+@Module({
+  providers: [RequestContextService],
+  exports: [RequestContextService],
+})
+export class RequestContextModule {}

--- a/src/global/request-context/request-context.service.spec.ts
+++ b/src/global/request-context/request-context.service.spec.ts
@@ -1,0 +1,49 @@
+import { RequestContextService } from '@/global/request-context/request-context.service';
+
+describe('RequestContextService', () => {
+  let service: RequestContextService;
+
+  beforeEach(() => {
+    service = new RequestContextService();
+  });
+
+  it('run() 안에서 get()/getClientIp()/getUserAgent() 가 컨텍스트를 반환한다', () => {
+    service.run({ clientIp: '203.0.113.9', userAgent: 'jest-ua' }, () => {
+      expect(service.get()).toEqual({
+        clientIp: '203.0.113.9',
+        userAgent: 'jest-ua',
+      });
+      expect(service.getClientIp()).toBe('203.0.113.9');
+      expect(service.getUserAgent()).toBe('jest-ua');
+    });
+  });
+
+  it('run() 밖에서는 undefined 를 반환한다', () => {
+    expect(service.get()).toBeUndefined();
+    expect(service.getClientIp()).toBeUndefined();
+    expect(service.getUserAgent()).toBeUndefined();
+  });
+
+  it('async 경계(await)를 넘어도 컨텍스트가 유지된다', async () => {
+    await service.run({ clientIp: '198.51.100.7' }, async () => {
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 0));
+      expect(service.getClientIp()).toBe('198.51.100.7');
+    });
+  });
+
+  it('중첩 run() 은 안쪽 컨텍스트가 우선하고, 벗어나면 복원된다', () => {
+    service.run({ clientIp: 'outer' }, () => {
+      expect(service.getClientIp()).toBe('outer');
+      service.run({ clientIp: 'inner' }, () => {
+        expect(service.getClientIp()).toBe('inner');
+      });
+      expect(service.getClientIp()).toBe('outer');
+    });
+  });
+
+  it('run() 콜백의 반환값을 그대로 전달한다', () => {
+    const result = service.run({ clientIp: 'x' }, () => 42);
+    expect(result).toBe(42);
+  });
+});

--- a/src/global/request-context/request-context.service.ts
+++ b/src/global/request-context/request-context.service.ts
@@ -1,0 +1,55 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import { Injectable } from '@nestjs/common';
+
+/**
+ * 요청 단위로 전파되는 횡단 메타데이터.
+ *
+ * transport(HTTP) 계층에서만 알 수 있는 값이라 도메인 서비스 시그니처를 오염시키지 않고
+ * AsyncLocalStorage 로 암묵 전파한다. 감사 로그(ip)·향후 requestId/UA 등이 여기 모인다.
+ */
+export interface RequestContextStore {
+  clientIp?: string;
+  userAgent?: string;
+}
+
+/**
+ * 요청 컨텍스트 저장소(싱글톤).
+ *
+ * `RequestContextMiddleware` 가 요청 진입 시 `run()` 으로 컨텍스트를 연다.
+ * 이후 같은 async continuation 에서 실행되는 resolver/service/repository 는
+ * `get()` 으로 컨텍스트를 읽는다. run() 밖에서 호출하면 undefined.
+ */
+@Injectable()
+export class RequestContextService {
+  private readonly storage = new AsyncLocalStorage<RequestContextStore>();
+
+  /**
+   * 주어진 컨텍스트로 callback 을 실행한다. callback 내부(및 그 async 후속)에서
+   * `get()` 이 이 컨텍스트를 반환한다.
+   */
+  run<T>(store: RequestContextStore, callback: () => T): T {
+    return this.storage.run(store, callback);
+  }
+
+  /**
+   * 현재 요청 컨텍스트. run() 밖이면 undefined.
+   */
+  get(): RequestContextStore | undefined {
+    return this.storage.getStore();
+  }
+
+  /**
+   * 현재 요청의 client IP. 없으면 undefined.
+   */
+  getClientIp(): string | undefined {
+    return this.storage.getStore()?.clientIp;
+  }
+
+  /**
+   * 현재 요청의 User-Agent. 없으면 undefined.
+   */
+  getUserAgent(): string | undefined {
+    return this.storage.getStore()?.userAgent;
+  }
+}

--- a/src/test/modules/testing-module.builder.ts
+++ b/src/test/modules/testing-module.builder.ts
@@ -2,12 +2,17 @@ import type { ModuleMetadata } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import type { PrismaClient } from '@prisma/client';
 
+import { RequestContextService } from '@/global/request-context';
 import { PrismaService } from '@/prisma/prisma.service';
 import { getTestPrismaClient } from '@/test/db/prisma-test-client';
 
 /**
  * 실DB(Testcontainers) Prisma 클라이언트를 PrismaService 위치에 주입한
  * TestingModule을 생성한다.
+ *
+ * `RequestContextService`(ALS)도 기본 제공한다 — AuditLogRepository 등 요청
+ * 컨텍스트를 주입받는 provider 가 어디서나 resolve 되도록. run() 밖이면 빈 컨텍스트라
+ * 기존 동작(ip/ua null)에 영향 없다.
  *
  * 사용 예:
  * ```ts
@@ -29,6 +34,7 @@ export async function createTestingModuleWithRealDb(
         provide: PrismaService,
         useValue: prisma,
       },
+      RequestContextService,
     ],
   }).compile();
 


### PR DESCRIPTION
## Summary

리팩토링 플랜 감사 중 발견한 #119(IP/UA 단일화 + trust proxy) PR의 두 가지 미완결을 바로잡습니다.

1. **보안**: `tryClientIp` 가 raw `X-Forwarded-For`(맨 왼쪽)·`X-Real-IP` 헤더를 `req.ip` 보다 먼저 신뢰해, `main.ts` 의 `TRUST_PROXY_HOPS` 설정이 사실상 죽은 config 였고 클라이언트가 IP 를 위조할 수 있었습니다. Express `trust proxy` 가 계산한 `req.ip` 단일 소스로 교정합니다.
2. **배선 누락**: seller 도메인의 감사 로그 35개 호출부가 `ipAddress` 를 전달하지 않아 `audit_log.ip_address` 가 항상 null 로 기록되고 있었습니다. 요청 컨텍스트(AsyncLocalStorage)를 도입해 단일 write 진입점에서 자동 보강하도록 했습니다.

IP 는 transport 계층 메타데이터라 도메인 서비스 시그니처에 인자로 흘려보내면 SoC 를 해칩니다. 그래서 명시적 threading 대신 **요청 컨텍스트(ALS)** 로 암묵 전파하여, 도메인 서비스/리졸버 시그니처를 전혀 건드리지 않고 `AuditLogRepository` 가 컨텍스트에서 IP/UA 를 읽도록 했습니다.

## Scope

**신규**
- `RequestContextService` (`src/global/request-context/request-context.service.ts`) — `AsyncLocalStorage` 기반 요청 컨텍스트 래퍼. `run()` / `get()` / `getClientIp()` / `getUserAgent()`
- `RequestContextMiddleware` — 요청 진입 시 `tryClientIp`/`tryUserAgent` 로 컨텍스트를 열고 `next()` 를 그 안에서 호출 (REST·GraphQL 공통)
- `RequestContextModule` (`@Global`) + barrel
- 신규 spec: `request-context.service.spec.ts`, `request-context.middleware.spec.ts`

**변경**
- `http-meta.ts` `tryClientIp` — raw XFF/X-Real-IP 분기 제거, `req.ip` → socket fallback 만 사용
- `app.module.ts` — `RequestContextModule` import + `RequestContextMiddleware` 를 모든 라우트에 가장 먼저 적용
- `AuditLogRepository.createAuditLog` — `ip_address`/`user_agent` 를 `args` → 요청 컨텍스트 → null 순으로 보강 (명시 인자 우선)
- `testing-module.builder.ts` — `RequestContextService` 기본 제공 (실DB spec 들이 실 `AuditLogRepository` 를 resolve 하도록)
- spec 갱신: `http-meta.spec.ts`(spoofing 가드), `audit-log.repository.spec.ts`(ALS 보강/우선순위/컨텍스트 밖 null)

**도메인 서비스/리졸버: 변경 없음.**

## 진행 상황

리팩토링 플랜 P2 잔여 작업 진행 중, 플랜·머지 PR 비판적 감사에서 도출된 항목입니다.

- [x] 플랜 자체 최적성 재검증 (모듈식 모놀리스 유지·UseCase 미도입 등 건전 판정)
- [x] 머지 PR 감사 (#113~#120 + #121 대기): Prisma/GqlFilter/분할/spec 품질 대부분 양호
- [x] 이 PR: #119 후속 — IP trust-proxy 정합 + 감사 로그 IP 배선
- [ ] P2-3: ESLint import/no-cycle + 모듈 경계 강화 (다음)
- [ ] (후속 후보) 감사 로그 user_agent 도 동일 메커니즘으로 정상화 — 인프라는 이미 컨텍스트에 UA 적재 완료

## Impact

- **FE**: 없음. SDL/REST 경로/응답·에러 페이로드 동일.
- **DB**: `audit_log.ip_address` / `user_agent` 가 운영 trust proxy 환경에서 실제 client IP/UA 로 기록됨 (이전엔 seller 도메인 전부 null). 스키마 변경 없음.
- **보안**: `TRUST_PROXY_HOPS` 정확 설정 시 XFF 위조 차단. 미설정(0) 시 socket 주소 사용(안전 기본).
- **Coverage**: 신규 `global/request-context/*` 100%. `yarn validate` 전체 통과 (146 suites / 1251 tests).

## Test plan

- [x] `tryClientIp`/`clientIpOf` — req.ip 우선, 위조 XFF/X-Real-IP 무시(spoofing 가드), socket fallback, undefined
- [x] `RequestContextService` — run 내부/외부, async 경계 유지, 중첩 run 복원, 반환값 전달
- [x] `RequestContextMiddleware` — next 시점 컨텍스트 적재, 위조 XFF 무시, async 핸들러 유지, 추출 실패 시 undefined
- [x] `AuditLogRepository` (실DB) — 컨텍스트에서 ip/ua 보강, 명시 인자 우선, 컨텍스트 밖 null
- [x] `yarn validate` (lint + tsc + dto:check + test:cov) 통과
- [ ] CI 통과 확인
