### PR TITLE
fix: 릴리즈 리뷰 반영 (pickup CLOSED·region 시드 정규화·keyword 경계 테스트)

### DIFF
--- a/prisma/seed/regions.ts
+++ b/prisma/seed/regions.ts
@@ -39,6 +39,8 @@ export async function seedRegions(prisma: PrismaClient): Promise<void> {
         sort_order: group.sortOrder,
       },
       update: {
+        level: 1,
+        parent_id: null,
         name: group.name,
         sort_order: group.sortOrder,
         is_active: true,
@@ -65,6 +67,7 @@ export async function seedRegions(prisma: PrismaClient): Promise<void> {
         parent_id: parentId,
       },
       update: {
+        level: 2,
         name: child.name,
         sort_order: child.sortOrder,
         parent_id: parentId,

--- a/src/features/pickup/constants/pickup-error-messages.ts
+++ b/src/features/pickup/constants/pickup-error-messages.ts
@@ -7,4 +7,5 @@ export const PICKUP_ERRORS = {
 export const PICKUP_DAY_REASON = {
   PAST: 'PAST',
   OUT_OF_RANGE: 'OUT_OF_RANGE',
+  CLOSED: 'CLOSED', // 당일이지만 현재시각+리드타임으로 가용 슬롯이 없음
 } as const;

--- a/src/features/pickup/services/pickup-slot.service.spec.ts
+++ b/src/features/pickup/services/pickup-slot.service.spec.ts
@@ -42,6 +42,16 @@ describe('PickupSlotService', () => {
         reason: 'OUT_OF_RANGE',
       });
     });
+
+    it('오늘이지만 가용 슬롯이 없으면 CLOSED로 막는다', () => {
+      // KST 19:00 + 리드 60분 = cutoff 20:00 > 마지막 슬롯 19:30 → 당일 슬롯 없음
+      const now = new Date('2026-06-18T10:00:00.000Z'); // KST 06-18 19:00
+      const calendar = service.pickupCalendar('2026-06', now);
+      expect(calendar.days.find((d) => d.date === '2026-06-18')).toMatchObject({
+        selectable: false,
+        reason: 'CLOSED',
+      });
+    });
   });
 
   describe('pickupTimeSlots', () => {

--- a/src/features/pickup/services/pickup-slot.service.ts
+++ b/src/features/pickup/services/pickup-slot.service.ts
@@ -41,6 +41,12 @@ export class PickupSlotService {
 
     const daysInMonth = new Date(Date.UTC(ym.year, ym.month, 0)).getUTCDate();
 
+    // 오늘은 현재시각+리드타임 이후 가용 슬롯이 하나라도 있어야 선택 가능
+    // (없으면 pickupTimeSlots가 전부 마감 → 캘린더도 선택 불가로 일치시킨다)
+    const cutoffMinutes = kstMinutesOfDay(now) + PICKUP_MIN_LEAD_MINUTES;
+    const lastSlotMinutes = PICKUP_CLOSE_MINUTES - PICKUP_SLOT_INTERVAL_MINUTES;
+    const todayHasSlot = cutoffMinutes <= lastSlotMinutes;
+
     const days = Array.from({ length: daysInMonth }, (_, index) => {
       const day = index + 1;
       const date = kstMidnightUtc(ym.year, ym.month, day);
@@ -58,6 +64,13 @@ export class PickupSlotService {
           date: formatKstDate(date),
           selectable: false,
           reason: PICKUP_DAY_REASON.OUT_OF_RANGE,
+        };
+      }
+      if (diff === 0 && !todayHasSlot) {
+        return {
+          date: formatKstDate(date),
+          selectable: false,
+          reason: PICKUP_DAY_REASON.CLOSED,
         };
       }
       return { date: formatKstDate(date), selectable: true, reason: null };

--- a/src/features/region/dto/inputs/search-regions.input.spec.ts
+++ b/src/features/region/dto/inputs/search-regions.input.spec.ts
@@ -45,4 +45,10 @@ describe('SearchRegionsInput', () => {
     const errors = await validate(build({ keyword: 'a', limit: 1.5 }));
     expect(errors[0].property).toBe('limit');
   });
+
+  it('keyword 최대 길이 경계(80 통과, 81 거절)', async () => {
+    expect(await validate(build({ keyword: 'a'.repeat(80) }))).toHaveLength(0);
+    const errors = await validate(build({ keyword: 'a'.repeat(81) }));
+    expect(errors[0].property).toBe('keyword');
+  });
 });


### PR DESCRIPTION
## Summary

릴리즈 PR #148 봇 재리뷰에서 나온 valid 지적을 반영합니다(작은 fix).

## 변경 (반영)

- **P2 (Codex)** — `pickupCalendar`가 당일 모든 슬롯 마감 시(현재시각+리드타임 > 마지막 슬롯) `selectable=false`(`CLOSED`)로 처리. 캘린더는 선택 가능인데 시간 슬롯은 전부 마감인 dead-end 방지(`pickupTimeSlots`와 일치)
- **regions.ts upsert 정규화 (CodeRabbit)** — level1/level2 `update`에 `level`·`parent_id` 보정. 재시드 시 오염된 계층 데이터 정정
- **keyword 경계 테스트 (CodeRabbit)** — `@MaxLength(80)` 80통과/81거절 케이스 보강

## 보류 → 후속 이슈로 분리

- **P1 region_id backfill (Codex)** — 운영 기존 DB 배포 시 매장 `region_id=NULL` → 지역필터 `popularStores` 빈 결과. **개발 단계 무해**(시드 매장은 region 연결됨, 배포 꺼짐). 운영 배포 전 처리(seller 매장 등록 시 region 연결 or backfill 마이그레이션) — 별도 이슈
- **migration FK 락 분리 배포 (CodeRabbit)** — 운영 데이터량에서 락 리스크. 운영 배포 시 단계적 적용

## 미반영 (오탐)

- 실DB 의존 spec 지적(CodeRabbit Major 4건) — 이 프로젝트는 `createTestingModuleWithRealDb` 기반 통합 테스트가 표준 컨벤션이라 의도된 패턴

## Test plan

- `yarn validate` 통과 — 159 suites / **1344 tests** / 커버리지 임계 충족
