### PR TITLE
chore: 릴리즈 — 비로그인 500 수정·storeReviews 사진후기 필터

### DIFF
--- a/src/features/store/dto/inputs/store-reviews.input.ts
+++ b/src/features/store/dto/inputs/store-reviews.input.ts
@@ -1,4 +1,5 @@
 import {
+  IsBoolean,
   IsInt,
   IsNotEmpty,
   IsOptional,
@@ -11,6 +12,10 @@ export class StoreReviewsInput {
   @IsString()
   @IsNotEmpty()
   storeId!: string;
+
+  @IsOptional()
+  @IsBoolean()
+  photoOnly?: boolean;
 
   @IsOptional()
   @IsString()

--- a/src/features/store/repositories/store-review.repository.ts
+++ b/src/features/store/repositories/store-review.repository.ts
@@ -33,18 +33,27 @@ export interface StoreReviewRow {
 export class StoreReviewRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  /** 매장 공개 리뷰 공통 가드: 리뷰·매장 활성(photoOnly면 활성 미디어 존재). */
+  private publicReviewWhere(photoOnly: boolean): Prisma.ReviewWhereInput {
+    return {
+      deleted_at: null,
+      // storeDetail과 동일하게 비활성/삭제 매장의 리뷰는 노출하지 않는다
+      store: { is_active: true, deleted_at: null },
+      ...(photoOnly ? { media: { some: { deleted_at: null } } } : {}),
+    };
+  }
+
   /** 매장 공개 리뷰 목록(최신순, 커서 id desc). soft-delete 제외. */
   async listStoreReviews(args: {
     storeId: bigint;
+    photoOnly: boolean;
     limit: number;
     cursor?: bigint;
   }): Promise<StoreReviewRow[]> {
     return this.prisma.review.findMany({
       where: {
         store_id: args.storeId,
-        deleted_at: null,
-        // storeDetail과 동일하게 비활성/삭제 매장의 리뷰는 노출하지 않는다
-        store: { is_active: true, deleted_at: null },
+        ...this.publicReviewWhere(args.photoOnly),
         // 0n도 유효 인자(parseId("0")=0n). truthiness는 0n을 falsy로 떨궈
         // zero cursor가 페이지를 리셋하므로 undefined로만 분기한다.
         ...(args.cursor !== undefined ? { id: { lt: args.cursor } } : {}),
@@ -78,13 +87,15 @@ export class StoreReviewRepository {
     });
   }
 
-  /** 매장 활성 리뷰 수(후기 탭 카운트). 비활성/삭제 매장은 0. */
-  async countStoreReviews(storeId: bigint): Promise<number> {
+  /** 매장 활성 리뷰 수(photoOnly=true면 사진 리뷰 수). 비활성/삭제 매장은 0. */
+  async countStoreReviews(args: {
+    storeId: bigint;
+    photoOnly: boolean;
+  }): Promise<number> {
     return this.prisma.review.count({
       where: {
-        store_id: storeId,
-        deleted_at: null,
-        store: { is_active: true, deleted_at: null },
+        store_id: args.storeId,
+        ...this.publicReviewWhere(args.photoOnly),
       },
     });
   }

--- a/src/features/store/resolvers/store-review-query.resolver.spec.ts
+++ b/src/features/store/resolvers/store-review-query.resolver.spec.ts
@@ -63,7 +63,30 @@ describe('Store Review Query Resolver (real DB)', () => {
     );
 
     expect(result.totalCount).toBe(1);
+    expect(result.photoTotalCount).toBe(0);
     expect(result.items[0].isLiked).toBe(false);
+  });
+
+  it('storeReviews: photoOnly 필터가 service까지 전달된다', async () => {
+    const store = await createStore(prisma);
+    await makeReview(store.id);
+    const photoReview = await makeReview(store.id);
+    await prisma.reviewMedia.create({
+      data: {
+        review_id: photoReview.id,
+        media_type: 'IMAGE',
+        media_url: 'a.png',
+        sort_order: 0,
+      },
+    });
+
+    const result = await resolver.storeReviews(
+      { storeId: store.id.toString(), photoOnly: true },
+      undefined,
+    );
+
+    expect(result.items.map((r) => r.id)).toEqual([photoReview.id.toString()]);
+    expect(result.photoTotalCount).toBe(1);
   });
 
   it('storeReviews: 로그인 사용자(JwtUser)의 좋아요 여부를 채운다', async () => {

--- a/src/features/store/services/store-review.service.spec.ts
+++ b/src/features/store/services/store-review.service.spec.ts
@@ -56,11 +56,12 @@ describe('StoreReviewService (real DB)', () => {
     });
   }
 
-  it('리뷰가 없으면 빈 목록과 totalCount 0', async () => {
+  it('리뷰가 없으면 빈 목록과 totalCount/photoTotalCount 0', async () => {
     const store = await createStore(prisma);
     const result = await service.storeReviews({ storeId: store.id.toString() });
     expect(result.items).toEqual([]);
     expect(result.totalCount).toBe(0);
+    expect(result.photoTotalCount).toBe(0);
     expect(result.hasMore).toBe(false);
     expect(result.nextCursor).toBeNull();
   });
@@ -85,6 +86,7 @@ describe('StoreReviewService (real DB)', () => {
     const result = await service.storeReviews({ storeId: store.id.toString() });
 
     expect(result.totalCount).toBe(1);
+    expect(result.photoTotalCount).toBe(1);
     expect(result.items[0]).toMatchObject({
       rating: 4,
       authorNickname: '구매자1',
@@ -128,6 +130,52 @@ describe('StoreReviewService (real DB)', () => {
       liker1.id,
     );
     expect(loggedIn.items[0].isLiked).toBe(true);
+  });
+
+  it('photoOnly=true면 활성 미디어가 있는 리뷰만 반환한다', async () => {
+    const store = await createStore(prisma);
+    await makeReview(store.id, {});
+    const photoReview = await makeReview(store.id, {});
+    await prisma.reviewMedia.create({
+      data: {
+        review_id: photoReview.id,
+        media_type: 'IMAGE',
+        media_url: 'a.png',
+        sort_order: 0,
+      },
+    });
+
+    const result = await service.storeReviews({
+      storeId: store.id.toString(),
+      photoOnly: true,
+    });
+
+    expect(result.items.map((r) => r.id)).toEqual([photoReview.id.toString()]);
+    // totalCount는 필터와 무관한 전체 리뷰 수, photoTotalCount는 사진 리뷰 수
+    expect(result.totalCount).toBe(2);
+    expect(result.photoTotalCount).toBe(1);
+  });
+
+  it('soft-delete된 미디어만 있는 리뷰는 사진후기로 치지 않는다', async () => {
+    const store = await createStore(prisma);
+    const review = await makeReview(store.id, {});
+    await prisma.reviewMedia.create({
+      data: {
+        review_id: review.id,
+        media_type: 'IMAGE',
+        media_url: 'a.png',
+        sort_order: 0,
+        deleted_at: new Date(),
+      },
+    });
+
+    const result = await service.storeReviews({
+      storeId: store.id.toString(),
+      photoOnly: true,
+    });
+
+    expect(result.items).toEqual([]);
+    expect(result.photoTotalCount).toBe(0);
   });
 
   it('soft-delete된 리뷰는 목록·카운트에서 제외한다', async () => {

--- a/src/features/store/services/store-review.service.ts
+++ b/src/features/store/services/store-review.service.ts
@@ -12,7 +12,7 @@ export class StoreReviewService {
   constructor(private readonly repo: StoreReviewRepository) {}
 
   /**
-   * 매장 공개 리뷰 목록(커서). soft-delete 제외, 최신순.
+   * 매장 공개 리뷰 목록(커서). soft-delete 제외, 최신순. 사진 필터 지원.
    * 좋아요 수는 집계, isLiked는 로그인 사용자에 한해 채운다(비로그인 false).
    */
   async storeReviews(
@@ -21,14 +21,18 @@ export class StoreReviewService {
   ): Promise<StoreReviewConnection> {
     const storeId = parseId(input.storeId);
     const limit = input.limit ?? DEFAULT_STORE_REVIEWS_LIMIT;
+    const photoOnly = input.photoOnly ?? false;
 
-    const [rows, totalCount] = await Promise.all([
+    // photoTotalCount는 필터와 무관하게 항상 사진 리뷰 총수(productReviews와 동일 의미)
+    const [rows, totalCount, photoTotalCount] = await Promise.all([
       this.repo.listStoreReviews({
         storeId,
+        photoOnly,
         limit,
         cursor: input.cursor ? parseId(input.cursor) : undefined,
       }),
-      this.repo.countStoreReviews(storeId),
+      this.repo.countStoreReviews({ storeId, photoOnly: false }),
+      this.repo.countStoreReviews({ storeId, photoOnly: true }),
     ]);
 
     const hasMore = rows.length > limit;
@@ -51,6 +55,7 @@ export class StoreReviewService {
         ),
       ),
       totalCount,
+      photoTotalCount,
       hasMore,
       nextCursor: hasMore ? page[page.length - 1].id.toString() : null,
     };

--- a/src/features/store/store-reviews.graphql
+++ b/src/features/store/store-reviews.graphql
@@ -5,6 +5,8 @@ extend type Query {
 
 input StoreReviewsInput {
   storeId: ID!
+  """true면 사진(미디어) 있는 리뷰만(사진후기 그리드)."""
+  photoOnly: Boolean = false
   """이전 페이지 마지막 리뷰 id(이후부터 조회)."""
   cursor: ID
   limit: Int = 20
@@ -15,6 +17,8 @@ type StoreReviewConnection {
   items: [StoreReview!]!
   """전체 리뷰 수(후기 탭 카운트). 0이면 빈 상태."""
   totalCount: Int!
+  """사진 리뷰 수(사진후기 카운트)."""
+  photoTotalCount: Int!
   hasMore: Boolean!
   nextCursor: ID
 }

--- a/src/features/store/types/store-review-output.type.ts
+++ b/src/features/store/types/store-review-output.type.ts
@@ -25,6 +25,7 @@ export interface StoreReview {
 export interface StoreReviewConnection {
   items: StoreReview[];
   totalCount: number;
+  photoTotalCount: number;
   hasMore: boolean;
   nextCursor: string | null;
 }

--- a/src/global/auth/decorators/current-user.decorator.spec.ts
+++ b/src/global/auth/decorators/current-user.decorator.spec.ts
@@ -2,60 +2,70 @@ import type { ExecutionContext } from '@nestjs/common';
 
 import { currentUserFactory } from '@/global/auth/decorators/current-user.decorator';
 
-function makeExecutionContext(opts: {
-  gqlReqUser?: unknown;
-  httpReqUser?: unknown;
-  gqlContextType?: string;
+/**
+ * 실제 ExecutionContextHost 동작에 충실한 mock을 만든다.
+ * 핵심: switchToHttp().getRequest()는 컨텍스트 타입과 무관하게 args[0]을 반환한다.
+ * (GraphQL 컨텍스트에서 args[0]은 resolver root — 루트 Query면 undefined)
+ * 과거 mock이 getRequest()를 항상 객체로 반환해 비로그인 GraphQL 500 버그를 놓쳤다.
+ */
+function makeExecutionContext(args: {
+  type: 'graphql' | 'http';
+  args: unknown[];
 }): ExecutionContext {
-  const gqlReq = opts.gqlReqUser !== undefined ? { user: opts.gqlReqUser } : {};
-  const httpReq = { user: opts.httpReqUser };
-  // GraphQL resolver args는 (root, args, context, info) 4 요소.
-  // GqlExecutionContext.getContext()는 args[2]를 반환한다.
-  const gqlArgs = [null, null, { req: gqlReq }, null];
-
-  const ctx = {
-    getType: () => opts.gqlContextType ?? 'http',
-    getArgs: () => gqlArgs,
-    getArgByIndex: (idx: number) => gqlArgs[idx] ?? null,
+  return {
+    getType: () => args.type,
+    getArgs: () => args.args,
+    getArgByIndex: (idx: number) => args.args[idx],
     switchToHttp: () => ({
-      getRequest: () => httpReq,
-      getResponse: () => ({}),
-      getNext: () => () => undefined,
+      getRequest: () => args.args[0],
+      getResponse: () => args.args[1],
+      getNext: () => args.args[2],
     }),
     switchToRpc: () => ({}) as never,
     switchToWs: () => ({}) as never,
     getHandler: () => () => undefined,
     getClass: () => class {},
   } as unknown as ExecutionContext;
-  return ctx;
+}
+
+/** GraphQL resolver args: (root, args, context, info). 루트 Query의 root는 undefined. */
+function makeGqlContext(reqUser?: unknown): ExecutionContext {
+  return makeExecutionContext({
+    type: 'graphql',
+    args: [undefined, {}, { req: { user: reqUser } }, {}],
+  });
+}
+
+/** REST handler args: (req, res, next). */
+function makeHttpContext(reqUser?: unknown): ExecutionContext {
+  return makeExecutionContext({
+    type: 'http',
+    args: [{ user: reqUser }, {}, () => undefined],
+  });
 }
 
 describe('currentUserFactory', () => {
   it('GraphQL context에 req.user가 있으면 그 값을 반환한다', () => {
     const user = { accountId: '42' };
-    const ctx = makeExecutionContext({
-      gqlReqUser: user,
-      gqlContextType: 'graphql',
-    });
-
-    const result = currentUserFactory(undefined, ctx);
+    const result = currentUserFactory(undefined, makeGqlContext(user));
     expect(result).toEqual(user);
   });
 
-  it('GraphQL context에 req.user가 없으면 HTTP request.user로 fallback', () => {
+  it('GraphQL 비로그인(req.user 없음)이면 크래시 없이 undefined를 반환한다', () => {
+    // 회귀 케이스: 과거에는 HTTP 폴백으로 내려가 args[0](undefined).user에서
+    // TypeError가 발생, OptionalJwtAuthGuard public query가 전부 500이었다.
+    const result = currentUserFactory(undefined, makeGqlContext(undefined));
+    expect(result).toBeUndefined();
+  });
+
+  it('HTTP context면 request.user를 반환한다', () => {
     const user = { accountId: '100' };
-    const ctx = makeExecutionContext({
-      httpReqUser: user,
-      gqlContextType: 'http',
-    });
-
-    const result = currentUserFactory(undefined, ctx);
+    const result = currentUserFactory(undefined, makeHttpContext(user));
     expect(result).toEqual(user);
   });
 
-  it('어느 곳에도 user가 없으면 undefined 반환', () => {
-    const ctx = makeExecutionContext({});
-    const result = currentUserFactory(undefined, ctx);
+  it('HTTP context에 user가 없으면 undefined를 반환한다', () => {
+    const result = currentUserFactory(undefined, makeHttpContext(undefined));
     expect(result).toBeUndefined();
   });
 });

--- a/src/global/auth/decorators/current-user.decorator.ts
+++ b/src/global/auth/decorators/current-user.decorator.ts
@@ -1,5 +1,5 @@
 import { createParamDecorator, type ExecutionContext } from '@nestjs/common';
-import { GqlExecutionContext } from '@nestjs/graphql';
+import { GqlExecutionContext, type GqlContextType } from '@nestjs/graphql';
 import type { Request } from 'express';
 
 import type { JwtUser } from '@/global/auth/types/jwt-payload.type';
@@ -34,16 +34,18 @@ export function currentUserFactory(
   _data: unknown,
   ctx: ExecutionContext,
 ): JwtUser | undefined {
-  // GraphQL Context
-  const gqlContext = GqlExecutionContext.create(ctx);
-  const gqlReq = gqlContext.getContext<{ req?: Request }>()?.req;
-  if (gqlReq?.user) {
-    return gqlReq.user;
+  // GraphQL 요청은 HTTP 경로로 폴백하지 않는다.
+  // GraphQL ExecutionContext의 switchToHttp().getRequest()는 HTTP request가 아니라
+  // resolver root(args[0])를 반환하므로, 루트 Query에서 비로그인이면
+  // undefined.user TypeError(500)가 난다. 컨텍스트 타입으로 분기해 차단한다.
+  if (ctx.getType<GqlContextType>() === 'graphql') {
+    const gqlReq = GqlExecutionContext.create(ctx).getContext<{
+      req?: Request;
+    }>()?.req;
+    return gqlReq?.user;
   }
 
-  // HTTP Context
-  const request = ctx.switchToHttp().getRequest<Request>();
-  return request.user;
+  return ctx.switchToHttp().getRequest<Request>().user;
 }
 
 export const CurrentUser = createParamDecorator(currentUserFactory);


### PR DESCRIPTION
## Summary

FE 연동 중 발견된 비로그인 500 버그 수정과 매장 사진후기 필드 추가 릴리즈입니다.

- #170 `fix`: `CurrentUser` 데코레이터가 GraphQL 비로그인 요청에서 HTTP 폴백으로 내려가 TypeError(500)를 내던 버그 수정. `OptionalJwtAuthGuard`를 쓰는 모든 public query(`storeReviews`, `storeDetail`, `productReviews`, `productDetail` 등)의 비로그인 접근이 정상화됩니다.
- #171 `feat`: `StoreReviewsInput.photoOnly`(기본 false) · `StoreReviewConnection.photoTotalCount` 추가. `productReviews`와 동일 의미론(photoTotalCount는 필터와 무관하게 사진 리뷰 총수).

## Scope

- `src/global/auth/decorators/` — 컨텍스트 타입 분기 + spec mock 정합화/회귀 케이스
- `src/features/store/` — SDL·DTO·repository·service·output type (additive 변경)

## 진행 상황

- [x] #170, #171 각각 develop 머지 완료 (CI green + Codex 👍)
- [x] 로컬 develop에서 비로그인 조회·photoOnly 필터 수동 검증 완료 (사용자 확인)

## Impact

- 비로그인 사용자의 매장/상품 상세·리뷰 조회 500 오류 해소 (운영에 살아있던 버그).
- 매장 사진후기 그리드 구현 가능(`storeReviews(photoOnly: true)` + `photoTotalCount`).
- 스키마 변경은 additive — 기존 FE 호출 breaking 없음. DB 마이그레이션 없음.

## Test plan

- [x] 데코레이터: GraphQL 로그인/비로그인·HTTP 경로 단위 테스트 (비로그인 회귀 케이스 포함)
- [x] storeReviews: photoOnly 필터·photoTotalCount·soft-delete 미디어 제외 service/resolver 테스트
- [x] `yarn validate` 전체 green (양 PR 각각 1464+ 테스트)
- [x] 로컬 수동 검증: 비로그인 storeReviews 200 응답, photoOnly 필터 동작


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 매장 리뷰를 사진이 포함된 리뷰만 조회하도록 필터링할 수 있습니다.
  * 리뷰 응답에 전체 사진 리뷰 수가 함께 제공됩니다.

* **버그 수정**
  * GraphQL 인증 사용자 정보를 컨텍스트에 맞게 정확히 확인하도록 개선했습니다.
  * 삭제된 사진만 포함된 리뷰가 사진 리뷰로 집계되지 않습니다.

* **테스트**
  * 사진 리뷰 필터와 사진 리뷰 수 집계에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->