### PR TITLE
fix: 릴리즈 리뷰 반영 (StoreImage soft-delete·ID 빈값/0n 방어·discountRate clamp)

### DIFF
--- a/src/features/product/dto/inputs/store-products.input.ts
+++ b/src/features/product/dto/inputs/store-products.input.ts
@@ -1,11 +1,20 @@
-import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 export class StoreProductsInput {
   @IsString()
+  @IsNotEmpty()
   storeId!: string;
 
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   categoryId?: string;
 
   @IsOptional()
@@ -14,6 +23,7 @@ export class StoreProductsInput {
 
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   cursor?: string;
 
   @IsOptional()

--- a/src/features/product/services/product-storefront-mappers.helper.spec.ts
+++ b/src/features/product/services/product-storefront-mappers.helper.spec.ts
@@ -40,6 +40,10 @@ describe('calcDiscountRate', () => {
   it('정가가 0 이하이면 0', () => {
     expect(calcDiscountRate(0, 0)).toBe(0);
   });
+
+  it('salePrice가 음수 등 비정상이면 0~100으로 clamp한다', () => {
+    expect(calcDiscountRate(40000, -10000)).toBe(100);
+  });
 });
 
 describe('toStoreProduct', () => {

--- a/src/features/product/services/product-storefront-mappers.helper.ts
+++ b/src/features/product/services/product-storefront-mappers.helper.ts
@@ -15,7 +15,9 @@ export function calcDiscountRate(
   if (salePrice === null || regularPrice <= 0 || salePrice >= regularPrice) {
     return 0;
   }
-  return Math.round((1 - salePrice / regularPrice) * 100);
+  // salePrice가 음수 등 비정상 값이어도 공개 계약(0~100)을 지키도록 clamp
+  const rate = Math.round((1 - salePrice / regularPrice) * 100);
+  return Math.min(100, Math.max(0, rate));
 }
 
 export function toStoreProduct(row: StoreProductRow): StoreProduct {

--- a/src/features/product/services/product-storefront.service.spec.ts
+++ b/src/features/product/services/product-storefront.service.spec.ts
@@ -334,7 +334,7 @@ describe('ProductStorefrontService (real DB)', () => {
       expect(result).toEqual([]);
     });
 
-    it('비활성/삭제 매장의 카테고리는 노출하지 않는다', async () => {
+    it('비활성 매장의 카테고리는 노출하지 않는다', async () => {
       const store = await createStore(prisma, { is_active: false });
       const product = await createProduct(prisma, { store_id: store.id });
       const cat = await prisma.category.create({
@@ -347,6 +347,30 @@ describe('ProductStorefrontService (real DB)', () => {
       });
       await prisma.productCategory.create({
         data: { product_id: product.id, category_id: cat.id },
+      });
+
+      const result = await service.storeProductCategories(store.id.toString());
+
+      expect(result).toEqual([]);
+    });
+
+    it('soft-delete된 매장의 카테고리는 노출하지 않는다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const cat = await prisma.category.create({
+        data: {
+          name: '돌잔치',
+          category_type: 'EVENT',
+          sort_order: 0,
+          is_active: true,
+        },
+      });
+      await prisma.productCategory.create({
+        data: { product_id: product.id, category_id: cat.id },
+      });
+      await prisma.store.update({
+        where: { id: store.id },
+        data: { deleted_at: new Date() },
       });
 
       const result = await service.storeProductCategories(store.id.toString());

--- a/src/features/store/dto/inputs/store-reviews.input.ts
+++ b/src/features/store/dto/inputs/store-reviews.input.ts
@@ -1,11 +1,20 @@
-import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 export class StoreReviewsInput {
   @IsString()
+  @IsNotEmpty()
   storeId!: string;
 
   @IsOptional()
   @IsString()
+  @IsNotEmpty()
   cursor?: string;
 
   @IsOptional()

--- a/src/features/store/services/store-detail.service.ts
+++ b/src/features/store/services/store-detail.service.ts
@@ -30,7 +30,7 @@ export class StoreDetailService {
 
     const [reviewStats, wishlistedIds] = await Promise.all([
       this.repo.aggregateReviewStats([storeId]),
-      accountId
+      accountId !== undefined
         ? this.wishlistRepo.findWishlistedStoreIds({
             accountId,
             storeIds: [storeId],

--- a/src/features/store/services/store-review.service.ts
+++ b/src/features/store/services/store-review.service.ts
@@ -37,7 +37,7 @@ export class StoreReviewService {
 
     const [likeCounts, likedIds] = await Promise.all([
       this.repo.aggregateLikeCounts(reviewIds),
-      accountId
+      accountId !== undefined
         ? this.repo.findLikedReviewIds({ reviewIds, accountId })
         : Promise.resolve(new Set<string>()),
     ]);

--- a/src/prisma/soft-delete.middleware.ts
+++ b/src/prisma/soft-delete.middleware.ts
@@ -10,6 +10,7 @@ const SOFT_DELETE_MODELS = new Set<Prisma.ModelName>([
   'Store',
   'StoreBusinessHour',
   'StoreSpecialClosure',
+  'StoreImage',
   'Category',
   'Tag',
   'Product',


### PR DESCRIPTION
## Summary

릴리즈 PR #161 리뷰에서 나온 **Codex P2 + CodeRabbit Functional** 지적을 반영한다. store-detail 조회 API의 soft-delete 등록·입력 방어를 보강한다.

## Scope

- **StoreImage** 를 `SOFT_DELETE_MODELS`에 등록 → 직접 조회 시 `deleted_at` 자동 필터 적용 (Codex P2)
- `storeProducts`/`storeReviews` input의 ID(`storeId`·`categoryId`·`cursor`)에 `@IsNotEmpty` 추가 — 빈 문자열 차단
- `discountRate`를 0~100으로 clamp — 음수 `salePrice` 등 비정상 데이터에도 공개 계약 보장
- `accountId` `0n` falsy 분기를 `!== undefined`로 (`storeReviews`·`storeDetail` — account id 0의 좋아요/찜 조회 누락 방지)
- product-storefront service spec: "비활성 매장" / "soft-delete 매장" 케이스 분리·검증 추가

## 진행 상황

- 릴리즈 PR #161에서 발견된 지적. develop에 반영하면 릴리즈 PR이 자동 갱신됨
- **CodeRabbit Major(서비스/리졸버 spec을 mock으로 전환)는 미반영** — 이 레포는 testcontainers 기반 realDB 통합 테스트가 모든 기존 spec에 확립된 컨벤션이라, 일반론적 mock 제안은 부적합(릴리즈 PR에 근거 코멘트 예정)

## Impact

- 조회 동작의 입력/soft-delete 방어 강화. 기존 정상 경로 동작 변화 없음
- 스키마/계약 변경 없음

## Test plan

- `yarn validate` 통과(168 suites / **1403 tests**) — 음수 clamp·soft-delete 매장 케이스 테스트 추가
