### PR TITLE
fix(build): nest build 출력을 dist 루트로 정렬 (dist/main.js)

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Summary

`nest build` 산출물 경로 불일치로 인한 **운영 부팅 실패(잠복 결함)**를 고칩니다.

`tsconfig.build.json` 에 `include` 가 없어 tsc 가 `src` + `scripts` + `prisma` 를 모두 컴파일 → 공통 루트가 프로젝트 루트가 되어 진입점이 **`dist/src/main.js`** 로 출력됐습니다. 반면 `ecosystem.config.js`(`script: 'dist/main.js'`)와 `package.json`(`start:prod: "node dist/main"`)은 **`dist/main.js`** 를 기대 → PM2/start 가 모듈을 못 찾아 **부팅 실패**. 자동 배포가 비활성(`workflow_dispatch`)이라 그동안 드러나지 않았습니다.

릴리즈 영향 점검 중 발견했습니다 (`docs_*_develop-to-main-release-impact.md`). 이 상태로 배포하면 PM2 start 단계에서 깨집니다.

## Scope

**변경: `tsconfig.build.json`**
- `"include": ["src/**/*"]` 추가 → 빌드가 `src` 만 컴파일, rootDir 이 `src` 로 잡혀 **`dist/main.js`** 로 출력
- 결과적으로 nest-cli 에셋(`dist/features/**/*.graphql`) 및 실행 경로(`ecosystem`/`start:prod`)와 정합. ecosystem/start 스크립트는 변경 불필요(원래 기대 경로가 맞았음)

> 본 결함은 이번 클린아키텍처 리팩토링과 무관한 **사전 결함**(3월 `@/` alias 마이그레이션 이후)이나, 릴리즈/배포 전 반드시 선행되어야 함.

## 진행 상황

- [x] 리팩토링 플랜 P0~P2 완료 (#124~#127)
- [x] develop→main 릴리즈 영향 점검 → 본 결함 발견
- [x] **이 PR**: 빌드 출력 경로 정렬 (배포 부팅 차단 해소)
- [ ] develop→main 릴리즈 (FE 협의 + `TRUST_PROXY_HOPS` + 인프라 기동 확인 후)

## Impact

- **FE / DB / 런타임 동작**: 영향 없음 (빌드 출력 위치만 변경, 컴파일 결과·로직 동일).
- **빌드**: `dist/main.js` 로 출력 (이전 `dist/src/main.js`). `dist/src/`·`dist/scripts/`·`dist/prisma/`(루트 prisma 디렉터리 산출물) 등 불필요 산출물 제거 → 번들 정리.
- **배포**: PM2 `script: dist/main.js` 부팅 정상화. **이 수정 없이는 배포 시 부팅 실패.**

## Test plan

- [x] `yarn build` → `dist/main.js` 생성 확인, `dist/src/` 부재 확인, `dist/features/*.graphql` 에셋 유지
- [x] 부팅 테스트: `node dist/main.js` 가 전체 모듈 그래프·DI 해석 후 DB 연결 단계까지 도달 (`Cannot find module`/`Nest can't resolve` 없음). DB 미연결 에러만 발생 = 코드/경로 정상
- [x] 컴파일된 상대 import(`require("./...")`) 가 새 루트에서 정합
- [ ] CI 통과 확인
