### PR TITLE
fix: 릴리즈 리뷰 반영 (seller 조회 nested soft-delete 가드·댓글 삭제 명시 가드)

### DIFF
--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -96,8 +96,12 @@ export class ProductRepository {
             }
           : {}),
       },
+      // soft-delete extension은 root만 patch하므로 nested relation에 가드를 명시한다
       include: {
-        images: { orderBy: { sort_order: 'asc' } },
+        images: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+        },
         product_categories: {
           include: {
             category: true,
@@ -109,9 +113,11 @@ export class ProductRepository {
           },
         },
         option_groups: {
+          where: { deleted_at: null },
           orderBy: { sort_order: 'asc' },
           include: {
             option_items: {
+              where: { deleted_at: null },
               orderBy: { sort_order: 'asc' },
             },
           },
@@ -119,6 +125,7 @@ export class ProductRepository {
         custom_template: {
           include: {
             text_tokens: {
+              where: { deleted_at: null },
               orderBy: { sort_order: 'asc' },
             },
           },
@@ -153,8 +160,12 @@ export class ProductRepository {
         store_id: args.storeId,
         is_active: true,
       },
+      // soft-delete extension은 root만 patch하므로 nested relation에 가드를 명시한다
       include: {
-        images: { orderBy: { sort_order: 'asc' } },
+        images: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+        },
         product_categories: {
           include: {
             category: true,
@@ -166,9 +177,11 @@ export class ProductRepository {
           },
         },
         option_groups: {
+          where: { deleted_at: null },
           orderBy: { sort_order: 'asc' },
           include: {
             option_items: {
+              where: { deleted_at: null },
               orderBy: { sort_order: 'asc' },
             },
           },
@@ -176,6 +189,7 @@ export class ProductRepository {
         custom_template: {
           include: {
             text_tokens: {
+              where: { deleted_at: null },
               orderBy: { sort_order: 'asc' },
             },
           },
@@ -193,8 +207,12 @@ export class ProductRepository {
         id: args.productId,
         store_id: args.storeId,
       },
+      // soft-delete extension은 root만 patch하므로 nested relation에 가드를 명시한다
       include: {
-        images: { orderBy: { sort_order: 'asc' } },
+        images: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+        },
         product_categories: {
           include: {
             category: true,
@@ -206,9 +224,11 @@ export class ProductRepository {
           },
         },
         option_groups: {
+          where: { deleted_at: null },
           orderBy: { sort_order: 'asc' },
           include: {
             option_items: {
+              where: { deleted_at: null },
               orderBy: { sort_order: 'asc' },
             },
           },
@@ -216,6 +236,7 @@ export class ProductRepository {
         custom_template: {
           include: {
             text_tokens: {
+              where: { deleted_at: null },
               orderBy: { sort_order: 'asc' },
             },
           },

--- a/src/features/seller/services/seller-product-query.service.spec.ts
+++ b/src/features/seller/services/seller-product-query.service.spec.ts
@@ -181,6 +181,48 @@ describe('SellerProductQueryService (real DB)', () => {
       expect(result.images).toHaveLength(1);
     });
 
+    it('soft-delete된 이미지·옵션 그룹·옵션 아이템은 상세에서 제외한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const product = await createSellerProduct(store.id);
+      await prisma.productImage.create({
+        data: {
+          product_id: product.id,
+          image_url: 'deleted.png',
+          sort_order: 1,
+          deleted_at: new Date(),
+        },
+      });
+      const group = await prisma.productOptionGroup.create({
+        data: { product_id: product.id, name: '사이즈' },
+      });
+      await prisma.productOptionItem.create({
+        data: { option_group_id: group.id, title: '살아있는 항목' },
+      });
+      await prisma.productOptionItem.create({
+        data: {
+          option_group_id: group.id,
+          title: '삭제된 항목',
+          deleted_at: new Date(),
+        },
+      });
+      await prisma.productOptionGroup.create({
+        data: {
+          product_id: product.id,
+          name: '삭제된 그룹',
+          deleted_at: new Date(),
+        },
+      });
+
+      const result = await service.sellerProduct(account.id, product.id);
+
+      // createSellerProduct가 만든 활성 이미지 1장만 남는다
+      expect(result.images).toHaveLength(1);
+      expect(result.optionGroups.map((g) => g.name)).toEqual(['사이즈']);
+      expect(result.optionGroups[0].optionItems.map((i) => i.title)).toEqual([
+        '살아있는 항목',
+      ]);
+    });
+
     it('custom_template이 존재하는 product 조회 시 customTemplate 필드가 채워진다', async () => {
       const { account, store } = await setupSellerWithStore(prisma);
       const product = await createSellerProduct(store.id, {

--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -663,7 +663,8 @@ export class UserRepository {
     commentId: bigint;
   }): Promise<'deleted' | 'not-found' | 'forbidden'> {
     const comment = await this.prisma.reviewComment.findFirst({
-      where: { id: args.commentId },
+      // extension이 주입하지만 재삭제 방지 계약을 코드에서 바로 읽도록 명시한다
+      where: { id: args.commentId, deleted_at: null },
       select: { id: true, account_id: true },
     });
     if (!comment) return 'not-found';


### PR DESCRIPTION
## Summary

릴리즈 PR #168의 CodeRabbit 리뷰 중 유효 판정 2건을 반영합니다.

## Scope

- `ProductRepository.findProductById` / `findProductByIdIncludingInactive` / `listProductsByStore`: nested relation(이미지·옵션 그룹·옵션 아이템·커스텀 텍스트 토큰)에 `deleted_at: null` 가드 명시 — seller 상품 조회 응답에 soft-delete된 이미지/옵션이 노출되던 문제 수정
- `UserRepository.softDeleteMyReviewComment`: 조회 조건에 `deleted_at: null` 명시 (extension 주입에 더한 명시적 계약)

## 진행 상황

- [x] 수정 + 회귀 테스트(soft-delete 이미지/그룹/아이템 상세 제외) 추가
- [x] `yarn validate` 통과 (1,463 tests)

## Impact

- 구매자 API 동작 변화 없음 (구매자 경로는 이미 가드 완비)
- seller 상품 상세/목록에서 삭제된 이미지·옵션이 사라짐 (올바른 동작으로 교정)

## Test plan

- [x] seller 상품 상세: soft-delete 이미지·옵션 그룹·옵션 아이템 제외 회귀 테스트
- [x] 기존 seller/product 전체 스위트 통과
