### PR TITLE
fix: GraphQL 비로그인 요청에서 CurrentUser 데코레이터 500 오류 수정

### DIFF
--- a/src/global/auth/decorators/current-user.decorator.spec.ts
+++ b/src/global/auth/decorators/current-user.decorator.spec.ts
@@ -2,60 +2,70 @@ import type { ExecutionContext } from '@nestjs/common';
 
 import { currentUserFactory } from '@/global/auth/decorators/current-user.decorator';
 
-function makeExecutionContext(opts: {
-  gqlReqUser?: unknown;
-  httpReqUser?: unknown;
-  gqlContextType?: string;
+/**
+ * 실제 ExecutionContextHost 동작에 충실한 mock을 만든다.
+ * 핵심: switchToHttp().getRequest()는 컨텍스트 타입과 무관하게 args[0]을 반환한다.
+ * (GraphQL 컨텍스트에서 args[0]은 resolver root — 루트 Query면 undefined)
+ * 과거 mock이 getRequest()를 항상 객체로 반환해 비로그인 GraphQL 500 버그를 놓쳤다.
+ */
+function makeExecutionContext(args: {
+  type: 'graphql' | 'http';
+  args: unknown[];
 }): ExecutionContext {
-  const gqlReq = opts.gqlReqUser !== undefined ? { user: opts.gqlReqUser } : {};
-  const httpReq = { user: opts.httpReqUser };
-  // GraphQL resolver args는 (root, args, context, info) 4 요소.
-  // GqlExecutionContext.getContext()는 args[2]를 반환한다.
-  const gqlArgs = [null, null, { req: gqlReq }, null];
-
-  const ctx = {
-    getType: () => opts.gqlContextType ?? 'http',
-    getArgs: () => gqlArgs,
-    getArgByIndex: (idx: number) => gqlArgs[idx] ?? null,
+  return {
+    getType: () => args.type,
+    getArgs: () => args.args,
+    getArgByIndex: (idx: number) => args.args[idx],
     switchToHttp: () => ({
-      getRequest: () => httpReq,
-      getResponse: () => ({}),
-      getNext: () => () => undefined,
+      getRequest: () => args.args[0],
+      getResponse: () => args.args[1],
+      getNext: () => args.args[2],
     }),
     switchToRpc: () => ({}) as never,
     switchToWs: () => ({}) as never,
     getHandler: () => () => undefined,
     getClass: () => class {},
   } as unknown as ExecutionContext;
-  return ctx;
+}
+
+/** GraphQL resolver args: (root, args, context, info). 루트 Query의 root는 undefined. */
+function makeGqlContext(reqUser?: unknown): ExecutionContext {
+  return makeExecutionContext({
+    type: 'graphql',
+    args: [undefined, {}, { req: { user: reqUser } }, {}],
+  });
+}
+
+/** REST handler args: (req, res, next). */
+function makeHttpContext(reqUser?: unknown): ExecutionContext {
+  return makeExecutionContext({
+    type: 'http',
+    args: [{ user: reqUser }, {}, () => undefined],
+  });
 }
 
 describe('currentUserFactory', () => {
   it('GraphQL context에 req.user가 있으면 그 값을 반환한다', () => {
     const user = { accountId: '42' };
-    const ctx = makeExecutionContext({
-      gqlReqUser: user,
-      gqlContextType: 'graphql',
-    });
-
-    const result = currentUserFactory(undefined, ctx);
+    const result = currentUserFactory(undefined, makeGqlContext(user));
     expect(result).toEqual(user);
   });
 
-  it('GraphQL context에 req.user가 없으면 HTTP request.user로 fallback', () => {
+  it('GraphQL 비로그인(req.user 없음)이면 크래시 없이 undefined를 반환한다', () => {
+    // 회귀 케이스: 과거에는 HTTP 폴백으로 내려가 args[0](undefined).user에서
+    // TypeError가 발생, OptionalJwtAuthGuard public query가 전부 500이었다.
+    const result = currentUserFactory(undefined, makeGqlContext(undefined));
+    expect(result).toBeUndefined();
+  });
+
+  it('HTTP context면 request.user를 반환한다', () => {
     const user = { accountId: '100' };
-    const ctx = makeExecutionContext({
-      httpReqUser: user,
-      gqlContextType: 'http',
-    });
-
-    const result = currentUserFactory(undefined, ctx);
+    const result = currentUserFactory(undefined, makeHttpContext(user));
     expect(result).toEqual(user);
   });
 
-  it('어느 곳에도 user가 없으면 undefined 반환', () => {
-    const ctx = makeExecutionContext({});
-    const result = currentUserFactory(undefined, ctx);
+  it('HTTP context에 user가 없으면 undefined를 반환한다', () => {
+    const result = currentUserFactory(undefined, makeHttpContext(undefined));
     expect(result).toBeUndefined();
   });
 });

--- a/src/global/auth/decorators/current-user.decorator.ts
+++ b/src/global/auth/decorators/current-user.decorator.ts
@@ -1,5 +1,5 @@
 import { createParamDecorator, type ExecutionContext } from '@nestjs/common';
-import { GqlExecutionContext } from '@nestjs/graphql';
+import { GqlExecutionContext, type GqlContextType } from '@nestjs/graphql';
 import type { Request } from 'express';
 
 import type { JwtUser } from '@/global/auth/types/jwt-payload.type';
@@ -34,16 +34,18 @@ export function currentUserFactory(
   _data: unknown,
   ctx: ExecutionContext,
 ): JwtUser | undefined {
-  // GraphQL Context
-  const gqlContext = GqlExecutionContext.create(ctx);
-  const gqlReq = gqlContext.getContext<{ req?: Request }>()?.req;
-  if (gqlReq?.user) {
-    return gqlReq.user;
+  // GraphQL 요청은 HTTP 경로로 폴백하지 않는다.
+  // GraphQL ExecutionContext의 switchToHttp().getRequest()는 HTTP request가 아니라
+  // resolver root(args[0])를 반환하므로, 루트 Query에서 비로그인이면
+  // undefined.user TypeError(500)가 난다. 컨텍스트 타입으로 분기해 차단한다.
+  if (ctx.getType<GqlContextType>() === 'graphql') {
+    const gqlReq = GqlExecutionContext.create(ctx).getContext<{
+      req?: Request;
+    }>()?.req;
+    return gqlReq?.user;
   }
 
-  // HTTP Context
-  const request = ctx.switchToHttp().getRequest<Request>();
-  return request.user;
+  return ctx.switchToHttp().getRequest<Request>().user;
 }
 
 export const CurrentUser = createParamDecorator(currentUserFactory);


### PR DESCRIPTION
## Summary

FE 연동 중 보고된 버그 수정: `OptionalJwtAuthGuard` + `@CurrentUser()`를 쓰는 public GraphQL query(`storeReviews`, `storeDetail`, `productReviews`, `productDetail` 등)가 **비로그인 요청에서 전부 500**으로 실패하던 문제를 수정한다.

- 원인: `currentUserFactory`가 GraphQL 컨텍스트에서 `req.user`가 없으면 HTTP 폴백으로 내려가는데, GraphQL ExecutionContext의 `switchToHttp().getRequest()`는 HTTP request가 아니라 **resolver root(`args[0]`)** 를 반환한다. 루트 Query의 root는 `undefined`이므로 `request.user`에서 `TypeError` → 500.
- 수정: `ctx.getType<GqlContextType>() === 'graphql'` 분기로 GraphQL 요청이 HTTP 경로로 폴백하지 않게 차단.

## Scope

- `src/global/auth/decorators/current-user.decorator.ts` — 컨텍스트 타입 분기
- `src/global/auth/decorators/current-user.decorator.spec.ts` — mock을 실제 `ExecutionContextHost` 동작(`getRequest() = args[0]`)에 맞게 재작성 + 비로그인 회귀 케이스 추가

## 진행 상황

- [x] 데코레이터 컨텍스트 타입 분기 수정
- [x] spec mock 실제 동작 정합화 (기존 mock은 `getRequest()`가 항상 객체를 반환해 버그를 가렸음)
- [x] GraphQL 비로그인 회귀 테스트 추가
- [x] `yarn validate` 통과 (lint + tsc + dto:check + arch:check + test:cov 1464건)

## Impact

- 비로그인 사용자의 public query 접근이 정상화된다 (매장 상세/리뷰, 상품 상세/리뷰 화면).
- 로그인 사용자·REST(`@CurrentUser()` in `auth.controller`) 경로는 동작 변화 없음.
- 스키마/API 계약 변경 없음.

## Test plan

- [x] GraphQL + 로그인: `req.user` 반환
- [x] GraphQL + 비로그인: 크래시 없이 `undefined` 반환 (회귀 케이스 — 구 코드에서는 TypeError)
- [x] HTTP + user 유/무: `request.user` / `undefined` 반환
