### PR TITLE
ci: codecov-action v6.0.0 → v6.0.2 (keybase 키 이전 GPG 검증 실패 대응)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -51,7 +51,7 @@ jobs:
         run: yarn test:cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info


### PR DESCRIPTION
## Summary

CI `check` 잡의 `Upload coverage to Codecov` 스텝이 **GPG 서명 검증 실패**로 깨지는 것을 수정합니다. `codecov/codecov-action`을 **v6.0.0 → v6.0.2**로 올립니다(SHA-pin 유지).

## 원인 (코드 무관, 외부 장애)

- Codecov가 Keybase 계정 `codecovsecurity`에 대한 접근을 잃고 `codecovsecops`로 이전하며 **옛 계정을 brick**했습니다. 이 때문에 uploader CLI의 PGP 공개키를 못 받아 검증이 실패합니다 (`gpg: Can't check signature: No public key` → exit 1).
- 참고: codecov/codecov-action#1956 (2026-06-07 오픈). develop은 6/6까지 CI 통과하다 이후 전 PR이 `check`에서 막힘.

## Scope

```diff
# .github/workflows/pr-check.yml
- uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+ uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
```

v6.0.2(=v7.0.0 백포트)는 wrapper가 PGP 키를 `codecovsecops` 계정에서 받도록 수정한 버전입니다.

```diff
# v6.0.1...v6.0.2 (codecov/codecov-action, dist/codecov.sh)
- curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg ... --import
+ curl -s https://keybase.io/codecovsecops/pgp_keys.asc  | gpg ... --import
```

## Impact

- **레포 전체 CI 복구** — 이 PR이 머지돼야 이후 모든 PR(진행 중인 리팩토링 PR, 향후 release PR 포함)의 `check`가 통과합니다.
- 런타임/앱 코드 무관. CI 워크플로우 1줄(SHA-pin 갱신)뿐.

## Test plan

- [ ] 이 PR 자체의 `check` 잡에서 Codecov 업로드 스텝이 통과하는지 확인 (= 픽스 검증)
- [ ] 나머지 필수 체크(pr-title, coverage-report, CodeQL) 통과
