### PR TITLE
fix(store): storeReviews의 0 값 cursor 보존

### DIFF
--- a/src/features/store/repositories/store-review.repository.ts
+++ b/src/features/store/repositories/store-review.repository.ts
@@ -45,7 +45,9 @@ export class StoreReviewRepository {
         deleted_at: null,
         // storeDetail과 동일하게 비활성/삭제 매장의 리뷰는 노출하지 않는다
         store: { is_active: true, deleted_at: null },
-        ...(args.cursor ? { id: { lt: args.cursor } } : {}),
+        // 0n도 유효 인자(parseId("0")=0n). truthiness는 0n을 falsy로 떨궈
+        // zero cursor가 페이지를 리셋하므로 undefined로만 분기한다.
+        ...(args.cursor !== undefined ? { id: { lt: args.cursor } } : {}),
       },
       select: {
         id: true,

--- a/src/features/store/services/store-review.service.spec.ts
+++ b/src/features/store/services/store-review.service.spec.ts
@@ -201,4 +201,16 @@ describe('StoreReviewService (real DB)', () => {
 
     expect(result.items[0].authorNickname).toBeNull();
   });
+
+  it('cursor "0"은 페이지를 리셋하지 않고 빈 결과를 반환한다', async () => {
+    const store = await createStore(prisma);
+    await makeReview(store.id, {});
+
+    const result = await service.storeReviews({
+      storeId: store.id.toString(),
+      cursor: '0',
+    });
+
+    expect(result.items).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

`storeReviews`의 cursor가 `"0"`일 때 페이지가 리셋되던 버그를 수정한다. 머지된 PR #159(storeReviews) 이후, PR #158(storeProducts) 리뷰에서 발견된 동일 패턴(`0n` falsy 누락)을 storeReviews에도 적용하는 후속이다.

## Scope

- `listStoreReviews`의 cursor 분기를 `args.cursor ?` → `args.cursor !== undefined`로 변경
- `parseId("0") = 0n`이 truthiness 체크에서 falsy로 떨어져 zero cursor가 필터를 드롭(=첫 페이지 재조회)하던 것을, `0n`을 유효 인자로 다뤄 빈 결과(올바른 동작)가 되도록 수정

## 배경

- PR #158 storeProducts에서 Codex가 동일한 `0n` 보존 이슈(:740)를 지적해 반영했고, storeReviews에도 같은 패턴이 있어 일관성을 위해 후속 정리

## Impact

- 조회 동작 정정만(스키마/계약 변경 없음). 정상 cursor(실제 리뷰 id)는 동작 변화 없음

## Test plan

- `cursor "0"`은 페이지를 리셋하지 않고 빈 결과를 반환하는 테스트 추가
- `yarn validate` 전체 통과(pre-push)
