### PR TITLE
refactor(lint): import/no-cycle 활성화 + common/global 모듈 경계 ESLint 강제 (P2-3)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,11 +59,99 @@ export default defineConfig(
           alphabetize: { order: 'asc', caseInsensitive: true },
         },
       ],
+      // 순환 참조 금지 (P2-3). 현재 위반 0건 — 회귀 방지용.
+      'import/no-cycle': ['error', { ignoreExternal: true }],
     },
     settings: {
       'import/resolver': {
         typescript: { project: path.join(__dirname, 'tsconfig.json') },
       },
+    },
+  },
+
+  // 모듈 경계 강화 (P2-3) — CLAUDE.md 의존성 방향 룰을 ESLint 로 강제.
+  // common 은 features/global/prisma 에 의존 금지 (common → 무의존).
+  {
+    files: ['src/common/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '@/features',
+                '@/features/**',
+                '@/global',
+                '@/global/**',
+                '@/prisma',
+                '@/prisma/**',
+              ],
+              message:
+                'common 은 features/global/prisma 에 의존하면 안 됩니다 (common → 무의존).',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // common/utils 는 순수 함수 — DI(Injectable/Inject)·ConfigService·Prisma 의존 금지.
+  // (DI 없는 값 클래스인 HttpException 류는 허용)
+  {
+    files: ['src/common/utils/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@nestjs/common',
+              importNames: ['Injectable', 'Inject'],
+              message:
+                'common/utils 는 DI-free 순수 함수만 (Injectable/Inject 금지).',
+            },
+            {
+              name: '@nestjs/config',
+              message:
+                'common/utils 는 ConfigService 등 런타임 서비스에 의존하면 안 됩니다.',
+            },
+          ],
+          patterns: [
+            {
+              group: [
+                '@/features',
+                '@/features/**',
+                '@/global',
+                '@/global/**',
+                '@/prisma',
+                '@/prisma/**',
+              ],
+              message:
+                'common 은 features/global/prisma 에 의존하면 안 됩니다 (common → 무의존).',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  // global 은 features/prisma 에 의존 금지 (global → common, config).
+  {
+    files: ['src/global/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/features', '@/features/**', '@/prisma', '@/prisma/**'],
+              message:
+                'global 은 features/prisma 에 의존하면 안 됩니다 (global → common, config).',
+            },
+          ],
+        },
+      ],
     },
   },
 


### PR DESCRIPTION
## Summary

리팩토링 플랜 **P2-3**(ESLint `import/no-cycle` 활성화 + 모듈 경계 강화)의 코어를 적용합니다. CLAUDE.md 의 의존성 방향 룰을 사람 규율이 아니라 ESLint 로 자동 강제해, 경계 위반·순환참조가 PR 단계에서 잡히게 합니다.

신규 의존성 없이(`eslint-plugin-import` 기존 설치) 적용했고, **기존 코드 위반 0건**이라 회귀 방지 성격입니다.

cross-feature 내부 import 강제(features 간 직접 import 금지)는 별도 결정사항으로 분리했습니다 — 아래 *진행 상황* 참조.

## Scope

**변경: `eslint.config.mjs`**

- `import/no-cycle` 활성화 (`error`, `ignoreExternal`) — 현재 순환참조 0건
- `no-restricted-imports` 경계 룰 3종 추가:
  - `src/common/**` → `@/features`·`@/global`·`@/prisma` import 금지 (common → 무의존)
  - `src/common/utils/**` → 위 + `@nestjs/common` 의 `Injectable`/`Inject`·`@nestjs/config` import 금지 (순수 함수 보장). DI 없는 값 클래스(`HttpException` 류)는 허용
  - `src/global/**` → `@/features`·`@/prisma` import 금지 (global → common, config)

## 진행 상황

플랜 P2 잔여, 자율 진행 중.

- [x] #124 (IP trust-proxy + 감사 로그 ALS) 머지
- [x] #125 (e2e me mock) 머지
- [x] **이 PR**: P2-3 코어 — import/no-cycle + common/global 경계
- [ ] **결정 필요**: cross-feature 내부 import 강제. 현재 `user` 서비스 4곳이 `product`/`order` 의 repository 내부 파일을 deep-path 로 직접 import (CLAUDE.md "내부 파일 직접 import 금지" 위반). 강제하려면 (a) `eslint-plugin-boundaries` 신규 의존성 도입 또는 (b) feature 별 `no-restricted-imports` 설정 + 해당 4개 import 를 barrel 경유로 수정 필요 → 사용자 사인오프 후 별도 PR
- [ ] P2-4 (UseCase 재평가) — 측정 후 권고안 제시 예정

## Impact

- **FE / DB / 런타임**: 영향 없음 (lint 설정만).
- **CI**: lint 단계에서 경계·순환참조 위반을 차단. 현재 위반 0건이라 통과.
- **개발 경험**: common/global 에서 잘못된 방향 import 시 즉시 lint 에러.

## Test plan

- [x] `npx eslint 'src/**/*.ts'` — 새 규칙 위반 0건
- [x] `yarn lint` — 0 errors (기존 미사용 import 경고 1건은 무관)
- [x] `yarn validate` (pre-push) 통과
- [ ] CI 통과 확인
