### PR TITLE
fix(auth): 카카오 OIDC 토큰 교환 client_secret_post 인증방식 지정

### DIFF
--- a/src/features/auth/services/oidc-client.service.spec.ts
+++ b/src/features/auth/services/oidc-client.service.spec.ts
@@ -84,10 +84,12 @@ describe('OidcClientService', () => {
         client_secret: 'google-client-secret',
         redirect_uris: ['http://localhost:4000/auth/oidc/google/callback'],
         response_types: ['code'],
+        // 구글은 basic/post 모두 지원 → 기본값 유지
+        token_endpoint_auth_method: 'client_secret_basic',
       });
     });
 
-    it('Kakao provider의 client를 생성해야 한다', async () => {
+    it('Kakao provider의 client를 client_secret_post 인증방식으로 생성해야 한다 (invalid_client 방지)', async () => {
       // Arrange
       mockConfig.get.mockImplementation((key: string) => {
         const config: Record<string, string> = {
@@ -103,11 +105,14 @@ describe('OidcClientService', () => {
       await service.getClient('kakao');
 
       // Assert
+      // 카카오 토큰 엔드포인트는 client_secret_post만 지원한다.
+      // 기본값(client_secret_basic)으로 두면 invalid_client (Bad client credentials)로 거부된다.
       expect(mockIssuer.Client).toHaveBeenCalledWith({
         client_id: 'kakao-client-id',
         client_secret: 'kakao-client-secret',
         redirect_uris: ['http://localhost:4000/auth/oidc/kakao/callback'],
         response_types: ['code'],
+        token_endpoint_auth_method: 'client_secret_post',
       });
     });
 

--- a/src/features/auth/services/oidc-client.service.ts
+++ b/src/features/auth/services/oidc-client.service.ts
@@ -1,7 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { IdentityProvider } from '@prisma/client';
-import { Issuer, generators, type Client, type TokenSet } from 'openid-client';
+import {
+  Issuer,
+  generators,
+  type Client,
+  type ClientAuthMethod,
+  type TokenSet,
+} from 'openid-client';
 
 import { mustGetEnv } from '@/common/helpers/config.helper';
 import type { OidcProvider } from '@/features/auth/types/oidc-provider.type';
@@ -27,8 +33,13 @@ export class OidcClientService {
     const cached = this.clients.get(provider);
     if (cached) return cached;
 
-    const { issuerUrl, clientId, clientSecret, redirectUri } =
-      this.getProviderConfig(provider);
+    const {
+      issuerUrl,
+      clientId,
+      clientSecret,
+      redirectUri,
+      tokenEndpointAuthMethod,
+    } = this.getProviderConfig(provider);
 
     const issuer = await Issuer.discover(issuerUrl);
 
@@ -37,6 +48,9 @@ export class OidcClientService {
       client_secret: clientSecret,
       redirect_uris: [redirectUri],
       response_types: ['code'],
+      // 카카오 토큰 엔드포인트는 client_secret_post만 지원한다.
+      // openid-client 기본값(client_secret_basic)을 쓰면 invalid_client로 거부된다.
+      token_endpoint_auth_method: tokenEndpointAuthMethod,
     });
 
     this.clients.set(provider, client);
@@ -140,6 +154,7 @@ export class OidcClientService {
     clientId: string;
     clientSecret: string;
     redirectUri: string;
+    tokenEndpointAuthMethod: ClientAuthMethod;
   } {
     const backendBaseUrl =
       this.config.get<string>('BACKEND_BASE_URL')?.trim() ??
@@ -150,14 +165,28 @@ export class OidcClientService {
       const clientId = this.mustGet('OIDC_GOOGLE_CLIENT_ID');
       const clientSecret = this.mustGet('OIDC_GOOGLE_CLIENT_SECRET');
       const redirectUri = `${backendBaseUrl}/auth/oidc/google/callback`;
-      return { issuerUrl, clientId, clientSecret, redirectUri };
+      // 구글은 basic/post 모두 지원 → openid-client 기본값(basic) 유지
+      return {
+        issuerUrl,
+        clientId,
+        clientSecret,
+        redirectUri,
+        tokenEndpointAuthMethod: 'client_secret_basic',
+      };
     }
 
     const issuerUrl = this.mustGet('OIDC_KAKAO_ISSUER_URL');
     const clientId = this.mustGet('OIDC_KAKAO_CLIENT_ID');
     const clientSecret = this.mustGet('OIDC_KAKAO_CLIENT_SECRET');
     const redirectUri = `${backendBaseUrl}/auth/oidc/kakao/callback`;
-    return { issuerUrl, clientId, clientSecret, redirectUri };
+    // 카카오는 client_secret_post만 지원
+    return {
+      issuerUrl,
+      clientId,
+      clientSecret,
+      redirectUri,
+      tokenEndpointAuthMethod: 'client_secret_post',
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

카카오 OIDC 로그인 콜백의 토큰 교환 단계에서 발생하던 `invalid_client (Bad client credentials)` 에러를 수정한다. 카카오 토큰 엔드포인트는 `client_secret_post` 인증방식만 지원하는데, openid-client는 `client_secret`이 있으면 기본값으로 `client_secret_basic`(HTTP Basic 헤더)을 사용해 카카오가 자격증명을 읽지 못하고 거부하던 문제다.

## Scope

- `src/features/auth/services/oidc-client.service.ts`
  - provider별 `token_endpoint_auth_method`를 명시적으로 지정
  - kakao → `client_secret_post` (카카오 discovery `token_endpoint_auth_methods_supported: ['client_secret_post']`)
  - google → `client_secret_basic` (기존 동작 유지, 구글은 basic/post 모두 지원)
- `src/features/auth/services/oidc-client.service.spec.ts`
  - 두 provider의 client 생성 단언에 `token_endpoint_auth_method` 추가 (인증방식 회귀 가드)

## 진행 상황

- 카카오 discovery 문서로 `client_secret_post` 단일 지원 확인
- 토큰 엔드포인트 직접 probe로 auth method가 원인임을 격리
- 수정 후 로컬 end-to-end 로그인 성공 확인 (콜백 302 → returnTo 리다이렉트)
- tsc / eslint / jest(해당 spec 9건) 통과

## Impact

- 카카오 로그인 토큰 교환 정상화. 구글 로그인 동작은 변화 없음(기존 basic 유지).
- 스키마/마이그레이션/외부 계약 변경 없음.

## Test plan

- `yarn jest src/features/auth/services/oidc-client.service.spec.ts` — 9 passed
- 로컬 카카오 로그인 full flow 수동 검증: authorize → callback → 세션 쿠키 발급 → 프론트 returnTo(302) 정상

## Note

- 이번 디버깅에서 별개로 발견된 설정 이슈(`OIDC_KAKAO_CLIENT_SECRET` 값 불일치)는 환경변수 문제라 본 PR 범위 밖이다. **운영 환경의 카카오 Client Secret 값이 올바른지 별도 점검 필요.**
