### PR TITLE
refactor(features): 배럴 public surface 정리 (구체 repository 누출 제거 + dead 배럴 삭제)

### DIFF
--- a/src/features/audit-log/index.ts
+++ b/src/features/audit-log/index.ts
@@ -1,5 +1,6 @@
+// cross-feature 공개 API. 구체 AuditLogRepository는 노출하지 않는다 —
+// 소비처는 토큰(AUDIT_LOG_REPOSITORY) + 인터페이스(IAuditLogRepository)로만 주입.
 export { AuditLogModule } from '@/features/audit-log/audit-log.module';
-export { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 export {
   AUDIT_LOG_REPOSITORY,
   type IAuditLogRepository,

--- a/src/features/conversation/index.ts
+++ b/src/features/conversation/index.ts
@@ -1,2 +1,3 @@
+// cross-feature 공개 API. 단일 구현 repo라 토큰/인터페이스 없이 구체 클래스로 주입(의도적).
 export { ConversationModule } from '@/features/conversation/conversation.module';
 export { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';

--- a/src/features/order/index.ts
+++ b/src/features/order/index.ts
@@ -1,3 +1,4 @@
+// cross-feature 공개 API. 단일 구현 repo라 토큰/인터페이스 없이 구체 클래스로 주입(의도적).
 export { OrderModule } from '@/features/order/order.module';
 export { OrderRepository } from '@/features/order/repositories/order.repository';
 export { OrderDomainService } from '@/features/order/services/order-domain.service';

--- a/src/features/product/index.ts
+++ b/src/features/product/index.ts
@@ -1,2 +1,3 @@
+// cross-feature 공개 API. 단일 구현 repo라 토큰/인터페이스 없이 구체 클래스로 주입(의도적).
 export { ProductModule } from '@/features/product/product.module';
 export { ProductRepository } from '@/features/product/repositories/product.repository';

--- a/src/features/seller/index.ts
+++ b/src/features/seller/index.ts
@@ -1,2 +1,0 @@
-export { SellerModule } from '@/features/seller/seller.module';
-export { SellerRepository } from '@/features/seller/repositories/seller.repository';

--- a/src/features/seller/resolvers/seller-content.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-content.resolver.spec.ts
@@ -1,7 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerContentMutationResolver } from '@/features/seller/resolvers/seller-content-mutation.resolver';

--- a/src/features/seller/resolvers/seller-conversation.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-conversation.resolver.spec.ts
@@ -1,7 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ConversationRepository } from '@/features/conversation';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerConversationMutationResolver } from '@/features/seller/resolvers/seller-conversation-mutation.resolver';

--- a/src/features/seller/resolvers/seller-order.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-order.resolver.spec.ts
@@ -1,7 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import {
   OrderDomainService,
   OrderRepository,

--- a/src/features/seller/resolvers/seller-product.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-product.resolver.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import type { SellerAddProductImageInput } from '@/features/seller/dto/inputs/seller-add-product-image.input';
 import type { SellerCreateOptionGroupInput } from '@/features/seller/dto/inputs/seller-create-option-group.input';

--- a/src/features/seller/resolvers/seller-store.resolver.spec.ts
+++ b/src/features/seller/resolvers/seller-store.resolver.spec.ts
@@ -1,7 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerStoreMutationResolver } from '@/features/seller/resolvers/seller-store-mutation.resolver';
 import { SellerStoreQueryResolver } from '@/features/seller/resolvers/seller-store-query.resolver';

--- a/src/features/seller/services/seller-audit.service.spec.ts
+++ b/src/features/seller/services/seller-audit.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException } from '@nestjs/common';
 import { Prisma, type PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerAuditService } from '@/features/seller/services/seller-audit.service';
 import { SellerFaqService } from '@/features/seller/services/seller-faq.service';

--- a/src/features/seller/services/seller-banner.service.spec.ts
+++ b/src/features/seller/services/seller-banner.service.spec.ts
@@ -5,7 +5,8 @@ import {
 } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerBannerService } from '@/features/seller/services/seller-banner.service';

--- a/src/features/seller/services/seller-conversation.service.spec.ts
+++ b/src/features/seller/services/seller-conversation.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ConversationRepository } from '@/features/conversation';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerConversationService } from '@/features/seller/services/seller-conversation.service';

--- a/src/features/seller/services/seller-custom-template.service.spec.ts
+++ b/src/features/seller/services/seller-custom-template.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient, Product } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerCustomTemplateService } from '@/features/seller/services/seller-custom-template.service';

--- a/src/features/seller/services/seller-faq.service.spec.ts
+++ b/src/features/seller/services/seller-faq.service.spec.ts
@@ -1,7 +1,8 @@
 import { NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerFaqService } from '@/features/seller/services/seller-faq.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';

--- a/src/features/seller/services/seller-option.service.spec.ts
+++ b/src/features/seller/services/seller-option.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient, Product } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerOptionService } from '@/features/seller/services/seller-option.service';

--- a/src/features/seller/services/seller-order.service.spec.ts
+++ b/src/features/seller/services/seller-order.service.spec.ts
@@ -5,7 +5,8 @@ import {
 } from '@nestjs/common';
 import { OrderStatus, type PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import {
   OrderDomainService,
   OrderRepository,

--- a/src/features/seller/services/seller-product-image.service.spec.ts
+++ b/src/features/seller/services/seller-product-image.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerProductImageService } from '@/features/seller/services/seller-product-image.service';

--- a/src/features/seller/services/seller-product-lifecycle.service.spec.ts
+++ b/src/features/seller/services/seller-product-lifecycle.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerProductLifecycleService } from '@/features/seller/services/seller-product-lifecycle.service';

--- a/src/features/seller/services/seller-product-query.service.spec.ts
+++ b/src/features/seller/services/seller-product-query.service.spec.ts
@@ -5,7 +5,8 @@ import {
 } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerProductQueryService } from '@/features/seller/services/seller-product-query.service';

--- a/src/features/seller/services/seller-product-taxonomy.service.spec.ts
+++ b/src/features/seller/services/seller-product-taxonomy.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { ProductRepository } from '@/features/product';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerProductTaxonomyService } from '@/features/seller/services/seller-product-taxonomy.service';

--- a/src/features/seller/services/seller-store-hours.service.spec.ts
+++ b/src/features/seller/services/seller-store-hours.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerStoreHoursService } from '@/features/seller/services/seller-store-hours.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';

--- a/src/features/seller/services/seller-store-policy.service.spec.ts
+++ b/src/features/seller/services/seller-store-policy.service.spec.ts
@@ -1,7 +1,8 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerStorePolicyService } from '@/features/seller/services/seller-store-policy.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';

--- a/src/features/seller/services/seller-store-profile.service.spec.ts
+++ b/src/features/seller/services/seller-store-profile.service.spec.ts
@@ -1,7 +1,8 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
-import { AUDIT_LOG_REPOSITORY, AuditLogRepository } from '@/features/audit-log';
+import { AUDIT_LOG_REPOSITORY } from '@/features/audit-log';
+import { AuditLogRepository } from '@/features/audit-log/repositories/audit-log.repository';
 import { SellerRepository } from '@/features/seller/repositories/seller.repository';
 import { SellerStoreProfileService } from '@/features/seller/services/seller-store-profile.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';

--- a/src/features/user/index.ts
+++ b/src/features/user/index.ts
@@ -1,2 +1,0 @@
-export { UserModule } from '@/features/user/user.module';
-export { UserRepository } from '@/features/user/repositories/user.repository';


### PR DESCRIPTION
## Summary

근거 기반 정합성 리뷰(NestJS 공식 문서 대조)에서 식별한 **feature 배럴(index.ts)의 public surface 누출**을 정리합니다. 핵심은 토큰 패턴을 쓰는 `audit-log`가 배럴로 구체 `AuditLogRepository` 클래스를 함께 노출해 토큰 계약을 우회할 수 있던 점(실제 누출)이고, 더불어 cross-feature에서 전혀 쓰이지 않는 dead 배럴(`seller`, `user`)을 제거합니다. **런타임 코드 변경 0** — 구조/공개표면 정리 + 테스트 import 경로 조정뿐입니다.

## Scope

**배럴 정리 (6 파일)**
- `audit-log/index.ts`: 구체 `AuditLogRepository` export 제거. public surface = `Module` + 토큰(`AUDIT_LOG_REPOSITORY`) + 인터페이스(`IAuditLogRepository`)만. 소비처는 이미 토큰+인터페이스로 주입 중이라 무영향.
- `seller/index.ts`, `user/index.ts`: **삭제** — cross-feature에서 import되지 않는 dead 배럴(모듈은 app.module이 직접 경로로 import). "cross-feature로 안 쓰이는 feature는 배럴 없음"(auth/system과 동일) 원칙에 정합.
- `product`/`order`/`conversation/index.ts`: 구체 repository export **유지**(실제 cross-feature 주입 — 단일 구현이라 토큰 없이 구체 클래스 주입이 의도된 public API). 의도를 주석으로 명시.

**테스트 import 경로 조정 (19 파일)**
- seller spec들이 `{ provide: AUDIT_LOG_REPOSITORY, useClass: AuditLogRepository }`로 실제 클래스를 wiring → 토큰은 배럴에서, 구체 클래스는 실제 경로(`@/features/audit-log/repositories/audit-log.repository`)에서 import하도록 분리. 테스트 동작 동일(boundaries는 spec 예외).

## 진행 상황

- 정합성 리뷰의 액션 아이템 중 **Tier 1(저위험·고가치)** 항목. 토큰 패턴 전면 적용(Tier 3)은 별개 결정으로 미포함 — 단일 구현 repo의 구체 주입은 정당(YAGNI)하다는 리뷰 결론에 따라 product/order/conversation은 현행 유지.
- lint 가드는 기존 `boundaries/entry-point`가 이미 cross-feature deep import를 차단하므로 추가 불필요.

## Impact

- **런타임/FE/DB**: 영향 없음. 공개 표면 축소 + dead code 제거 + 테스트 import 경로 변경뿐.
- **아키텍처**: audit-log의 토큰 계약이 배럴 우회 경로 없이 일관됨. dead 배럴 제거로 표면 최소화.

## Test plan

- [x] `yarn validate` (lint + tsc + dto:check + test:cov) 통과 — **144 suites / 1229 tests**, 커버리지 임계 유지
- [x] 배럴 변경 후 tsc로 구체 클래스 참조처(spec 19개) 전수 확인 및 정리
- [ ] CI 통과 확인

## 후속 (이 PR 범위 밖)

- seller spec들이 실제 `AuditLogRepository`(+Prisma)를 instantiate하는 테스트 결합 smell → 토큰에 `useValue` mock(`IAuditLogRepository`) 주입으로 전환 권장 (Tier 2 테스트 품질).
