### PR TITLE
refactor(lint): cross-feature 내부 import 금지 (boundaries) + barrel 경유 정리 (P2-3)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 import importPlugin from 'eslint-plugin-import';
+import boundaries from 'eslint-plugin-boundaries';
 import prettierRecommended from 'eslint-plugin-prettier/recommended';
 import { defineConfig } from 'eslint/config';
 import { fileURLToPath } from 'node:url';
@@ -149,6 +150,41 @@ export default defineConfig(
               message:
                 'global 은 features/prisma 에 의존하면 안 됩니다 (global → common, config).',
             },
+          ],
+        },
+      ],
+    },
+  },
+
+  // cross-feature 내부 import 금지 (P2-3) — feature 는 다른 feature 를 barrel(index.ts) 로만 import.
+  // 같은 feature 내부 import 와 src 루트(app.module/main — 미분류) 의 import 는 검사 대상 아님.
+  // 테스트 파일은 통합 테스트 편의상 제외.
+  {
+    files: ['src/**/*.ts'],
+    plugins: { boundaries },
+    settings: {
+      'boundaries/elements': [
+        { type: 'common', pattern: 'src/common', mode: 'folder' },
+        { type: 'config', pattern: 'src/config', mode: 'folder' },
+        { type: 'prisma', pattern: 'src/prisma', mode: 'folder' },
+        { type: 'global', pattern: 'src/global', mode: 'folder' },
+        {
+          type: 'feature',
+          pattern: 'src/features/*',
+          mode: 'folder',
+          capture: ['family'],
+        },
+      ],
+      'boundaries/ignore': ['**/*.spec.ts', '**/*.test.ts'],
+    },
+    rules: {
+      'boundaries/entry-point': [
+        'error',
+        {
+          default: 'disallow',
+          rules: [
+            { target: ['common', 'config', 'prisma', 'global'], allow: '**' },
+            { target: ['feature'], allow: 'index.ts' },
           ],
         },
       ],

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.0.1",
     "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-boundaries": "^6.0.2",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
     "globals": "^17.6.0",
@@ -125,7 +126,9 @@
             "isolatedModules": false
           },
           "diagnostics": {
-            "ignoreCodes": [151002]
+            "ignoreCodes": [
+              151002
+            ]
           }
         }
       ]

--- a/src/features/user/services/user-mypage.service.ts
+++ b/src/features/user/services/user-mypage.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { OrderRepository } from '@/features/order/repositories/order.repository';
+import { OrderRepository } from '@/features/order';
 import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import type { MyPageOverview } from '@/features/user/types/user-mypage-output.type';

--- a/src/features/user/services/user-order.service.ts
+++ b/src/features/user/services/user-order.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { OrderStatus } from '@prisma/client';
 
 import { formatBusinessHours } from '@/common/utils/business-hours-formatter';
-import { OrderRepository } from '@/features/order/repositories/order.repository';
+import { OrderRepository } from '@/features/order';
 import { USER_ORDER_ERRORS } from '@/features/user/constants/user-order-error-messages';
 import type { MyOrdersInput } from '@/features/user/dto/inputs/my-orders.input';
 import type {

--- a/src/features/user/services/user-recent-view.service.ts
+++ b/src/features/user/services/user-recent-view.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
-import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductRepository } from '@/features/product';
 import type { MyRecentViewedProductsInput } from '@/features/user/dto/inputs/my-recent-viewed-products.input';
 import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
 import { UserRepository } from '@/features/user/repositories/user.repository';

--- a/src/features/user/services/user-wishlist.service.ts
+++ b/src/features/user/services/user-wishlist.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
-import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductRepository } from '@/features/product';
 import { USER_WISHLIST_ERRORS } from '@/features/user/constants/user-wishlist-error-messages';
 import { DEFAULT_PAGINATION_LIMIT } from '@/features/user/constants/user.constants';
 import type { MyWishlistInput } from '@/features/user/dto/inputs/my-wishlist.input';

--- a/src/features/user/user.module.ts
+++ b/src/features/user/user.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 
-import { OrderModule } from '@/features/order/order.module';
-import { ProductModule } from '@/features/product/product.module';
+import { OrderModule } from '@/features/order';
+import { ProductModule } from '@/features/product';
 import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
 import { ReviewRepository } from '@/features/user/repositories/review.repository';
 import { UserRepository } from '@/features/user/repositories/user.repository';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,6 +1360,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@boundaries/elements@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@boundaries/elements@npm:2.0.1"
+  dependencies:
+    eslint-import-resolver-node: "npm:0.3.9"
+    eslint-module-utils: "npm:2.12.1"
+    handlebars: "npm:4.7.9"
+    is-core-module: "npm:2.16.1"
+    micromatch: "npm:4.0.8"
+  checksum: 10c0/0c38a3a9d08c8d7aa79cd29b3d98ac61608120dad69ee568dbbbc0522c944cb7b60a1d985fd2ebfcd4c4ad0fe4caf44b81e519a49a99d3af85c769fe0cdad537
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -6590,6 +6603,7 @@ __metadata:
     eslint: "npm:^9.39.4"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-import-resolver-typescript: "npm:^4.4.4"
+    eslint-plugin-boundaries: "npm:^6.0.2"
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-prettier: "npm:^5.5.5"
     express: "npm:^5.2.1"
@@ -6630,6 +6644,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2, chalk@npm:~4.1.0":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^1.1.1":
   version: 1.1.3
   resolution: "chalk@npm:1.1.3"
@@ -6640,16 +6664,6 @@ __metadata:
     strip-ansi: "npm:^3.0.0"
     supports-color: "npm:^2.0.0"
   checksum: 10c0/28c3e399ec286bb3a7111fd4225ebedb0d7b813aef38a37bca7c498d032459c265ef43404201d5fbb8d888d29090899c95335b4c0cda13e8b126ff15c541cef8
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2, chalk@npm:~4.1.0":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
   languageName: node
   linkType: hard
 
@@ -8312,7 +8326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.9":
+"eslint-import-resolver-node@npm:0.3.9, eslint-import-resolver-node@npm:^0.3.9":
   version: 0.3.9
   resolution: "eslint-import-resolver-node@npm:0.3.9"
   dependencies:
@@ -8347,7 +8361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.12.1":
+"eslint-module-utils@npm:2.12.1, eslint-module-utils@npm:^2.12.1":
   version: 2.12.1
   resolution: "eslint-module-utils@npm:2.12.1"
   dependencies:
@@ -8356,6 +8370,22 @@ __metadata:
     eslint:
       optional: true
   checksum: 10c0/6f4efbe7a91ae49bf67b4ab3644cb60bc5bd7db4cb5521de1b65be0847ffd3fb6bce0dd68f0995e1b312d137f768e2a1f842ee26fe73621afa05f850628fdc40
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-boundaries@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "eslint-plugin-boundaries@npm:6.0.2"
+  dependencies:
+    "@boundaries/elements": "npm:2.0.1"
+    chalk: "npm:4.1.2"
+    eslint-import-resolver-node: "npm:0.3.9"
+    eslint-module-utils: "npm:2.12.1"
+    handlebars: "npm:4.7.9"
+    micromatch: "npm:4.0.8"
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 10c0/70dfc01d1a0837be8e227335f57359c85955c094437985a592cd4dd555a1b662bde7b9458d5b1e14d933dd67e66a5931686bf98e85ee607cc6d114459d29b370
   languageName: node
   linkType: hard
 
@@ -9929,6 +9959,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"handlebars@npm:4.7.9, handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.2"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
+  languageName: node
+  linkType: hard
+
 "handlebars@npm:^4.7.7":
   version: 4.7.8
   resolution: "handlebars@npm:4.7.8"
@@ -9944,24 +9992,6 @@ __metadata:
   bin:
     handlebars: bin/handlebars
   checksum: 10c0/7aff423ea38a14bb379316f3857fe0df3c5d66119270944247f155ba1f08e07a92b340c58edaa00cfe985c21508870ee5183e0634dcb53dd405f35c93ef7f10d
-  languageName: node
-  linkType: hard
-
-"handlebars@npm:^4.7.9":
-  version: 4.7.9
-  resolution: "handlebars@npm:4.7.9"
-  dependencies:
-    minimist: "npm:^1.2.5"
-    neo-async: "npm:^2.6.2"
-    source-map: "npm:^0.6.1"
-    uglify-js: "npm:^3.1.4"
-    wordwrap: "npm:^1.0.0"
-  dependenciesMeta:
-    uglify-js:
-      optional: true
-  bin:
-    handlebars: bin/handlebars
-  checksum: 10c0/22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
   languageName: node
   linkType: hard
 
@@ -10492,7 +10522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.1":
+"is-core-module@npm:2.16.1, is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.1":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -12284,7 +12314,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.8":
+"micromatch@npm:4.0.8, micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:


### PR DESCRIPTION
## Summary

플랜 **P2-3**의 cross-feature 경계 강화입니다 (#126 코어에 이어). `eslint-plugin-boundaries` 로 "feature 는 다른 feature 를 **barrel(index.ts)** 로만 import" 를 자동 강제하고, 기존에 deep-path 로 다른 feature 내부 파일을 직접 참조하던 6곳을 barrel 경유로 정리했습니다.

CLAUDE.md "features 가 다른 features 의 내부 파일을 직접 import 금지 → Module export provider 로 주입" 룰을 사람 규율이 아니라 lint 로 강제합니다.

## Scope

**신규 의존성**: `eslint-plugin-boundaries` (devDependency)

**`eslint.config.mjs`**
- element 정의: common / config / prisma / global / feature(`src/features/*`, family capture)
- `boundaries/entry-point`: feature 타깃은 `index.ts` 로만 import 허용 (비-feature 요소는 임의 파일 허용). **같은 feature 내부 import 와 `app.module`(src 루트, 미분류) 의 import 는 검사 대상 아님** — 진짜 cross-feature 내부 결합만 차단
- 테스트 파일은 통합 테스트 편의상 `boundaries/ignore` 로 제외

**import 정리 (6곳, deep-path → barrel)**
- `user-wishlist.service` · `user-recent-view.service` → `@/features/product` (ProductRepository)
- `user-order.service` · `user-mypage.service` → `@/features/order` (OrderRepository)
- `user.module` → `@/features/order` · `@/features/product` (Order/ProductModule)

> product/order barrel 은 이미 해당 심볼을 export 하고 있어 export 추가는 불필요했습니다.

## 진행 상황

- [x] #124 (IP/ALS), #125 (e2e mock), #126 (P2-3 코어: import/no-cycle + common/global 경계) 머지
- [x] **이 PR**: P2-3 cross-feature 경계 — boundaries + 6곳 barrel 정리
- [ ] P2-4 (UseCase 재평가) — 별도 제시 (권고: 미도입)

## Impact

- **FE / DB / 런타임**: 영향 없음 (lint 설정 + import 경로만, 동작 동일).
- **CI**: lint 단계에서 cross-feature 내부 import 차단. 현재 위반 0건.
- **알려진 후속 과제**: `boundaries/entry-point` 는 v6 에서 deprecated (→ `boundaries/dependencies`). 신규 API 는 default-disallow 라 #126 의 no-restricted-imports 방향 룰과 중복·충돌 소지가 있어, 현 시점은 검증된 entry-point 를 유지. `dependencies` 마이그레이션은 Tech Debt 로 분리 추적.

## Test plan

- [x] 음성 테스트: deep-path cross-feature import 를 일시 복원 → boundaries 가 정확히 차단함을 확인 (`There is no rule allowing dependencies from feature/user to feature/order`)
- [x] barrel import 는 허용 (clean 상태 위반 0건)
- [x] `yarn validate` (lint + tsc + dto:check + test:cov) 통과 — 1254 tests, 146 suites
- [ ] CI 통과 확인
