### PR TITLE
chore(release): 카카오 OIDC client_secret_post 수정 및 S3 presign 로깅 개선

### DIFF
--- a/src/features/auth/services/oidc-client.service.spec.ts
+++ b/src/features/auth/services/oidc-client.service.spec.ts
@@ -84,10 +84,12 @@ describe('OidcClientService', () => {
         client_secret: 'google-client-secret',
         redirect_uris: ['http://localhost:4000/auth/oidc/google/callback'],
         response_types: ['code'],
+        // 구글은 basic/post 모두 지원 → 기본값 유지
+        token_endpoint_auth_method: 'client_secret_basic',
       });
     });
 
-    it('Kakao provider의 client를 생성해야 한다', async () => {
+    it('Kakao provider의 client를 client_secret_post 인증방식으로 생성해야 한다 (invalid_client 방지)', async () => {
       // Arrange
       mockConfig.get.mockImplementation((key: string) => {
         const config: Record<string, string> = {
@@ -103,11 +105,14 @@ describe('OidcClientService', () => {
       await service.getClient('kakao');
 
       // Assert
+      // 카카오 토큰 엔드포인트는 client_secret_post만 지원한다.
+      // 기본값(client_secret_basic)으로 두면 invalid_client (Bad client credentials)로 거부된다.
       expect(mockIssuer.Client).toHaveBeenCalledWith({
         client_id: 'kakao-client-id',
         client_secret: 'kakao-client-secret',
         redirect_uris: ['http://localhost:4000/auth/oidc/kakao/callback'],
         response_types: ['code'],
+        token_endpoint_auth_method: 'client_secret_post',
       });
     });
 

--- a/src/features/auth/services/oidc-client.service.ts
+++ b/src/features/auth/services/oidc-client.service.ts
@@ -1,7 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { IdentityProvider } from '@prisma/client';
-import { Issuer, generators, type Client, type TokenSet } from 'openid-client';
+import {
+  Issuer,
+  generators,
+  type Client,
+  type ClientAuthMethod,
+  type TokenSet,
+} from 'openid-client';
 
 import { mustGetEnv } from '@/common/helpers/config.helper';
 import type { OidcProvider } from '@/features/auth/types/oidc-provider.type';
@@ -27,8 +33,13 @@ export class OidcClientService {
     const cached = this.clients.get(provider);
     if (cached) return cached;
 
-    const { issuerUrl, clientId, clientSecret, redirectUri } =
-      this.getProviderConfig(provider);
+    const {
+      issuerUrl,
+      clientId,
+      clientSecret,
+      redirectUri,
+      tokenEndpointAuthMethod,
+    } = this.getProviderConfig(provider);
 
     const issuer = await Issuer.discover(issuerUrl);
 
@@ -37,6 +48,9 @@ export class OidcClientService {
       client_secret: clientSecret,
       redirect_uris: [redirectUri],
       response_types: ['code'],
+      // 카카오 토큰 엔드포인트는 client_secret_post만 지원한다.
+      // openid-client 기본값(client_secret_basic)을 쓰면 invalid_client로 거부된다.
+      token_endpoint_auth_method: tokenEndpointAuthMethod,
     });
 
     this.clients.set(provider, client);
@@ -140,6 +154,7 @@ export class OidcClientService {
     clientId: string;
     clientSecret: string;
     redirectUri: string;
+    tokenEndpointAuthMethod: ClientAuthMethod;
   } {
     const backendBaseUrl =
       this.config.get<string>('BACKEND_BASE_URL')?.trim() ??
@@ -150,14 +165,28 @@ export class OidcClientService {
       const clientId = this.mustGet('OIDC_GOOGLE_CLIENT_ID');
       const clientSecret = this.mustGet('OIDC_GOOGLE_CLIENT_SECRET');
       const redirectUri = `${backendBaseUrl}/auth/oidc/google/callback`;
-      return { issuerUrl, clientId, clientSecret, redirectUri };
+      // 구글은 basic/post 모두 지원 → openid-client 기본값(basic) 유지
+      return {
+        issuerUrl,
+        clientId,
+        clientSecret,
+        redirectUri,
+        tokenEndpointAuthMethod: 'client_secret_basic',
+      };
     }
 
     const issuerUrl = this.mustGet('OIDC_KAKAO_ISSUER_URL');
     const clientId = this.mustGet('OIDC_KAKAO_CLIENT_ID');
     const clientSecret = this.mustGet('OIDC_KAKAO_CLIENT_SECRET');
     const redirectUri = `${backendBaseUrl}/auth/oidc/kakao/callback`;
-    return { issuerUrl, clientId, clientSecret, redirectUri };
+    // 카카오는 client_secret_post만 지원
+    return {
+      issuerUrl,
+      clientId,
+      clientSecret,
+      redirectUri,
+      tokenEndpointAuthMethod: 'client_secret_post',
+    };
   }
 
   /**

--- a/src/global/storage/s3.service.spec.ts
+++ b/src/global/storage/s3.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { CustomLoggerService } from '@/global/logger/custom-logger.service';
 import { STORAGE_ERRORS } from '@/global/storage/constants/storage.constants';
 import { S3Service } from '@/global/storage/s3.service';
 
@@ -19,6 +20,10 @@ jest.mock('@aws-sdk/client-s3', () => ({
 describe('S3Service', () => {
   let service: S3Service;
 
+  const mockLogger = {
+    error: jest.fn(),
+  } as unknown as CustomLoggerService;
+
   const mockConfig = {
     region: 'ap-northeast-2',
     bucket: 'caquick-media-test',
@@ -35,10 +40,12 @@ describe('S3Service', () => {
           provide: ConfigService,
           useValue: { get: jest.fn().mockReturnValue(mockConfig) },
         },
+        { provide: CustomLoggerService, useValue: mockLogger },
       ],
     }).compile();
 
     service = module.get<S3Service>(S3Service);
+    (mockLogger.error as jest.Mock).mockClear();
   });
 
   describe('createUploadUrl', () => {
@@ -235,11 +242,19 @@ describe('S3Service', () => {
           typeof import('@aws-sdk/s3-request-presigner')
         >('@aws-sdk/s3-request-presigner');
         (mockGetSignedUrl as jest.Mock).mockRejectedValueOnce(
-          new Error('S3 error'),
+          new Error('Credential is missing'),
         );
 
         await expect(service.createUploadUrl(baseInput)).rejects.toThrow(
           STORAGE_ERRORS.S3_PRESIGN_FAILED,
+        );
+        // 실제 원인이 구조화 로그로 남아야 한다 (일반 메시지로 가려지지 않도록)
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          'S3 presigned URL 발급 실패',
+          expect.objectContaining({
+            cause: 'Error: Credential is missing',
+            hasStaticCredentials: true,
+          }),
         );
       });
     });
@@ -267,6 +282,7 @@ describe('S3Service', () => {
               }),
             },
           },
+          { provide: CustomLoggerService, useValue: mockLogger },
         ],
       }).compile();
 

--- a/src/global/storage/s3.service.ts
+++ b/src/global/storage/s3.service.ts
@@ -10,6 +10,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 
 import type { S3Config } from '@/config/s3.config';
+import { CustomLoggerService } from '@/global/logger/custom-logger.service';
 import {
   STORAGE_ERRORS,
   UPLOAD_POLICIES,
@@ -36,13 +37,22 @@ export class S3Service {
   private readonly bucket: string;
   private readonly region: string;
   private readonly presignExpiresSeconds: number;
+  // presign 실패 진단용: 정적 자격증명(Access Key) 주입 여부.
+  // 로컬에서 키 누락이면 getSignedUrl이 "Credential is missing"으로 throw된다.
+  private readonly hasStaticCredentials: boolean;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly logger: CustomLoggerService,
+  ) {
     const config = this.configService.get<S3Config>('s3')!;
 
     this.bucket = config.bucket;
     this.region = config.region;
     this.presignExpiresSeconds = config.presignExpiresSeconds;
+    this.hasStaticCredentials = Boolean(
+      config.accessKeyId && config.secretAccessKey,
+    );
 
     this.client = new S3Client({
       region: config.region,
@@ -96,7 +106,20 @@ export class S3Service {
         key,
         expiresInSeconds: this.presignExpiresSeconds,
       };
-    } catch {
+    } catch (error) {
+      // 실제 실패 원인(예: 자격증명 누락 "Credential is missing")이 일반 메시지에
+      // 가려지지 않도록 구조화 로그로 남긴다. 시크릿(키 값)은 절대 로깅하지 않는다.
+      this.logger.error('S3 presigned URL 발급 실패', {
+        bucket: this.bucket,
+        region: this.region,
+        key,
+        purpose: input.purpose,
+        hasStaticCredentials: this.hasStaticCredentials,
+        cause:
+          error instanceof Error
+            ? `${error.name}: ${error.message}`
+            : String(error),
+      });
       throw new InternalServerErrorException(STORAGE_ERRORS.S3_PRESIGN_FAILED);
     }
   }


### PR DESCRIPTION
## Summary

`develop` → `main` 릴리즈. 카카오 OIDC 로그인 토큰 교환 버그 수정과 S3 presign 실패 진단 로깅 개선을 운영에 반영한다.

## Scope

포함 PR 2건:
- **#154 fix(auth): 카카오 OIDC 토큰 교환 client_secret_post 인증방식 지정**
  - 카카오 토큰 엔드포인트는 `client_secret_post`만 지원하는데 openid-client 기본값(`client_secret_basic`)으로 `invalid_client (Bad client credentials)` 발생하던 문제 수정. provider별 `token_endpoint_auth_method` 명시(kakao=post, google=basic).
- **#155 fix(storage): S3 presign 실패 시 실제 원인 구조화 로깅**
  - bare `catch`가 원인을 삼켜 진단 불가능하던 문제. 실제 error/컨텍스트를 구조화 로그로 기록(시크릿 제외).

## 진행 상황

- 두 PR 모두 develop에서 CI 통과·Codex 리뷰 완료 후 머지됨
- 변경 범위: auth(OIDC) + storage(S3) 서비스 및 테스트 (4 files)

## Impact

- 카카오 로그인 토큰 교환 정상화(운영 반영). 구글 로그인 동작 변화 없음.
- S3 업로드 실패 시 운영 로그에서 근본 원인(자격증명/권한 등) 즉시 식별 가능. 동작 자체 변화 없음(관측성 향상).
- 스키마/마이그레이션/외부 계약 변경 없음.

## Test plan

- 각 PR에서 단위 테스트 통과(oidc-client 9건, s3.service 30건) + 로컬 카카오 로그인 full flow 수동 검증 완료
- 릴리즈 CI(check/coverage/CodeQL/pr-title) 통과 확인

## 운영 반영 시 확인 (env — 코드 외)

- 운영 환경 `OIDC_KAKAO_CLIENT_SECRET`이 카카오 콘솔과 일치하는지
- 운영 환경 `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`(또는 IAM Role) 및 버킷 PutObject 권한


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **Tests**
  * OIDC 인증 및 스토리지 서비스에 대한 테스트 검증 강화

* **Refactor**
  * 토큰 엔드포인트 인증 방식을 각 제공자별로 명시적으로 설정하여 호환성 개선
  * 파일 업로드 실패 시 원인 분석을 위한 상세한 진단 로그 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->