### PR TITLE
feat(product): 구매자 매장 상품 목록·카테고리 조회 API

### DIFF
--- a/src/features/product/constants/product-storefront.constants.ts
+++ b/src/features/product/constants/product-storefront.constants.ts
@@ -1,0 +1,2 @@
+/** 매장 상품 목록 기본 페이지 크기. */
+export const DEFAULT_STORE_PRODUCTS_LIMIT = 20;

--- a/src/features/product/dto/inputs/store-products.input.ts
+++ b/src/features/product/dto/inputs/store-products.input.ts
@@ -1,0 +1,24 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class StoreProductsInput {
+  @IsString()
+  storeId!: string;
+
+  @IsOptional()
+  @IsString()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/src/features/product/product-storefront.graphql
+++ b/src/features/product/product-storefront.graphql
@@ -1,0 +1,58 @@
+extend type Query {
+  """매장이 보유한 활성 상품의 카테고리 목록(좌측 사이드바). 빈 카테고리 제외. 비로그인 접근 가능."""
+  storeProductCategories(storeId: ID!): [StoreProductCategory!]!
+
+  """매장 상품 목록(카테고리 필터 / 매장 내 검색 / 커서). 비로그인 접근 가능."""
+  storeProducts(input: StoreProductsInput!): StoreProductConnection!
+}
+
+"""매장 상품 카테고리(사이드바 항목)."""
+type StoreProductCategory {
+  id: ID!
+  name: String!
+  categoryType: CategoryType!
+  sortOrder: Int!
+  """이 매장의 해당 카테고리 활성 상품 수."""
+  productCount: Int!
+}
+
+"""상품 카테고리 분류."""
+enum CategoryType {
+  EVENT
+  STYLE
+  OTHER
+}
+
+input StoreProductsInput {
+  storeId: ID!
+  """특정 카테고리 섹션만. 비우면 전체."""
+  categoryId: ID
+  """매장 내 상품명·태그 검색어."""
+  search: String
+  """이전 페이지 마지막 항목 id(이후부터 조회)."""
+  cursor: ID
+  limit: Int = 20
+}
+
+"""매장 상품 목록(커서 기반)."""
+type StoreProductConnection {
+  items: [StoreProduct!]!
+  hasMore: Boolean!
+  nextCursor: ID
+}
+
+"""매장 상품 카드."""
+type StoreProduct {
+  id: ID!
+  name: String!
+  description: String
+  """대표 이미지(sort_order 최소). 없으면 null."""
+  thumbnailUrl: String
+  regularPrice: Int!
+  salePrice: Int
+  """할인율(0~100). salePrice 없으면 0."""
+  discountRate: Int!
+  currency: String!
+  """소속 카테고리 ID(FE 섹션 그룹핑/스크롤 스파이용)."""
+  categoryIds: [ID!]!
+}

--- a/src/features/product/product.module.ts
+++ b/src/features/product/product.module.ts
@@ -1,9 +1,15 @@
 import { Module } from '@nestjs/common';
 
 import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductStorefrontQueryResolver } from '@/features/product/resolvers/product-storefront-query.resolver';
+import { ProductStorefrontService } from '@/features/product/services/product-storefront.service';
 
 @Module({
-  providers: [ProductRepository],
+  providers: [
+    ProductRepository,
+    ProductStorefrontService,
+    ProductStorefrontQueryResolver,
+  ],
   exports: [ProductRepository],
 })
 export class ProductModule {}

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -736,8 +736,10 @@ export class ProductRepository {
         is_active: true,
         deleted_at: null,
         store: { is_active: true, deleted_at: null },
-        ...(args.cursor ? { id: { lt: args.cursor } } : {}),
-        ...(args.categoryId
+        // 0n도 유효한 인자로 다뤄야 한다(parseId("0")=0n). truthiness 체크는 0n을
+        // falsy로 떨궈 잘못된 필터를 전체조회로 만들므로 undefined로만 분기한다.
+        ...(args.cursor !== undefined ? { id: { lt: args.cursor } } : {}),
+        ...(args.categoryId !== undefined
           ? {
               product_categories: {
                 some: {

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -756,7 +756,10 @@ export class ProductRepository {
                   product_tags: {
                     some: {
                       deleted_at: null,
-                      tag: { name: { contains: args.search } },
+                      tag: {
+                        name: { contains: args.search },
+                        deleted_at: null,
+                      },
                     },
                   },
                 },

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -794,7 +794,13 @@ export class ProductRepository {
       by: ['category_id'],
       where: {
         deleted_at: null,
-        product: { store_id: storeId, is_active: true, deleted_at: null },
+        product: {
+          store_id: storeId,
+          is_active: true,
+          deleted_at: null,
+          // storeProducts와 동일하게 비활성/삭제 매장은 카테고리도 노출하지 않는다
+          store: { is_active: true, deleted_at: null },
+        },
       },
       _count: { _all: true },
     });

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1,7 +1,28 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { type CategoryType, Prisma } from '@prisma/client';
 
 import { PrismaService } from '@/prisma';
+
+/** 구매자 매장 상품 카드 row. product-storefront 매퍼 입력. */
+export interface StoreProductRow {
+  id: bigint;
+  name: string;
+  description: string | null;
+  regular_price: number;
+  sale_price: number | null;
+  currency: string;
+  images: { image_url: string }[];
+  product_categories: { category_id: bigint }[];
+}
+
+/** 매장 상품 카테고리(사이드바) row. */
+export interface StoreProductCategoryRow {
+  id: bigint;
+  name: string;
+  category_type: CategoryType;
+  sort_order: number;
+  product_count: number;
+}
 
 @Injectable()
 export class ProductRepository {
@@ -696,5 +717,113 @@ export class ProductRepository {
         id: true,
       },
     });
+  }
+
+  /**
+   * 구매자용 매장 상품 목록. 활성 상품(+활성 매장)만, 카테고리/검색 필터.
+   * 카드용 가벼운 select(대표 이미지 1장 + 카테고리 id). 커서는 id < cursor(desc).
+   */
+  async listActiveProductsByStore(args: {
+    storeId: bigint;
+    limit: number;
+    cursor?: bigint;
+    categoryId?: bigint;
+    search?: string;
+  }): Promise<StoreProductRow[]> {
+    return this.prisma.product.findMany({
+      where: {
+        store_id: args.storeId,
+        is_active: true,
+        deleted_at: null,
+        store: { is_active: true, deleted_at: null },
+        ...(args.cursor ? { id: { lt: args.cursor } } : {}),
+        ...(args.categoryId
+          ? {
+              product_categories: {
+                some: { category_id: args.categoryId, deleted_at: null },
+              },
+            }
+          : {}),
+        ...(args.search
+          ? {
+              OR: [
+                { name: { contains: args.search } },
+                {
+                  product_tags: {
+                    some: {
+                      deleted_at: null,
+                      tag: { name: { contains: args.search } },
+                    },
+                  },
+                },
+              ],
+            }
+          : {}),
+      },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        regular_price: true,
+        sale_price: true,
+        currency: true,
+        images: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+          take: 1,
+          select: { image_url: true },
+        },
+        product_categories: {
+          where: { deleted_at: null },
+          select: { category_id: true },
+        },
+      },
+      orderBy: { id: 'desc' },
+      take: args.limit + 1,
+    });
+  }
+
+  /**
+   * 매장이 보유한 활성 상품의 카테고리(사이드바). 빈 카테고리 제외.
+   * sort_order asc, productCount는 이 매장의 활성 상품 기준.
+   */
+  async listStoreProductCategories(
+    storeId: bigint,
+  ): Promise<StoreProductCategoryRow[]> {
+    const grouped = await this.prisma.productCategory.groupBy({
+      by: ['category_id'],
+      where: {
+        deleted_at: null,
+        product: { store_id: storeId, is_active: true, deleted_at: null },
+      },
+      _count: { _all: true },
+    });
+    if (grouped.length === 0) return [];
+
+    const countByCategory = new Map(
+      grouped.map((g) => [g.category_id, g._count._all]),
+    );
+    const categories = await this.prisma.category.findMany({
+      where: {
+        id: { in: grouped.map((g) => g.category_id) },
+        is_active: true,
+        deleted_at: null,
+      },
+      select: {
+        id: true,
+        name: true,
+        category_type: true,
+        sort_order: true,
+      },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
+
+    return categories.map((category) => ({
+      id: category.id,
+      name: category.name,
+      category_type: category.category_type,
+      sort_order: category.sort_order,
+      product_count: countByCategory.get(category.id) ?? 0,
+    }));
   }
 }

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -740,7 +740,11 @@ export class ProductRepository {
         ...(args.categoryId
           ? {
               product_categories: {
-                some: { category_id: args.categoryId, deleted_at: null },
+                some: {
+                  category_id: args.categoryId,
+                  deleted_at: null,
+                  category: { is_active: true, deleted_at: null },
+                },
               },
             }
           : {}),
@@ -774,7 +778,11 @@ export class ProductRepository {
           select: { image_url: true },
         },
         product_categories: {
-          where: { deleted_at: null },
+          // storeProductCategories와 동일하게 비활성/삭제 카테고리는 categoryIds에서 제외
+          where: {
+            deleted_at: null,
+            category: { is_active: true, deleted_at: null },
+          },
           select: { category_id: true },
         },
       },

--- a/src/features/product/resolvers/product-storefront-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-storefront-query.resolver.spec.ts
@@ -1,0 +1,71 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductStorefrontQueryResolver } from '@/features/product/resolvers/product-storefront-query.resolver';
+import { ProductStorefrontService } from '@/features/product/services/product-storefront.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createProduct, createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 통합 경로 검증.
+ * 분기/필터 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('ProductStorefront Query Resolver (real DB)', () => {
+  let resolver: ProductStorefrontQueryResolver;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        ProductStorefrontQueryResolver,
+        ProductStorefrontService,
+        ProductRepository,
+      ],
+    });
+    resolver = module.get(ProductStorefrontQueryResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('storeProducts: 서비스에 위임해 상품 목록을 반환한다', async () => {
+    const store = await createStore(prisma);
+    await createProduct(prisma, { store_id: store.id, name: '케이크' });
+
+    const result = await resolver.storeProducts({
+      storeId: store.id.toString(),
+    });
+
+    expect(result.items.map((p) => p.name)).toEqual(['케이크']);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('storeProductCategories: 서비스에 위임해 카테고리를 반환한다', async () => {
+    const store = await createStore(prisma);
+    const product = await createProduct(prisma, { store_id: store.id });
+    const category = await prisma.category.create({
+      data: {
+        name: '생일',
+        category_type: 'EVENT',
+        sort_order: 0,
+        is_active: true,
+      },
+    });
+    await prisma.productCategory.create({
+      data: { product_id: product.id, category_id: category.id },
+    });
+
+    const result = await resolver.storeProductCategories(store.id.toString());
+
+    expect(result.map((c) => c.name)).toEqual(['생일']);
+  });
+});

--- a/src/features/product/resolvers/product-storefront-query.resolver.ts
+++ b/src/features/product/resolvers/product-storefront-query.resolver.ts
@@ -1,0 +1,30 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { StoreProductsInput } from '@/features/product/dto/inputs/store-products.input';
+import { ProductStorefrontService } from '@/features/product/services/product-storefront.service';
+import type {
+  StoreProductCategory,
+  StoreProductConnection,
+} from '@/features/product/types/product-storefront-output.type';
+
+/**
+ * 구매자 매장 상품 조회 resolver. 개인화 필드가 없는 public query(인증 불필요).
+ */
+@Resolver('Query')
+export class ProductStorefrontQueryResolver {
+  constructor(private readonly service: ProductStorefrontService) {}
+
+  @Query('storeProducts')
+  storeProducts(
+    @Args('input') input: StoreProductsInput,
+  ): Promise<StoreProductConnection> {
+    return this.service.storeProducts(input);
+  }
+
+  @Query('storeProductCategories')
+  storeProductCategories(
+    @Args('storeId') storeId: string,
+  ): Promise<StoreProductCategory[]> {
+    return this.service.storeProductCategories(storeId);
+  }
+}

--- a/src/features/product/services/product-storefront-mappers.helper.spec.ts
+++ b/src/features/product/services/product-storefront-mappers.helper.spec.ts
@@ -1,0 +1,97 @@
+import type {
+  StoreProductCategoryRow,
+  StoreProductRow,
+} from '@/features/product/repositories/product.repository';
+import {
+  calcDiscountRate,
+  toStoreProduct,
+  toStoreProductCategory,
+} from '@/features/product/services/product-storefront-mappers.helper';
+
+function makeProductRow(o: Partial<StoreProductRow> = {}): StoreProductRow {
+  return {
+    id: 1n,
+    name: '레터링 케이크',
+    description: '설명',
+    regular_price: 40000,
+    sale_price: 35000,
+    currency: 'KRW',
+    images: [{ image_url: 'thumb.png' }],
+    product_categories: [{ category_id: 10n }, { category_id: 20n }],
+    ...o,
+  };
+}
+
+describe('calcDiscountRate', () => {
+  it('정상 할인율을 정수로 반올림한다', () => {
+    expect(calcDiscountRate(40000, 35000)).toBe(13); // 12.5 → 13
+    expect(calcDiscountRate(33000, 31350)).toBe(5);
+  });
+
+  it('salePrice가 null이면 0', () => {
+    expect(calcDiscountRate(40000, null)).toBe(0);
+  });
+
+  it('salePrice가 정가 이상이면 0', () => {
+    expect(calcDiscountRate(40000, 40000)).toBe(0);
+    expect(calcDiscountRate(40000, 45000)).toBe(0);
+  });
+
+  it('정가가 0 이하이면 0', () => {
+    expect(calcDiscountRate(0, 0)).toBe(0);
+  });
+});
+
+describe('toStoreProduct', () => {
+  it('row를 카드로 매핑한다(id 문자열·대표이미지·할인율·카테고리ids)', () => {
+    const result = toStoreProduct(makeProductRow());
+    expect(result).toEqual({
+      id: '1',
+      name: '레터링 케이크',
+      description: '설명',
+      thumbnailUrl: 'thumb.png',
+      regularPrice: 40000,
+      salePrice: 35000,
+      discountRate: 13,
+      currency: 'KRW',
+      categoryIds: ['10', '20'],
+    });
+  });
+
+  it('이미지가 없으면 thumbnailUrl은 null', () => {
+    expect(
+      toStoreProduct(makeProductRow({ images: [] })).thumbnailUrl,
+    ).toBeNull();
+  });
+
+  it('salePrice가 없으면 discountRate는 0', () => {
+    const r = toStoreProduct(makeProductRow({ sale_price: null }));
+    expect(r.salePrice).toBeNull();
+    expect(r.discountRate).toBe(0);
+  });
+
+  it('카테고리가 없으면 categoryIds는 빈 배열', () => {
+    expect(
+      toStoreProduct(makeProductRow({ product_categories: [] })).categoryIds,
+    ).toEqual([]);
+  });
+});
+
+describe('toStoreProductCategory', () => {
+  it('카테고리 row를 매핑한다', () => {
+    const row: StoreProductCategoryRow = {
+      id: 5n,
+      name: '생일 케이크',
+      category_type: 'EVENT',
+      sort_order: 2,
+      product_count: 7,
+    };
+    expect(toStoreProductCategory(row)).toEqual({
+      id: '5',
+      name: '생일 케이크',
+      categoryType: 'EVENT',
+      sortOrder: 2,
+      productCount: 7,
+    });
+  });
+});

--- a/src/features/product/services/product-storefront-mappers.helper.ts
+++ b/src/features/product/services/product-storefront-mappers.helper.ts
@@ -1,0 +1,45 @@
+import type {
+  StoreProductCategoryRow,
+  StoreProductRow,
+} from '@/features/product/repositories/product.repository';
+import type {
+  StoreProduct,
+  StoreProductCategory,
+} from '@/features/product/types/product-storefront-output.type';
+
+/** 할인율(0~100, 정수). salePrice가 없거나 비정상(정가 이상)이면 0. */
+export function calcDiscountRate(
+  regularPrice: number,
+  salePrice: number | null,
+): number {
+  if (salePrice === null || regularPrice <= 0 || salePrice >= regularPrice) {
+    return 0;
+  }
+  return Math.round((1 - salePrice / regularPrice) * 100);
+}
+
+export function toStoreProduct(row: StoreProductRow): StoreProduct {
+  return {
+    id: row.id.toString(),
+    name: row.name,
+    description: row.description,
+    thumbnailUrl: row.images[0]?.image_url ?? null,
+    regularPrice: row.regular_price,
+    salePrice: row.sale_price,
+    discountRate: calcDiscountRate(row.regular_price, row.sale_price),
+    currency: row.currency,
+    categoryIds: row.product_categories.map((pc) => pc.category_id.toString()),
+  };
+}
+
+export function toStoreProductCategory(
+  row: StoreProductCategoryRow,
+): StoreProductCategory {
+  return {
+    id: row.id.toString(),
+    name: row.name,
+    categoryType: row.category_type,
+    sortOrder: row.sort_order,
+    productCount: row.product_count,
+  };
+}

--- a/src/features/product/services/product-storefront.service.spec.ts
+++ b/src/features/product/services/product-storefront.service.spec.ts
@@ -255,5 +255,25 @@ describe('ProductStorefrontService (real DB)', () => {
 
       expect(result).toEqual([]);
     });
+
+    it('비활성/삭제 매장의 카테고리는 노출하지 않는다', async () => {
+      const store = await createStore(prisma, { is_active: false });
+      const product = await createProduct(prisma, { store_id: store.id });
+      const cat = await prisma.category.create({
+        data: {
+          name: '생일',
+          category_type: 'EVENT',
+          sort_order: 0,
+          is_active: true,
+        },
+      });
+      await prisma.productCategory.create({
+        data: { product_id: product.id, category_id: cat.id },
+      });
+
+      const result = await service.storeProductCategories(store.id.toString());
+
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/src/features/product/services/product-storefront.service.spec.ts
+++ b/src/features/product/services/product-storefront.service.spec.ts
@@ -183,6 +183,39 @@ describe('ProductStorefrontService (real DB)', () => {
       expect(second.hasMore).toBe(false);
       expect(second.nextCursor).toBeNull();
     });
+
+    it('비활성/삭제 카테고리는 categoryIds에서 제외한다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const active = await prisma.category.create({
+        data: {
+          name: '활성',
+          category_type: 'EVENT',
+          sort_order: 0,
+          is_active: true,
+        },
+      });
+      const inactive = await prisma.category.create({
+        data: {
+          name: '비활성',
+          category_type: 'EVENT',
+          sort_order: 1,
+          is_active: false,
+        },
+      });
+      await prisma.productCategory.create({
+        data: { product_id: product.id, category_id: active.id },
+      });
+      await prisma.productCategory.create({
+        data: { product_id: product.id, category_id: inactive.id },
+      });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+      });
+
+      expect(result.items[0].categoryIds).toEqual([active.id.toString()]);
+    });
   });
 
   describe('storeProductCategories', () => {

--- a/src/features/product/services/product-storefront.service.spec.ts
+++ b/src/features/product/services/product-storefront.service.spec.ts
@@ -1,0 +1,259 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductStorefrontService } from '@/features/product/services/product-storefront.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createProduct, createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+async function addCategory(
+  prisma: PrismaClient,
+  productId: bigint,
+  opts: { name: string; sortOrder?: number },
+): Promise<bigint> {
+  const category = await prisma.category.create({
+    data: {
+      name: opts.name,
+      category_type: 'EVENT',
+      sort_order: opts.sortOrder ?? 0,
+      is_active: true,
+    },
+  });
+  await prisma.productCategory.create({
+    data: { product_id: productId, category_id: category.id },
+  });
+  return category.id;
+}
+
+describe('ProductStorefrontService (real DB)', () => {
+  let service: ProductStorefrontService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ProductStorefrontService, ProductRepository],
+    });
+    service = module.get(ProductStorefrontService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  describe('storeProducts', () => {
+    it('활성 상품만 반환하고 비활성/삭제 상품은 제외한다', async () => {
+      const store = await createStore(prisma);
+      await createProduct(prisma, { store_id: store.id, name: '활성' });
+      await createProduct(prisma, {
+        store_id: store.id,
+        name: '비활성',
+        is_active: false,
+      });
+      const deleted = await createProduct(prisma, {
+        store_id: store.id,
+        name: '삭제',
+      });
+      await prisma.product.update({
+        where: { id: deleted.id },
+        data: { deleted_at: new Date() },
+      });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+      });
+
+      expect(result.items.map((p) => p.name)).toEqual(['활성']);
+      expect(result.hasMore).toBe(false);
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('매장이 비활성이면 빈 결과', async () => {
+      const store = await createStore(prisma, { is_active: false });
+      await createProduct(prisma, { store_id: store.id });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+      });
+
+      expect(result.items).toEqual([]);
+    });
+
+    it('대표 이미지(sort_order 최소)와 할인율을 채운다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, {
+        store_id: store.id,
+        regular_price: 40000,
+        sale_price: 35000,
+      });
+      await prisma.productImage.create({
+        data: { product_id: product.id, image_url: 'b.png', sort_order: 1 },
+      });
+      await prisma.productImage.create({
+        data: { product_id: product.id, image_url: 'a.png', sort_order: 0 },
+      });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+      });
+
+      expect(result.items[0].thumbnailUrl).toBe('a.png');
+      expect(result.items[0].discountRate).toBe(13);
+    });
+
+    it('categoryId로 필터한다', async () => {
+      const store = await createStore(prisma);
+      const p1 = await createProduct(prisma, {
+        store_id: store.id,
+        name: '생일',
+      });
+      const p2 = await createProduct(prisma, {
+        store_id: store.id,
+        name: '돌잔치',
+      });
+      const birthdayId = await addCategory(prisma, p1.id, {
+        name: '생일 케이크',
+      });
+      await addCategory(prisma, p2.id, { name: '돌잔치 케이크' });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+        categoryId: birthdayId.toString(),
+      });
+
+      expect(result.items.map((p) => p.name)).toEqual(['생일']);
+    });
+
+    it('search로 상품명·태그를 부분일치 검색한다', async () => {
+      const store = await createStore(prisma);
+      await createProduct(prisma, {
+        store_id: store.id,
+        name: '강아지 케이크',
+      });
+      const tagged = await createProduct(prisma, {
+        store_id: store.id,
+        name: '미니 케이크',
+      });
+      const tag = await prisma.tag.create({ data: { name: '강아지' } });
+      await prisma.productTag.create({
+        data: { product_id: tagged.id, tag_id: tag.id },
+      });
+      await createProduct(prisma, {
+        store_id: store.id,
+        name: '초콜릿 케이크',
+      });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+        search: '강아지',
+      });
+
+      expect(result.items.map((p) => p.name).sort()).toEqual([
+        '강아지 케이크',
+        '미니 케이크',
+      ]);
+    });
+
+    it('커서 페이지네이션으로 hasMore/nextCursor를 처리한다', async () => {
+      const store = await createStore(prisma);
+      for (let i = 0; i < 3; i++) {
+        await createProduct(prisma, { store_id: store.id, name: `P${i}` });
+      }
+
+      const first = await service.storeProducts({
+        storeId: store.id.toString(),
+        limit: 2,
+      });
+      expect(first.items).toHaveLength(2);
+      expect(first.hasMore).toBe(true);
+      expect(first.nextCursor).not.toBeNull();
+
+      const second = await service.storeProducts({
+        storeId: store.id.toString(),
+        limit: 2,
+        cursor: first.nextCursor ?? undefined,
+      });
+      expect(second.items).toHaveLength(1);
+      expect(second.hasMore).toBe(false);
+      expect(second.nextCursor).toBeNull();
+    });
+  });
+
+  describe('storeProductCategories', () => {
+    it('매장 보유 카테고리만 sort_order 순으로, productCount와 함께 반환한다', async () => {
+      const store = await createStore(prisma);
+      const p1 = await createProduct(prisma, { store_id: store.id });
+      const p2 = await createProduct(prisma, { store_id: store.id });
+
+      const birthday = await prisma.category.create({
+        data: {
+          name: '생일',
+          category_type: 'EVENT',
+          sort_order: 2,
+          is_active: true,
+        },
+      });
+      const dol = await prisma.category.create({
+        data: {
+          name: '돌잔치',
+          category_type: 'EVENT',
+          sort_order: 1,
+          is_active: true,
+        },
+      });
+      // 어떤 상품도 속하지 않은 빈 카테고리(제외돼야 함)
+      await prisma.category.create({
+        data: {
+          name: '크리스마스',
+          category_type: 'EVENT',
+          sort_order: 3,
+          is_active: true,
+        },
+      });
+      await prisma.productCategory.create({
+        data: { product_id: p1.id, category_id: birthday.id },
+      });
+      await prisma.productCategory.create({
+        data: { product_id: p2.id, category_id: birthday.id },
+      });
+      await prisma.productCategory.create({
+        data: { product_id: p1.id, category_id: dol.id },
+      });
+
+      const result = await service.storeProductCategories(store.id.toString());
+
+      expect(result.map((c) => c.name)).toEqual(['돌잔치', '생일']);
+      expect(result.find((c) => c.name === '생일')?.productCount).toBe(2);
+      expect(result.find((c) => c.name === '돌잔치')?.productCount).toBe(1);
+    });
+
+    it('비활성 상품의 카테고리는 제외한다', async () => {
+      const store = await createStore(prisma);
+      const inactive = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: false,
+      });
+      const cat = await prisma.category.create({
+        data: {
+          name: '생일',
+          category_type: 'EVENT',
+          sort_order: 0,
+          is_active: true,
+        },
+      });
+      await prisma.productCategory.create({
+        data: { product_id: inactive.id, category_id: cat.id },
+      });
+
+      const result = await service.storeProductCategories(store.id.toString());
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/features/product/services/product-storefront.service.spec.ts
+++ b/src/features/product/services/product-storefront.service.spec.ts
@@ -216,6 +216,27 @@ describe('ProductStorefrontService (real DB)', () => {
 
       expect(result.items[0].categoryIds).toEqual([active.id.toString()]);
     });
+
+    it('soft-delete된 태그로는 검색되지 않는다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, {
+        store_id: store.id,
+        name: '미니 케이크',
+      });
+      const tag = await prisma.tag.create({
+        data: { name: '강아지', deleted_at: new Date() },
+      });
+      await prisma.productTag.create({
+        data: { product_id: product.id, tag_id: tag.id },
+      });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+        search: '강아지',
+      });
+
+      expect(result.items).toEqual([]);
+    });
   });
 
   describe('storeProductCategories', () => {

--- a/src/features/product/services/product-storefront.service.spec.ts
+++ b/src/features/product/services/product-storefront.service.spec.ts
@@ -237,6 +237,30 @@ describe('ProductStorefrontService (real DB)', () => {
 
       expect(result.items).toEqual([]);
     });
+
+    it('categoryId "0"은 전체 목록이 아니라 빈 결과를 반환한다', async () => {
+      const store = await createStore(prisma);
+      await createProduct(prisma, { store_id: store.id });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+        categoryId: '0',
+      });
+
+      expect(result.items).toEqual([]);
+    });
+
+    it('cursor "0"은 페이지를 리셋하지 않고 빈 결과를 반환한다', async () => {
+      const store = await createStore(prisma);
+      await createProduct(prisma, { store_id: store.id });
+
+      const result = await service.storeProducts({
+        storeId: store.id.toString(),
+        cursor: '0',
+      });
+
+      expect(result.items).toEqual([]);
+    });
   });
 
   describe('storeProductCategories', () => {

--- a/src/features/product/services/product-storefront.service.ts
+++ b/src/features/product/services/product-storefront.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+
+import { parseId } from '@/common/utils/id-parser';
+import { DEFAULT_STORE_PRODUCTS_LIMIT } from '@/features/product/constants/product-storefront.constants';
+import type { StoreProductsInput } from '@/features/product/dto/inputs/store-products.input';
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import {
+  toStoreProduct,
+  toStoreProductCategory,
+} from '@/features/product/services/product-storefront-mappers.helper';
+import type {
+  StoreProductCategory,
+  StoreProductConnection,
+} from '@/features/product/types/product-storefront-output.type';
+
+@Injectable()
+export class ProductStorefrontService {
+  constructor(private readonly repo: ProductRepository) {}
+
+  /** 매장 상품 목록(커서). 활성 상품만. 카테고리/검색 필터. */
+  async storeProducts(
+    input: StoreProductsInput,
+  ): Promise<StoreProductConnection> {
+    const limit = input.limit ?? DEFAULT_STORE_PRODUCTS_LIMIT;
+    const search = input.search?.trim();
+    const rows = await this.repo.listActiveProductsByStore({
+      storeId: parseId(input.storeId),
+      limit,
+      cursor: input.cursor ? parseId(input.cursor) : undefined,
+      categoryId: input.categoryId ? parseId(input.categoryId) : undefined,
+      search: search ? search : undefined,
+    });
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+
+    return {
+      items: page.map(toStoreProduct),
+      hasMore,
+      nextCursor: hasMore ? page[page.length - 1].id.toString() : null,
+    };
+  }
+
+  /** 매장 보유 카테고리(사이드바). 빈 카테고리 제외. */
+  async storeProductCategories(
+    storeId: string,
+  ): Promise<StoreProductCategory[]> {
+    const rows = await this.repo.listStoreProductCategories(parseId(storeId));
+    return rows.map(toStoreProductCategory);
+  }
+}

--- a/src/features/product/types/product-storefront-output.type.ts
+++ b/src/features/product/types/product-storefront-output.type.ts
@@ -1,0 +1,30 @@
+/**
+ * product-storefront resolver 반환용 도메인 출력 타입.
+ * SDL(product-storefront.graphql)의 타입과 필드 일치.
+ */
+
+export interface StoreProduct {
+  id: string;
+  name: string;
+  description: string | null;
+  thumbnailUrl: string | null;
+  regularPrice: number;
+  salePrice: number | null;
+  discountRate: number;
+  currency: string;
+  categoryIds: string[];
+}
+
+export interface StoreProductConnection {
+  items: StoreProduct[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export interface StoreProductCategory {
+  id: string;
+  name: string;
+  categoryType: 'EVENT' | 'STYLE' | 'OTHER';
+  sortOrder: number;
+  productCount: number;
+}


### PR DESCRIPTION
## Summary

구매자 **매장 상품 탭** 조회 API를 신설한다. 매장 상세 화면의 상품 영역(좌측 카테고리 사이드바 + 카테고리별 상품 카드 + 매장 내 검색)을 담당한다. store-detail 도메인 작업의 2단계.

## Scope

- **신규 Query** (둘 다 개인화 없는 public 쿼리)
  - `storeProducts(input: StoreProductsInput!): StoreProductConnection!`
    - 활성 상품(+활성 매장)만, `categoryId` 필터 / `search`(상품명·태그 부분일치) / `cursor` 페이지네이션
    - 카드: 대표 이미지(sort_order 최소) `thumbnailUrl`, `discountRate`(정가·할인가 기반 계산), `categoryIds`(FE 섹션 그룹핑용)
  - `storeProductCategories(storeId: ID!): [StoreProductCategory!]!`
    - 매장이 보유한 활성 상품의 카테고리만(빈 카테고리 제외), `productCount` + `sortOrder` 정렬
- product feature에 구매자 조회 레이어 신설(resolver/service/mapper/dto/types/constants). 기존 repository만 있던 상태에서 확장
- `ProductRepository`에 `listActiveProductsByStore`·`listStoreProductCategories` 추가
- `CategoryType` enum을 SDL에 정의(기존 Prisma enum이나 GraphQL 미노출이었음)

## 진행 상황

- store-detail 도메인 **2/3** (PR1 `storeDetail`은 머지 완료, 다음 PR3 후기 탭)
- 상품 **상세**(`storeProduct`)는 store-detail spec에 화면이 없어 제외(별도 figma) — 합의된 Q1

## Impact

- 신규 조회 API 추가. **스키마 변경 없음**(기존 product/category 모델만 사용)
- 기존 동작/계약 변경 없음

## Test plan

- **단위(mapper)**: 할인율 경계(정상/null/정가이상/0), 카드 매핑(대표이미지·카테고리ids), 카테고리 매핑
- **통합(service, real DB)**: 활성 상품 필터(비활성/삭제 제외) · 매장 비활성 시 빈 결과 · 대표이미지/할인율 · categoryId 필터 · search(상품명·태그) · 커서 hasMore/nextCursor · 카테고리 빈것 제외/productCount/정렬/비활성 상품 제외
- **통합(resolver, real DB)**: 위임 검증
- `yarn validate` 전체 통과: **165 suites / 1381 tests**, lint·tsc·dto:check·arch:check 통과, 커버리지 임계 충족
