### PR TITLE
feat: storeReviews 사진후기 필터(photoOnly)·photoTotalCount 추가

### DIFF
--- a/src/features/store/dto/inputs/store-reviews.input.ts
+++ b/src/features/store/dto/inputs/store-reviews.input.ts
@@ -1,4 +1,5 @@
 import {
+  IsBoolean,
   IsInt,
   IsNotEmpty,
   IsOptional,
@@ -11,6 +12,10 @@ export class StoreReviewsInput {
   @IsString()
   @IsNotEmpty()
   storeId!: string;
+
+  @IsOptional()
+  @IsBoolean()
+  photoOnly?: boolean;
 
   @IsOptional()
   @IsString()

--- a/src/features/store/repositories/store-review.repository.ts
+++ b/src/features/store/repositories/store-review.repository.ts
@@ -33,18 +33,27 @@ export interface StoreReviewRow {
 export class StoreReviewRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  /** 매장 공개 리뷰 공통 가드: 리뷰·매장 활성(photoOnly면 활성 미디어 존재). */
+  private publicReviewWhere(photoOnly: boolean): Prisma.ReviewWhereInput {
+    return {
+      deleted_at: null,
+      // storeDetail과 동일하게 비활성/삭제 매장의 리뷰는 노출하지 않는다
+      store: { is_active: true, deleted_at: null },
+      ...(photoOnly ? { media: { some: { deleted_at: null } } } : {}),
+    };
+  }
+
   /** 매장 공개 리뷰 목록(최신순, 커서 id desc). soft-delete 제외. */
   async listStoreReviews(args: {
     storeId: bigint;
+    photoOnly: boolean;
     limit: number;
     cursor?: bigint;
   }): Promise<StoreReviewRow[]> {
     return this.prisma.review.findMany({
       where: {
         store_id: args.storeId,
-        deleted_at: null,
-        // storeDetail과 동일하게 비활성/삭제 매장의 리뷰는 노출하지 않는다
-        store: { is_active: true, deleted_at: null },
+        ...this.publicReviewWhere(args.photoOnly),
         // 0n도 유효 인자(parseId("0")=0n). truthiness는 0n을 falsy로 떨궈
         // zero cursor가 페이지를 리셋하므로 undefined로만 분기한다.
         ...(args.cursor !== undefined ? { id: { lt: args.cursor } } : {}),
@@ -78,13 +87,15 @@ export class StoreReviewRepository {
     });
   }
 
-  /** 매장 활성 리뷰 수(후기 탭 카운트). 비활성/삭제 매장은 0. */
-  async countStoreReviews(storeId: bigint): Promise<number> {
+  /** 매장 활성 리뷰 수(photoOnly=true면 사진 리뷰 수). 비활성/삭제 매장은 0. */
+  async countStoreReviews(args: {
+    storeId: bigint;
+    photoOnly: boolean;
+  }): Promise<number> {
     return this.prisma.review.count({
       where: {
-        store_id: storeId,
-        deleted_at: null,
-        store: { is_active: true, deleted_at: null },
+        store_id: args.storeId,
+        ...this.publicReviewWhere(args.photoOnly),
       },
     });
   }

--- a/src/features/store/resolvers/store-review-query.resolver.spec.ts
+++ b/src/features/store/resolvers/store-review-query.resolver.spec.ts
@@ -63,7 +63,30 @@ describe('Store Review Query Resolver (real DB)', () => {
     );
 
     expect(result.totalCount).toBe(1);
+    expect(result.photoTotalCount).toBe(0);
     expect(result.items[0].isLiked).toBe(false);
+  });
+
+  it('storeReviews: photoOnly 필터가 service까지 전달된다', async () => {
+    const store = await createStore(prisma);
+    await makeReview(store.id);
+    const photoReview = await makeReview(store.id);
+    await prisma.reviewMedia.create({
+      data: {
+        review_id: photoReview.id,
+        media_type: 'IMAGE',
+        media_url: 'a.png',
+        sort_order: 0,
+      },
+    });
+
+    const result = await resolver.storeReviews(
+      { storeId: store.id.toString(), photoOnly: true },
+      undefined,
+    );
+
+    expect(result.items.map((r) => r.id)).toEqual([photoReview.id.toString()]);
+    expect(result.photoTotalCount).toBe(1);
   });
 
   it('storeReviews: 로그인 사용자(JwtUser)의 좋아요 여부를 채운다', async () => {

--- a/src/features/store/services/store-review.service.spec.ts
+++ b/src/features/store/services/store-review.service.spec.ts
@@ -56,11 +56,12 @@ describe('StoreReviewService (real DB)', () => {
     });
   }
 
-  it('리뷰가 없으면 빈 목록과 totalCount 0', async () => {
+  it('리뷰가 없으면 빈 목록과 totalCount/photoTotalCount 0', async () => {
     const store = await createStore(prisma);
     const result = await service.storeReviews({ storeId: store.id.toString() });
     expect(result.items).toEqual([]);
     expect(result.totalCount).toBe(0);
+    expect(result.photoTotalCount).toBe(0);
     expect(result.hasMore).toBe(false);
     expect(result.nextCursor).toBeNull();
   });
@@ -85,6 +86,7 @@ describe('StoreReviewService (real DB)', () => {
     const result = await service.storeReviews({ storeId: store.id.toString() });
 
     expect(result.totalCount).toBe(1);
+    expect(result.photoTotalCount).toBe(1);
     expect(result.items[0]).toMatchObject({
       rating: 4,
       authorNickname: '구매자1',
@@ -128,6 +130,52 @@ describe('StoreReviewService (real DB)', () => {
       liker1.id,
     );
     expect(loggedIn.items[0].isLiked).toBe(true);
+  });
+
+  it('photoOnly=true면 활성 미디어가 있는 리뷰만 반환한다', async () => {
+    const store = await createStore(prisma);
+    await makeReview(store.id, {});
+    const photoReview = await makeReview(store.id, {});
+    await prisma.reviewMedia.create({
+      data: {
+        review_id: photoReview.id,
+        media_type: 'IMAGE',
+        media_url: 'a.png',
+        sort_order: 0,
+      },
+    });
+
+    const result = await service.storeReviews({
+      storeId: store.id.toString(),
+      photoOnly: true,
+    });
+
+    expect(result.items.map((r) => r.id)).toEqual([photoReview.id.toString()]);
+    // totalCount는 필터와 무관한 전체 리뷰 수, photoTotalCount는 사진 리뷰 수
+    expect(result.totalCount).toBe(2);
+    expect(result.photoTotalCount).toBe(1);
+  });
+
+  it('soft-delete된 미디어만 있는 리뷰는 사진후기로 치지 않는다', async () => {
+    const store = await createStore(prisma);
+    const review = await makeReview(store.id, {});
+    await prisma.reviewMedia.create({
+      data: {
+        review_id: review.id,
+        media_type: 'IMAGE',
+        media_url: 'a.png',
+        sort_order: 0,
+        deleted_at: new Date(),
+      },
+    });
+
+    const result = await service.storeReviews({
+      storeId: store.id.toString(),
+      photoOnly: true,
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.photoTotalCount).toBe(0);
   });
 
   it('soft-delete된 리뷰는 목록·카운트에서 제외한다', async () => {

--- a/src/features/store/services/store-review.service.ts
+++ b/src/features/store/services/store-review.service.ts
@@ -12,7 +12,7 @@ export class StoreReviewService {
   constructor(private readonly repo: StoreReviewRepository) {}
 
   /**
-   * 매장 공개 리뷰 목록(커서). soft-delete 제외, 최신순.
+   * 매장 공개 리뷰 목록(커서). soft-delete 제외, 최신순. 사진 필터 지원.
    * 좋아요 수는 집계, isLiked는 로그인 사용자에 한해 채운다(비로그인 false).
    */
   async storeReviews(
@@ -21,14 +21,18 @@ export class StoreReviewService {
   ): Promise<StoreReviewConnection> {
     const storeId = parseId(input.storeId);
     const limit = input.limit ?? DEFAULT_STORE_REVIEWS_LIMIT;
+    const photoOnly = input.photoOnly ?? false;
 
-    const [rows, totalCount] = await Promise.all([
+    // photoTotalCount는 필터와 무관하게 항상 사진 리뷰 총수(productReviews와 동일 의미)
+    const [rows, totalCount, photoTotalCount] = await Promise.all([
       this.repo.listStoreReviews({
         storeId,
+        photoOnly,
         limit,
         cursor: input.cursor ? parseId(input.cursor) : undefined,
       }),
-      this.repo.countStoreReviews(storeId),
+      this.repo.countStoreReviews({ storeId, photoOnly: false }),
+      this.repo.countStoreReviews({ storeId, photoOnly: true }),
     ]);
 
     const hasMore = rows.length > limit;
@@ -51,6 +55,7 @@ export class StoreReviewService {
         ),
       ),
       totalCount,
+      photoTotalCount,
       hasMore,
       nextCursor: hasMore ? page[page.length - 1].id.toString() : null,
     };

--- a/src/features/store/store-reviews.graphql
+++ b/src/features/store/store-reviews.graphql
@@ -5,6 +5,8 @@ extend type Query {
 
 input StoreReviewsInput {
   storeId: ID!
+  """true면 사진(미디어) 있는 리뷰만(사진후기 그리드)."""
+  photoOnly: Boolean = false
   """이전 페이지 마지막 리뷰 id(이후부터 조회)."""
   cursor: ID
   limit: Int = 20
@@ -15,6 +17,8 @@ type StoreReviewConnection {
   items: [StoreReview!]!
   """전체 리뷰 수(후기 탭 카운트). 0이면 빈 상태."""
   totalCount: Int!
+  """사진 리뷰 수(사진후기 카운트)."""
+  photoTotalCount: Int!
   hasMore: Boolean!
   nextCursor: ID
 }

--- a/src/features/store/types/store-review-output.type.ts
+++ b/src/features/store/types/store-review-output.type.ts
@@ -25,6 +25,7 @@ export interface StoreReview {
 export interface StoreReviewConnection {
   items: StoreReview[];
   totalCount: number;
+  photoTotalCount: number;
   hasMore: boolean;
   nextCursor: string | null;
 }


### PR DESCRIPTION
## Summary

FE 요청 반영: 매장 사진후기 화면을 위해 `storeReviews`에 사진 필터·카운트를 추가한다. `productReviews`에는 이미 있는 기능으로, 동일 의미론을 미러링한다.

- `StoreReviewsInput.photoOnly: Boolean = false` — true면 활성 미디어가 있는 리뷰만 조회
- `StoreReviewConnection.photoTotalCount: Int!` — 사진 리뷰 총수. **필터와 무관하게 항상 반환** (`productReviews.photoTotalCount`와 동일 의미)

배경: 서버 필터 없이 FE가 최신 N건에서 사진 리뷰를 골라내면, 사진 없는 리뷰가 몰린 구간에서 사진후기 그리드가 빈 화면이 되는 문제가 있었다.

## Scope

- `store-reviews.graphql` — SDL 필드 2개 추가 (additive, 기존 호출 breaking 없음)
- `store-reviews.input.ts` — `photoOnly` 검증 데코레이터 추가
- `store-review.repository.ts` — product 쪽 `publicReviewWhere` 패턴 미러링: `media.some(deleted_at: null)` 필터, `countStoreReviews`를 `{ storeId, photoOnly }` 시그니처로 변경
- `store-review.service.ts` — 목록 + 전체/사진 카운트 병렬 조회
- `store-review-output.type.ts` — `photoTotalCount` 추가

## 진행 상황

- [x] SDL/DTO/repository/service/output type 구현
- [x] codegen 재생성 · `yarn dto:check` 통과
- [x] 테스트 추가 (아래 Test plan)
- [x] `yarn validate` 통과

## Impact

- 기존 FE 호출은 그대로 동작 (photoOnly 기본 false, photoTotalCount는 additive 필드).
- 사진후기 그리드: `storeReviews(photoOnly: true)` + 헤더 카운트 `photoTotalCount`로 시안 구현 가능.
- soft-delete된 미디어만 있는 리뷰는 사진후기로 집계·노출되지 않는다.

## Test plan

- [x] service: `photoOnly=true`면 활성 미디어 있는 리뷰만 반환, `totalCount`(전체)/`photoTotalCount`(사진) 분리 검증
- [x] service: soft-delete된 미디어만 있는 리뷰는 사진후기 제외
- [x] service: 빈 목록·미디어 포함 목록에서 `photoTotalCount` 값 검증
- [x] resolver 통합: `photoOnly` 입력이 service까지 전달, `photoTotalCount` 반환 경로 검증
- [x] 기존 store 스위트 13개(76건) 전체 green
