### PR TITLE
fix(test): e2e me 쿼리 mock 에 account_identities 추가

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -36,6 +36,8 @@ describe('AppController (e2e)', () => {
         onboarding_completed_at: null,
         deleted_at: null,
       },
+      // toMePayload 가 account_identities.map 을 호출하므로 mock 에 포함해야 한다.
+      account_identities: [],
     }),
   };
   const mockPrismaService = {


### PR DESCRIPTION
## Summary

develop 에서 상시 실패하던 e2e 테스트(`GraphQL me는 인증이 통과되어야 한다`)를 고칩니다. 프로덕션 버그가 아니라 **테스트 mock 결함**입니다.

`toMePayload` 가 `account.account_identities.map(...)` 로 연동 소셜 계정을 매핑하는데(소셜 provider 노출 기능), e2e 의 `mockUserRepository.findAccountWithProfile` 가 `account_identities` 를 반환하지 않아 `Cannot read properties of undefined (reading 'map')` 로 깨지고 있었습니다. mock 에 `account_identities: []` 를 추가해 실제 repository 반환 형태와 맞춥니다.

## Scope

**변경**
- `test/app.e2e-spec.ts` — `mockUserRepository.findAccountWithProfile` 의 반환 객체에 `account_identities: []` 추가

프로덕션 코드 변경 없음. 테스트 mock 한 줄.

## Impact

- **FE / DB / 프로덕션**: 영향 없음 (테스트 전용).
- **CI**: e2e 7개 전부 통과 (이전 1개 실패 → 0).

## Test plan

- [x] `yarn test:e2e` — 7/7 통과
- [ ] CI 통과 확인
