### PR TITLE
fix(user): 리뷰 content 길이 검증 전 trim (공백-only 빈 리뷰 저장 회귀 수정)

### DIFF
--- a/src/features/user/dto/inputs/write-review.input.spec.ts
+++ b/src/features/user/dto/inputs/write-review.input.spec.ts
@@ -67,6 +67,46 @@ describe('WriteReviewInput', () => {
     expect(errors[0].property).toBe('content');
   });
 
+  it('공백만 입력은 trim 후 거절 (빈 리뷰 저장 방지)', async () => {
+    const dto = build({
+      orderItemId: '123',
+      rating: 4.5,
+      content: ' '.repeat(30),
+    });
+    const errors = await validate(dto);
+    expect(errors[0].property).toBe('content');
+  });
+
+  it('앞뒤 공백을 제외한 실제 길이로 검증 (raw 길이로 우회 불가)', async () => {
+    const dto = build({
+      orderItemId: '123',
+      rating: 4.5,
+      // raw 길이 24 지만 trim 후 18 → 거절
+      content: `   ${'a'.repeat(18)}   `,
+    });
+    const errors = await validate(dto);
+    expect(errors[0].property).toBe('content');
+  });
+
+  it('앞뒤 공백 포함이어도 trim 후 길이 충족 시 통과', async () => {
+    const dto = build({
+      orderItemId: '123',
+      rating: 4.5,
+      content: `  ${'a'.repeat(20)}  `,
+    });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('content 가 문자열이 아니면 trim 시도 없이(크래시 없이) IsString 으로 거절', async () => {
+    const dto = build({
+      orderItemId: '123',
+      rating: 4.5,
+      content: 12345 as unknown as string,
+    });
+    const errors = await validate(dto);
+    expect(errors[0].property).toBe('content');
+  });
+
   it('미디어 항목 mediaType 오류는 nested 에러로 보고', async () => {
     const dto = build({
       orderItemId: '123',

--- a/src/features/user/dto/inputs/write-review.input.ts
+++ b/src/features/user/dto/inputs/write-review.input.ts
@@ -1,4 +1,4 @@
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import {
   IsArray,
   IsNumber,
@@ -25,7 +25,12 @@ export class WriteReviewInput {
   @IsRatingValid()
   rating!: number;
 
+  // 길이 검증 전에 trim 한다. service 가 trim 후 저장하므로, 공백만/앞뒤 공백으로
+  // 부풀린 입력이 raw 길이로 통과해 빈 리뷰로 저장되는 회귀를 막는다.
   @IsString()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim() : value,
+  )
   @Length(20, 1000)
   content!: string;
 


### PR DESCRIPTION
## Summary

리팩토링 중 들어간 **리뷰 본문 검증 회귀**를 수정합니다. `WriteReviewInput.content`가 `@Length(20,1000)`을 **raw 문자열**에 적용하는데 `UserReviewService.writeReview`는 `content.trim()`으로 저장 → **공백 20칸 등이 검증을 통과해 빈/짧은 리뷰로 저장**될 수 있었습니다(리팩토링 전에는 trim 길이로 거절). Codex 리뷰(#139)에서 P2로 지적된 사항.

## Scope

- `write-review.input.ts`: `content`에 `@Transform(trim)`을 길이 검증 앞에 추가 → trim된 길이로 검증. 비-string 입력은 가드로 크래시 없이 `@IsString`이 거절. (전역 ValidationPipe `transform: true` 적용 중)
- `write-review.input.spec.ts`: 의미있는 테스트 4개 추가 — 공백-only 거절 / raw 길이 우회 불가 / trim 후 충족 시 통과 / 비-string 거절. 파일 커버리지 100%.

## Impact

- **FE/행동**: 공백만 또는 앞뒤 공백으로 부풀린 리뷰 본문이 이제 **400으로 거절**(리팩토링 전 동작 복원). 정상 입력은 영향 없음.
- DB/스키마 변경 없음.

## Test plan

- [x] `yarn validate` 통과 — depcruise 0 위반, **1233 tests**(+4), lint 0 errors
- [x] write-review.input.ts 커버리지 100%
- [ ] CI 통과 확인
