### PR TITLE
fix(storage): S3 presign 실패 시 실제 원인 구조화 로깅

### DIFF
--- a/src/global/storage/s3.service.spec.ts
+++ b/src/global/storage/s3.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { CustomLoggerService } from '@/global/logger/custom-logger.service';
 import { STORAGE_ERRORS } from '@/global/storage/constants/storage.constants';
 import { S3Service } from '@/global/storage/s3.service';
 
@@ -19,6 +20,10 @@ jest.mock('@aws-sdk/client-s3', () => ({
 describe('S3Service', () => {
   let service: S3Service;
 
+  const mockLogger = {
+    error: jest.fn(),
+  } as unknown as CustomLoggerService;
+
   const mockConfig = {
     region: 'ap-northeast-2',
     bucket: 'caquick-media-test',
@@ -35,10 +40,12 @@ describe('S3Service', () => {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue(mockConfig) },
         },
+        { provide: CustomLoggerService, useValue: mockLogger },
       ],
     }).compile();
 
     service = module.get<S3Service>(S3Service);
+    (mockLogger.error as jest.Mock).mockClear();
   });
 
   describe('createUploadUrl', () => {
@@ -235,11 +242,19 @@ describe('S3Service', () => {
           typeof import('@aws-sdk/s3-request-presigner')
         >('@aws-sdk/s3-request-presigner');
         (mockGetSignedUrl as jest.Mock).mockRejectedValueOnce(
-          new Error('S3 error'),
+          new Error('Credential is missing'),
         );
 
         await expect(service.createUploadUrl(baseInput)).rejects.toThrow(
           STORAGE_ERRORS.S3_PRESIGN_FAILED,
+        );
+        // 실제 원인이 구조화 로그로 남아야 한다 (일반 메시지로 가려지지 않도록)
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          'S3 presigned URL 발급 실패',
+          expect.objectContaining({
+            cause: 'Error: Credential is missing',
+            hasStaticCredentials: true,
+          }),
         );
       });
     });
@@ -267,6 +282,7 @@ describe('S3Service', () => {
               }),
             },
           },
+          { provide: CustomLoggerService, useValue: mockLogger },
         ],
       }).compile();
 

--- a/src/global/storage/s3.service.ts
+++ b/src/global/storage/s3.service.ts
@@ -10,6 +10,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 
 import type { S3Config } from '@/config/s3.config';
+import { CustomLoggerService } from '@/global/logger/custom-logger.service';
 import {
   STORAGE_ERRORS,
   UPLOAD_POLICIES,
@@ -36,13 +37,22 @@ export class S3Service {
   private readonly bucket: string;
   private readonly region: string;
   private readonly presignExpiresSeconds: number;
+  // presign 실패 진단용: 정적 자격증명(Access Key) 주입 여부.
+  // 로컬에서 키 누락이면 getSignedUrl이 "Credential is missing"으로 throw된다.
+  private readonly hasStaticCredentials: boolean;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly logger: CustomLoggerService,
+  ) {
     const config = this.configService.get<S3Config>('s3')!;
 
     this.bucket = config.bucket;
     this.region = config.region;
     this.presignExpiresSeconds = config.presignExpiresSeconds;
+    this.hasStaticCredentials = Boolean(
+      config.accessKeyId && config.secretAccessKey,
+    );
 
     this.client = new S3Client({
       region: config.region,
@@ -96,7 +106,20 @@ export class S3Service {
         key,
         expiresInSeconds: this.presignExpiresSeconds,
       };
-    } catch {
+    } catch (error) {
+      // 실제 실패 원인(예: 자격증명 누락 "Credential is missing")이 일반 메시지에
+      // 가려지지 않도록 구조화 로그로 남긴다. 시크릿(키 값)은 절대 로깅하지 않는다.
+      this.logger.error('S3 presigned URL 발급 실패', {
+        bucket: this.bucket,
+        region: this.region,
+        key,
+        purpose: input.purpose,
+        hasStaticCredentials: this.hasStaticCredentials,
+        cause:
+          error instanceof Error
+            ? `${error.name}: ${error.message}`
+            : String(error),
+      });
       throw new InternalServerErrorException(STORAGE_ERRORS.S3_PRESIGN_FAILED);
     }
   }


### PR DESCRIPTION
## Summary

`createProfileImageUploadUrl`(프로필 이미지 업로드 URL 발급) 등 S3 presign 실패 시, `s3.service.ts`의 bare `catch {}`가 실제 원인을 삼키고 "업로드 URL 생성에 실패했습니다"라는 일반 메시지만 남겨 **원인 진단이 불가능**하던 문제를 개선한다. catch에서 실제 에러와 컨텍스트를 구조화 로그로 남긴다.

> 주의: 이 PR은 실패 **원인을 드러내는 진단 개선**이지, 업로드 실패 자체를 고치는 변경이 아니다. 실제 보고된 500의 근본 원인은 환경별 AWS 자격증명/권한 설정으로 추정된다(아래 Note).

## Scope

- `src/global/storage/s3.service.ts`
  - `CustomLoggerService` 주입(LoggerModule은 `@Global`)
  - presign `catch`에서 실제 `error`(name/message)와 컨텍스트(`bucket`/`region`/`key`/`purpose`/`hasStaticCredentials`)를 `logger.error`로 기록
  - **시크릿(Access Key/Secret 값)은 로깅하지 않음**
- `src/global/storage/s3.service.spec.ts`
  - 두 DI 셋업에 logger mock 주입
  - presign 실패 시 실제 cause가 로그로 남는지 단언 추가

## 진행 상황

- 보고된 500 stacktrace 분석 → bare catch가 원인을 가린 것 확인
- presign(`getSignedUrl`)은 로컬 서명이라, 실패 throw는 보통 **자격증명 누락**(`Credential is missing`) 케이스임을 식별
- 로깅 개선으로 다음 발생 시 즉시 근본 원인 확인 가능하도록 처리
- jest(해당 spec 30건) / tsc / eslint 통과

## Impact

- 동작 변화 없음(여전히 동일 메시지로 500). **관측성만 향상** — 서버 로그에 실제 원인이 남는다.
- 스키마/마이그레이션 변경 없음.

## Test plan

- `yarn jest src/global/storage/s3.service.spec.ts` — 30 passed
- 자격증명 누락 환경에서 mutation 재시도 시, 서버 로그에 `cause: "Error: Credential is missing"` 형태로 실제 원인이 남는지 확인

## Note (환경 설정 — 본 PR 범위 밖)

- 보고된 에러의 stacktrace 경로가 `D:\dev\caquick-be`(Windows)로, 특정 개발 환경 백엔드에서 발생했다.
- 해당 환경의 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`(또는 IAM Role)가 설정되어 있는지, 버킷 PutObject 권한이 있는지 별도 점검 필요.
- 운영 환경도 동일하게 자격증명/권한 점검 권장.
