### PR TITLE
chore: 릴리즈 — 소셜 로그인 재가입·이메일 정책 정합화

### DIFF
--- a/prisma/migrations/20260813183650_relax_account_email_unique_and_retire_withdrawn_identity/migration.sql
+++ b/prisma/migrations/20260813183650_relax_account_email_unique_and_retire_withdrawn_identity/migration.sql
@@ -1,0 +1,24 @@
+-- DropIndex
+DROP INDEX `account_email_key` ON `account`;
+
+-- CreateIndex
+CREATE INDEX `idx_account_email` ON `account`(`email`);
+
+-- 아래 두 UPDATE 는 스키마가 아니라 기존 데이터 정리다(수기 추가).
+-- 탈퇴 계정의 identity 가 살아있던 탓에 재로그인이 삭제 계정을 다시 집어들었고,
+-- 그 트랜잭션이 커밋되며 탈퇴 시 비워둔 email 을 되채워 놓은 상태가 남아 있다.
+
+-- 탈퇴 계정이 도로 점유한 이메일 회수 (탈퇴 정책상 NULL 이어야 한다)
+UPDATE `account`
+SET `email` = NULL
+WHERE `deleted_at` IS NOT NULL AND `email` IS NOT NULL;
+
+-- 탈퇴 계정에 매달린 살아있는 identity 은퇴 처리.
+-- (provider, provider_subject) UNIQUE 를 비워 같은 소셜 계정으로 재가입할 수 있게 한다.
+-- provider_subject 는 VarChar(255) 라 prefix 를 붙인 뒤 LEFT 로 clamp 한다.
+UPDATE `account_identity` `ai`
+JOIN `account` `a` ON `a`.`id` = `ai`.`account_id`
+SET `ai`.`provider_subject` = LEFT(CONCAT('withdrawn:', `a`.`id`, ':', `ai`.`provider_subject`), 255),
+    `ai`.`deleted_at` = NOW(3),
+    `ai`.`updated_at` = NOW(3)
+WHERE `a`.`deleted_at` IS NOT NULL AND `ai`.`deleted_at` IS NULL;

--- a/prisma/migrations/20260813183650_relax_account_email_unique_and_retire_withdrawn_identity/migration.sql
+++ b/prisma/migrations/20260813183650_relax_account_email_unique_and_retire_withdrawn_identity/migration.sql
@@ -15,10 +15,11 @@ WHERE `deleted_at` IS NOT NULL AND `email` IS NOT NULL;
 
 -- 탈퇴 계정에 매달린 살아있는 identity 은퇴 처리.
 -- (provider, provider_subject) UNIQUE 를 비워 같은 소셜 계정으로 재가입할 수 있게 한다.
--- provider_subject 는 VarChar(255) 라 prefix 를 붙인 뒤 LEFT 로 clamp 한다.
+-- 원본 subject 는 provider 발급 외부 식별자라 그대로 두면 탈퇴 계정이 살아있는 소셜 계정과
+-- 계속 연결된다 → SHA-256 다이제스트로 대체한다(런타임 buildWithdrawnProviderSubject 와 동일 규칙).
 UPDATE `account_identity` `ai`
 JOIN `account` `a` ON `a`.`id` = `ai`.`account_id`
-SET `ai`.`provider_subject` = LEFT(CONCAT('withdrawn:', `a`.`id`, ':', `ai`.`provider_subject`), 255),
+SET `ai`.`provider_subject` = CONCAT('withdrawn:', `a`.`id`, ':', SHA2(`ai`.`provider_subject`, 256)),
     `ai`.`deleted_at` = NOW(3),
     `ai`.`updated_at` = NOW(3)
 WHERE `a`.`deleted_at` IS NOT NULL AND `ai`.`deleted_at` IS NULL;

--- a/prisma/migrations/20260813190819_retire_legacy_soft_deleted_identities/migration.sql
+++ b/prisma/migrations/20260813190819_retire_legacy_soft_deleted_identities/migration.sql
@@ -1,0 +1,22 @@
+-- 스키마 변경 없음. 앞선 마이그레이션이 놓친 잔여 데이터 정리다.
+--
+-- 20260813183650 은 `deleted_at IS NULL` 인 identity 만 은퇴 처리했다. 그런데 익명화 없이
+-- soft-delete 만 된 identity 가 남아 있으면, 로그인 경로는 그 row 를 못 보지만
+-- (provider, provider_subject) UNIQUE 는 그대로 자리를 잡고 있어 재가입용 identity 생성이
+-- 계속 막힌다 → 해당 소셜 계정은 영구히 409 로 떨어진다.
+--
+-- 그래서 (a) 탈퇴 계정에 매달린 살아있는 identity 와 (b) 이미 soft-delete 됐지만 원본
+-- subject 를 그대로 들고 있는 identity 를 함께 정리한다. 이미 최종 형식
+-- (`withdrawn:<accountId>:<sha256 64자리>`) 인 row 는 제외해 재실행에 안전하다.
+-- 중간 배포본이 남긴 평문 형식(`withdrawn:<accountId>:<원본 subject>`)도 이 정규식에
+-- 걸리지 않으므로 함께 익명화된다.
+--
+-- soft-delete 된 identity 를 되살리는 코드 경로는 없으므로 deleted_at 은 보존한다
+-- (살아있는 row 만 지금 시각으로 은퇴시킨다).
+UPDATE `account_identity` `ai`
+JOIN `account` `a` ON `a`.`id` = `ai`.`account_id`
+SET `ai`.`provider_subject` = CONCAT('withdrawn:', `ai`.`account_id`, ':', SHA2(`ai`.`provider_subject`, 256)),
+    `ai`.`deleted_at` = COALESCE(`ai`.`deleted_at`, NOW(3)),
+    `ai`.`updated_at` = NOW(3)
+WHERE `ai`.`provider_subject` NOT REGEXP '^withdrawn:[0-9]+:[0-9a-f]{64}$'
+  AND (`a`.`deleted_at` IS NOT NULL OR `ai`.`deleted_at` IS NOT NULL);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,7 +133,10 @@ model Account {
   account_type AccountType
   status       AccountStatus @default(ACTIVE)
 
-  email String? @unique @db.VarChar(320)
+  // 이메일은 계정 식별자가 아니다. 계정 식별은 (provider, provider_subject) 로만 하고
+  // provider 간 계정 통합을 하지 않기로 했으므로, 같은 사람이 구글/카카오를 모두 쓰면
+  // 서로 다른 account 가 같은 이메일을 갖는 게 정상이다 → 전역 unique 를 두지 않는다.
+  email String? @db.VarChar(320)
   name  String? @db.VarChar(100)
 
   created_at DateTime  @default(now()) @db.DateTime(3)
@@ -164,6 +167,7 @@ model Account {
 
   @@index([account_type, status], map: "idx_account_type_status")
   @@index([deleted_at], map: "idx_account_deleted_at")
+  @@index([email], map: "idx_account_email")
   @@map("account")
 }
 

--- a/src/common/utils/withdrawn-identity.spec.ts
+++ b/src/common/utils/withdrawn-identity.spec.ts
@@ -1,0 +1,25 @@
+import { buildWithdrawnProviderSubject } from '@/common/utils/withdrawn-identity';
+
+describe('buildWithdrawnProviderSubject', () => {
+  it('withdrawn:<accountId>:<subject> 형식으로 익명화한다', () => {
+    expect(buildWithdrawnProviderSubject(BigInt(7), 'kakao-sub-123')).toBe(
+      'withdrawn:7:kakao-sub-123',
+    );
+  });
+
+  it('계정이 다르면 같은 subject 라도 결과가 다르다', () => {
+    const first = buildWithdrawnProviderSubject(BigInt(1), 'same-sub');
+    const second = buildWithdrawnProviderSubject(BigInt(2), 'same-sub');
+
+    expect(first).not.toBe(second);
+  });
+
+  it('VarChar(255) 한도를 넘지 않도록 자른다', () => {
+    const longSubject = 'a'.repeat(300);
+
+    const result = buildWithdrawnProviderSubject(BigInt(1), longSubject);
+
+    expect(result).toHaveLength(255);
+    expect(result.startsWith('withdrawn:1:')).toBe(true);
+  });
+});

--- a/src/common/utils/withdrawn-identity.spec.ts
+++ b/src/common/utils/withdrawn-identity.spec.ts
@@ -1,25 +1,32 @@
+import { sha256Hex } from '@/common/utils/crypto';
 import { buildWithdrawnProviderSubject } from '@/common/utils/withdrawn-identity';
 
 describe('buildWithdrawnProviderSubject', () => {
-  it('withdrawn:<accountId>:<subject> 형식으로 익명화한다', () => {
+  it('withdrawn:<accountId>:<sha256> 형식으로 익명화한다', () => {
     expect(buildWithdrawnProviderSubject(BigInt(7), 'kakao-sub-123')).toBe(
-      'withdrawn:7:kakao-sub-123',
+      `withdrawn:7:${sha256Hex('kakao-sub-123')}`,
     );
   });
 
-  it('계정이 다르면 같은 subject 라도 결과가 다르다', () => {
+  it('원본 subject를 그대로 남기지 않는다', () => {
+    const result = buildWithdrawnProviderSubject(BigInt(7), 'kakao-sub-123');
+
+    expect(result).not.toContain('kakao-sub-123');
+  });
+
+  it('계정이 다르면 같은 subject라도 결과가 다르다', () => {
     const first = buildWithdrawnProviderSubject(BigInt(1), 'same-sub');
     const second = buildWithdrawnProviderSubject(BigInt(2), 'same-sub');
 
     expect(first).not.toBe(second);
   });
 
-  it('VarChar(255) 한도를 넘지 않도록 자른다', () => {
+  it('subject가 길어도 VarChar(255) 한도 안에 들어간다', () => {
     const longSubject = 'a'.repeat(300);
 
     const result = buildWithdrawnProviderSubject(BigInt(1), longSubject);
 
-    expect(result).toHaveLength(255);
+    expect(result.length).toBeLessThanOrEqual(255);
     expect(result.startsWith('withdrawn:1:')).toBe(true);
   });
 });

--- a/src/common/utils/withdrawn-identity.ts
+++ b/src/common/utils/withdrawn-identity.ts
@@ -1,0 +1,29 @@
+// AccountIdentity.provider_subject 컬럼 한도 (prisma schema: VarChar(255)).
+const MAX_PROVIDER_SUBJECT_LENGTH = 255;
+
+/**
+ * 은퇴 처리된 provider_subject 임을 나타내는 prefix.
+ */
+const WITHDRAWN_PREFIX = 'withdrawn';
+
+/**
+ * 탈퇴한 계정의 소셜 연동 subject 를 익명화한 값을 만든다.
+ *
+ * 탈퇴 후 같은 소셜 계정으로 다시 로그인하면 **재가입**(새 account) 이 정책인데,
+ * `account_identity` 에는 `(provider, provider_subject)` UNIQUE 가 걸려 있어 soft-delete
+ * 만으로는 새 row 를 만들 수 없다(MySQL unique index 는 deleted_at 을 보지 않는다).
+ * 그래서 탈퇴 시 subject 자체를 치환해 UNIQUE 를 비워 준다.
+ *
+ * accountId 를 함께 넣는 이유는 두 개 이상의 탈퇴 계정이 같은 소셜 계정을 거쳐 갔을 때
+ * 은퇴한 row 끼리 다시 충돌하지 않게 하기 위함이다.
+ *
+ * @param accountId 탈퇴하는 계정 PK
+ * @param providerSubject 원본 provider subject
+ */
+export function buildWithdrawnProviderSubject(
+  accountId: bigint,
+  providerSubject: string,
+): string {
+  const prefixed = `${WITHDRAWN_PREFIX}:${accountId.toString()}:${providerSubject}`;
+  return prefixed.slice(0, MAX_PROVIDER_SUBJECT_LENGTH);
+}

--- a/src/common/utils/withdrawn-identity.ts
+++ b/src/common/utils/withdrawn-identity.ts
@@ -1,5 +1,4 @@
-// AccountIdentity.provider_subject 컬럼 한도 (prisma schema: VarChar(255)).
-const MAX_PROVIDER_SUBJECT_LENGTH = 255;
+import { sha256Hex } from '@/common/utils/crypto';
 
 /**
  * 은퇴 처리된 provider_subject 임을 나타내는 prefix.
@@ -14,8 +13,15 @@ const WITHDRAWN_PREFIX = 'withdrawn';
  * 만으로는 새 row 를 만들 수 없다(MySQL unique index 는 deleted_at 을 보지 않는다).
  * 그래서 탈퇴 시 subject 자체를 치환해 UNIQUE 를 비워 준다.
  *
+ * 원본 subject 는 provider 가 발급한 안정적인 외부 식별자라 그대로 남기면 탈퇴 계정이
+ * 살아있는 소셜 계정과 계속 연결된다. 탈퇴 시 email 을 비우고 nickname 을 치환하는
+ * 정책과 어긋나므로 SHA-256 다이제스트로 대체해 복원 불가능하게 만든다.
+ *
  * accountId 를 함께 넣는 이유는 두 개 이상의 탈퇴 계정이 같은 소셜 계정을 거쳐 갔을 때
  * 은퇴한 row 끼리 다시 충돌하지 않게 하기 위함이다.
+ * (`withdrawn:` + accountId + `:` + 64자 hex → VarChar(255) 한도 안에 항상 들어간다.)
+ *
+ * DB 마이그레이션의 기존 데이터 정리 SQL 도 같은 규칙(MySQL `SHA2(subject, 256)`)을 쓴다.
  *
  * @param accountId 탈퇴하는 계정 PK
  * @param providerSubject 원본 provider subject
@@ -24,6 +30,5 @@ export function buildWithdrawnProviderSubject(
   accountId: bigint,
   providerSubject: string,
 ): string {
-  const prefixed = `${WITHDRAWN_PREFIX}:${accountId.toString()}:${providerSubject}`;
-  return prefixed.slice(0, MAX_PROVIDER_SUBJECT_LENGTH);
+  return `${WITHDRAWN_PREFIX}:${accountId.toString()}:${sha256Hex(providerSubject)}`;
 }

--- a/src/features/auth/constants/auth-error-messages.ts
+++ b/src/features/auth/constants/auth-error-messages.ts
@@ -1,0 +1,13 @@
+/**
+ * 인증 도메인 에러 메시지.
+ */
+export const AUTH_ERROR_MESSAGES = {
+  /** OIDC 임시 쿠키(state/nonce/code_verifier)가 없거나 만료됨 */
+  OIDC_SESSION_MISSING: 'OIDC session is missing.',
+  /** ID 토큰에 sub claim 이 없음 */
+  OIDC_SUBJECT_MISSING: 'OIDC subject is missing.',
+  /** 계정 upsert 결과가 비어 있음 */
+  ACCOUNT_UPSERT_FAILED: 'Account upsert failed.',
+  /** 동시 콜백 등으로 같은 소셜 연동이 중복 생성됨 */
+  ACCOUNT_IDENTITY_CONFLICT: 'Account identity already exists.',
+} as const;

--- a/src/features/auth/repositories/account.repository.interface.ts
+++ b/src/features/auth/repositories/account.repository.interface.ts
@@ -50,11 +50,12 @@ export interface IAccountRepository {
   findAccountByEmail(email: string): Promise<AccountWithProfile | null>;
 
   /**
-   * Identity 가 없을 때 계정을 만들거나(또는 이메일로 기존 계정에 붙여서) Identity 를 upsert 한다.
+   * OIDC 로그인 결과로 계정/Identity 를 upsert 한다.
    *
    * 정책:
-   * - (provider, subject) 로 우선 식별
+   * - (provider, subject) 로만 식별한다. 이메일로 기존 계정에 붙이지 않는다(provider 간 계정 통합 없음)
    * - 없으면 신규 계정 생성
+   * - 연동된 계정이 탈퇴 상태면 복구하지 않고 재가입(새 계정)으로 처리한다
    */
   upsertUserByOidcIdentity(args: {
     provider: IdentityProvider;

--- a/src/features/auth/repositories/account.repository.spec.ts
+++ b/src/features/auth/repositories/account.repository.spec.ts
@@ -3,6 +3,7 @@ import type { PrismaClient } from '@prisma/client';
 import { IdentityProvider } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
+import { buildWithdrawnProviderSubject } from '@/common/utils/withdrawn-identity';
 import { AccountRepository } from '@/features/auth/repositories/account.repository';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
@@ -253,8 +254,9 @@ describe('AccountRepository (real DB)', () => {
       });
       expect(retired.deleted_at).toBeInstanceOf(Date);
       expect(retired.provider_subject).toBe(
-        `withdrawn:${withdrawn.id.toString()}:rejoin-sub`,
+        buildWithdrawnProviderSubject(withdrawn.id, 'rejoin-sub'),
       );
+      expect(retired.provider_subject).not.toContain('rejoin-sub');
 
       // 새 identity 가 원본 subject 를 넘겨받는다
       const active = await prisma.accountIdentity.findFirstOrThrow({

--- a/src/features/auth/repositories/account.repository.spec.ts
+++ b/src/features/auth/repositories/account.repository.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException } from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 import { IdentityProvider } from '@prisma/client';
 
@@ -62,6 +63,23 @@ describe('AccountRepository (real DB)', () => {
         IdentityProvider.GOOGLE,
         'nonexistent',
       );
+      expect(result).toBeNull();
+    });
+
+    it('계정이 탈퇴 상태면 Identity가 살아 있어도 제외한다', async () => {
+      // nested include 에는 soft-delete 필터가 주입되지 않아 직접 명시해야 한다
+      const account = await createAccount(prisma, { deleted_at: new Date() });
+      await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'GOOGLE',
+        provider_subject: 'withdrawn-account-sub',
+      });
+
+      const result = await repo.findIdentityByProviderSubject(
+        IdentityProvider.GOOGLE,
+        'withdrawn-account-sub',
+      );
+
       expect(result).toBeNull();
     });
   });
@@ -160,6 +178,121 @@ describe('AccountRepository (real DB)', () => {
       expect(result.account!.user_profile!.nickname).toBe(
         `user_${result.account!.id}`,
       );
+    });
+
+    it('기존 Identity + 미인증 이메일이면 account email을 백필하지 않는다', async () => {
+      // 카카오처럼 email_verified 를 주지 않는 provider 의 2회차 로그인 재현.
+      // 예전에는 이 경로만 emailVerified 를 보지 않고 백필해 unique 충돌 500 을 냈다.
+      const account = await createAccount(prisma, { email: null });
+      await createUserProfile(prisma, { account_id: account.id });
+      await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'KAKAO',
+        provider_subject: 'kakao-relogin',
+      });
+
+      const result = await repo.upsertUserByOidcIdentity({
+        provider: IdentityProvider.KAKAO,
+        providerSubject: 'kakao-relogin',
+        providerEmail: 'unverified@example.com',
+        emailVerified: false,
+      });
+
+      expect(result.account!.email).toBeNull();
+    });
+
+    it('provider가 다른 계정이 같은 이메일을 각각 가질 수 있다(계정 통합 없음)', async () => {
+      const google = await repo.upsertUserByOidcIdentity({
+        provider: IdentityProvider.GOOGLE,
+        providerSubject: 'google-shared',
+        providerEmail: 'shared@example.com',
+        emailVerified: true,
+      });
+
+      const kakao = await repo.upsertUserByOidcIdentity({
+        provider: IdentityProvider.KAKAO,
+        providerSubject: 'kakao-shared',
+        providerEmail: 'shared@example.com',
+        emailVerified: true,
+      });
+
+      expect(google.account!.id).not.toBe(kakao.account!.id);
+      expect(google.account!.email).toBe('shared@example.com');
+      expect(kakao.account!.email).toBe('shared@example.com');
+    });
+
+    it('탈퇴 계정의 Identity가 남아 있으면 복구하지 않고 재가입시킨다', async () => {
+      // 탈퇴 처리 이전 데이터(identity 가 살아있는 상태) 재현.
+      const withdrawn = await createAccount(prisma, {
+        email: null,
+        deleted_at: new Date(),
+      });
+      await createAccountIdentity(prisma, {
+        account_id: withdrawn.id,
+        provider: 'GOOGLE',
+        provider_subject: 'rejoin-sub',
+      });
+
+      const result = await repo.upsertUserByOidcIdentity({
+        provider: IdentityProvider.GOOGLE,
+        providerSubject: 'rejoin-sub',
+        providerEmail: 'rejoin@example.com',
+        emailVerified: true,
+      });
+
+      // 새 계정으로 가입된다
+      expect(result.account).not.toBeNull();
+      expect(result.account!.id).not.toBe(withdrawn.id);
+      expect(result.account!.deleted_at).toBeNull();
+      expect(result.account!.user_profile).not.toBeNull();
+
+      // 옛 identity 는 익명화 + soft-delete 되어 자리를 비운다
+      // (deleted_at 을 명시해야 soft-delete extension 의 자동 필터를 우회한다)
+      const retired = await prisma.accountIdentity.findFirstOrThrow({
+        where: { account_id: withdrawn.id, deleted_at: { not: null } },
+      });
+      expect(retired.deleted_at).toBeInstanceOf(Date);
+      expect(retired.provider_subject).toBe(
+        `withdrawn:${withdrawn.id.toString()}:rejoin-sub`,
+      );
+
+      // 새 identity 가 원본 subject 를 넘겨받는다
+      const active = await prisma.accountIdentity.findFirstOrThrow({
+        where: { account_id: result.account!.id },
+      });
+      expect(active.provider_subject).toBe('rejoin-sub');
+      expect(active.deleted_at).toBeNull();
+
+      // 탈퇴 계정의 email 은 되채워지지 않는다
+      const stillWithdrawn = await prisma.account.findUniqueOrThrow({
+        where: { id: withdrawn.id },
+      });
+      expect(stillWithdrawn.email).toBeNull();
+    });
+
+    it('subject 익명화 없이 soft-delete된 Identity가 남아 있으면 ConflictException', async () => {
+      // MySQL unique index 는 deleted_at 을 보지 않는다. 익명화 없이 soft-delete 만 된
+      // 잔여 row 가 있으면 신규 생성이 UNIQUE 에 걸리는데, Prisma 원문 에러(파일 경로·
+      // 소스 라인 포함)가 500 본문으로 새어나가지 않도록 도메인 예외로 좁힌다.
+      const account = await createAccount(prisma);
+      const identity = await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'GOOGLE',
+        provider_subject: 'orphan-sub',
+      });
+      await prisma.accountIdentity.update({
+        where: { id: identity.id },
+        data: { deleted_at: new Date() },
+      });
+
+      await expect(
+        repo.upsertUserByOidcIdentity({
+          provider: IdentityProvider.GOOGLE,
+          providerSubject: 'orphan-sub',
+          providerEmail: 'orphan@example.com',
+          emailVerified: true,
+        }),
+      ).rejects.toThrow(ConflictException);
     });
 
     it('기존 Identity + account email이 null + user_profile 없는 경우: profile 신규 생성 + email 주입', async () => {

--- a/src/features/auth/repositories/account.repository.ts
+++ b/src/features/auth/repositories/account.repository.ts
@@ -1,7 +1,9 @@
-import { Injectable } from '@nestjs/common';
-import { AccountType, type IdentityProvider } from '@prisma/client';
+import { ConflictException, Injectable } from '@nestjs/common';
+import { AccountType, Prisma, type IdentityProvider } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
+import { buildWithdrawnProviderSubject } from '@/common/utils/withdrawn-identity';
+import { AUTH_ERROR_MESSAGES } from '@/features/auth/constants/auth-error-messages';
 import { buildInitialNickname } from '@/features/auth/helpers/initial-nickname.helper';
 import type {
   AccountForJwt,
@@ -33,6 +35,9 @@ export class AccountRepository implements IAccountRepository {
       where: {
         provider,
         provider_subject: providerSubject,
+        // soft-delete extension 은 top-level where 에만 deleted_at 을 주입한다.
+        // 상위 엔티티(account)까지 활성인지는 직접 명시해야 탈퇴 계정이 새어나오지 않는다.
+        account: { deleted_at: null },
       },
       include: {
         account: {
@@ -59,26 +64,72 @@ export class AccountRepository implements IAccountRepository {
     providerDisplayName?: string;
     providerProfileImageUrl?: string;
   }): Promise<{ account: AccountWithProfile | null }> {
-    return this.prisma.$transaction(async (tx) => {
-      const found = await tx.accountIdentity.findFirst({
-        where: {
-          provider: args.provider,
-          provider_subject: args.providerSubject,
-        },
-        include: {
-          account: {
-            include: { user_profile: true },
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const found = await tx.accountIdentity.findFirst({
+          where: {
+            provider: args.provider,
+            provider_subject: args.providerSubject,
           },
-        },
+          include: {
+            account: {
+              include: { user_profile: true },
+            },
+          },
+        });
+
+        const now = this.clock.now();
+
+        // 탈퇴한 계정의 연동이 남아 있는 경우: 정책은 복구가 아니라 재가입이다.
+        // (nested include 라 soft-delete extension 이 account 를 걸러주지 않으므로 직접 확인한다.
+        //  이 확인이 없으면 삭제된 계정을 그대로 집어들어 마지막 조회에서만 null 이 되어
+        //  "Account upsert failed" 401 로 끝나던 경로다.)
+        if (found?.account.deleted_at) {
+          await this.retireWithdrawnIdentity(tx, found, now);
+          return this.createNewIdentity(tx, args, now);
+        }
+
+        if (found) {
+          return this.updateExistingIdentity(tx, found, args, now);
+        }
+
+        return this.createNewIdentity(tx, args, now);
       });
-
-      const now = this.clock.now();
-
-      if (found) {
-        return this.updateExistingIdentity(tx, found, args, now);
+    } catch (error) {
+      // Prisma 원문 에러에는 파일 경로·소스 라인이 담겨 있어 그대로 500 본문으로 새어나간다.
+      // 도메인 예외로 좁혀서 내보낸다.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new ConflictException(
+          AUTH_ERROR_MESSAGES.ACCOUNT_IDENTITY_CONFLICT,
+        );
       }
+      throw error;
+    }
+  }
 
-      return this.createNewIdentity(tx, args, now);
+  /**
+   * 탈퇴 계정에 남아 있던 연동을 은퇴 처리한다(재가입 경로 확보).
+   *
+   * 탈퇴 시점에 처리되는 게 정상이지만, 그 처리가 없던 시절의 데이터가 남아 있을 수 있어
+   * 로그인 경로에서도 같은 규칙으로 정리한다.
+   */
+  private async retireWithdrawnIdentity(
+    tx: Parameters<Parameters<typeof this.prisma.$transaction>[0]>[0],
+    found: { id: bigint; account_id: bigint; provider_subject: string },
+    now: Date,
+  ): Promise<void> {
+    await tx.accountIdentity.update({
+      where: { id: found.id },
+      data: {
+        provider_subject: buildWithdrawnProviderSubject(
+          found.account_id,
+          found.provider_subject,
+        ),
+        deleted_at: now,
+      },
     });
   }
 
@@ -99,6 +150,7 @@ export class AccountRepository implements IAccountRepository {
     },
     args: {
       providerEmail?: string;
+      emailVerified: boolean;
       providerDisplayName?: string;
       providerProfileImageUrl?: string;
     },
@@ -115,11 +167,15 @@ export class AccountRepository implements IAccountRepository {
       },
     });
 
-    // account email/name 은 null 일 때만 채움(변경 불가 정책)
+    // account email/name 은 null 일 때만 채움(변경 불가 정책).
+    // email 은 신규 가입 경로와 같은 기준(verified 인 값만)을 적용한다 — 예전에는 이 백필만
+    // emailVerified 를 보지 않아, 미인증 이메일이 뒤늦게 주입되고 전역 unique 와 충돌했다.
     await tx.account.update({
       where: { id: found.account_id },
       data: {
-        email: found.account.email ?? args.providerEmail ?? null,
+        email:
+          found.account.email ??
+          this.resolveVerifiedEmail(args.providerEmail, args.emailVerified),
         name: found.account.name ?? args.providerDisplayName ?? null,
       },
     });
@@ -199,7 +255,7 @@ export class AccountRepository implements IAccountRepository {
       data: {
         account_type: AccountType.USER,
         status: 'ACTIVE',
-        email: email && emailVerified ? email : null,
+        email: this.resolveVerifiedEmail(email, emailVerified),
         name: displayName ?? null,
       },
     });
@@ -213,6 +269,19 @@ export class AccountRepository implements IAccountRepository {
     );
 
     return createdAccount.id;
+  }
+
+  /**
+   * account.email 에 저장할 값을 정한다.
+   *
+   * 미인증 이메일은 저장하지 않는다 — 계정 통합은 하지 않지만, account.email 은 사용자에게
+   * 노출되는 값이라 provider 가 검증한 값만 싣는다.
+   */
+  private resolveVerifiedEmail(
+    email?: string,
+    emailVerified?: boolean,
+  ): string | null {
+    return email && emailVerified ? email : null;
   }
 
   /**

--- a/src/features/auth/services/oidc-login.service.spec.ts
+++ b/src/features/auth/services/oidc-login.service.spec.ts
@@ -258,6 +258,91 @@ describe('OidcLoginService', () => {
       expect(mockRes.clearCookie).toHaveBeenCalledTimes(4);
     });
 
+    it('카카오는 email_verified 클레임이 없어도 인증된 이메일로 취급한다', async () => {
+      const mockReq = {
+        cookies: {
+          caquick_oidc_state: 'state',
+          caquick_oidc_nonce: 'nonce',
+          caquick_oidc_cv: 'verifier',
+          caquick_oidc_return_to: 'http://localhost:3000',
+        },
+        query: { code: 'code', state: 'state' },
+        headers: {},
+      } as unknown as Request;
+
+      const mockRes = {
+        cookie: jest.fn(),
+        clearCookie: jest.fn(),
+      } as unknown as Response;
+
+      mockConfig.get.mockReturnValue('http://localhost:4000');
+
+      // 카카오 ID 토큰 실제 형태: email 은 있지만 email_verified 가 없다
+      mockOidc.exchangeCode.mockResolvedValue({
+        claims: () => ({
+          sub: 'kakao-user-123',
+          email: 'kakao@example.com',
+          nickname: 'Kakao User',
+        }),
+      } as never);
+      mockOidc.toIdentityProvider.mockReturnValue('KAKAO');
+      mockAccounts.upsertUserByOidcIdentity.mockResolvedValue({
+        account: { id: BigInt(1) } as never,
+      });
+      mockRefreshSessions.createRefreshSession.mockResolvedValue({} as never);
+
+      await service.handleOidcCallback('kakao', mockReq, mockRes);
+
+      expect(mockAccounts.upsertUserByOidcIdentity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'KAKAO',
+          providerEmail: 'kakao@example.com',
+          emailVerified: true,
+        }),
+      );
+    });
+
+    it('구글은 email_verified 클레임이 없으면 미인증으로 본다', async () => {
+      const mockReq = {
+        cookies: {
+          caquick_oidc_state: 'state',
+          caquick_oidc_nonce: 'nonce',
+          caquick_oidc_cv: 'verifier',
+          caquick_oidc_return_to: 'http://localhost:3000',
+        },
+        query: { code: 'code', state: 'state' },
+        headers: {},
+      } as unknown as Request;
+
+      const mockRes = {
+        cookie: jest.fn(),
+        clearCookie: jest.fn(),
+      } as unknown as Response;
+
+      mockConfig.get.mockReturnValue('http://localhost:4000');
+
+      mockOidc.exchangeCode.mockResolvedValue({
+        claims: () => ({
+          sub: 'google-user-456',
+          email: 'nonverified@example.com',
+        }),
+      } as never);
+      mockOidc.toIdentityProvider.mockReturnValue('GOOGLE');
+      mockAccounts.upsertUserByOidcIdentity.mockResolvedValue({
+        account: { id: BigInt(1) } as never,
+      });
+      mockRefreshSessions.createRefreshSession.mockResolvedValue({} as never);
+
+      await service.handleOidcCallback('google', mockReq, mockRes);
+
+      expect(mockAccounts.upsertUserByOidcIdentity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'GOOGLE',
+          emailVerified: false,
+        }),
+      );
+    });
+
     it('OIDC 세션 쿠키가 없으면 UnauthorizedException을 던져야 한다', async () => {
       const mockReq = { cookies: {} } as unknown as Request;
       const mockRes = {} as Response;

--- a/src/features/auth/services/oidc-login.service.ts
+++ b/src/features/auth/services/oidc-login.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { Request, Response } from 'express';
 
+import { AUTH_ERROR_MESSAGES } from '@/features/auth/constants/auth-error-messages';
 import { ALLOWED_RETURN_TO_DOMAINS } from '@/features/auth/constants/auth.constants';
 import { AuthCookieOptions } from '@/features/auth/helpers/auth-cookie-options.helper';
 import { AuthCookie } from '@/features/auth/helpers/auth-cookie.helper';
@@ -85,7 +86,10 @@ export class OidcLoginService implements IOidcLoginService {
       codeVerifier,
     );
 
-    const userInfo = this.extractUserInfoFromClaims(tokenSet.claims());
+    const userInfo = this.extractUserInfoFromClaims(
+      provider,
+      tokenSet.claims(),
+    );
 
     const account = await this.upsertAccountFromOidc(provider, userInfo);
 
@@ -128,7 +132,7 @@ export class OidcLoginService implements IOidcLoginService {
       this.normalizeReturnTo(undefined);
 
     if (!expectedState || !expectedNonce || !codeVerifier) {
-      throw new UnauthorizedException('OIDC session is missing.');
+      throw new UnauthorizedException(AUTH_ERROR_MESSAGES.OIDC_SESSION_MISSING);
     }
 
     return { expectedState, expectedNonce, codeVerifier, returnTo };
@@ -159,7 +163,10 @@ export class OidcLoginService implements IOidcLoginService {
   /**
    * OIDC claims 에서 사용자 정보를 추출한다.
    */
-  private extractUserInfoFromClaims(claims: Record<string, unknown>): {
+  private extractUserInfoFromClaims(
+    provider: OidcProvider,
+    claims: Record<string, unknown>,
+  ): {
     subject: string;
     email?: string;
     emailVerified: boolean;
@@ -167,10 +174,17 @@ export class OidcLoginService implements IOidcLoginService {
     picture?: string;
   } {
     const subject = typeof claims.sub === 'string' ? claims.sub : null;
-    if (!subject) throw new UnauthorizedException('OIDC subject is missing.');
+    if (!subject) {
+      throw new UnauthorizedException(AUTH_ERROR_MESSAGES.OIDC_SUBJECT_MISSING);
+    }
 
     const email = typeof claims.email === 'string' ? claims.email : undefined;
-    const emailVerified = claims.email_verified === true;
+    // 카카오 ID 토큰에는 email_verified 클레임이 아예 없다. 표준대로 검사하면 카카오 계정의
+    // account.email 이 영구히 null 로 남는다. `account_email` 동의항목으로 내려오는 값은
+    // 카카오가 보유·관리하는 계정 이메일이므로 인증된 것으로 취급한다.
+    const emailVerified =
+      claims.email_verified === true ||
+      (provider === 'kakao' && email !== undefined);
 
     const displayName =
       (typeof claims.name === 'string' ? claims.name : undefined) ??
@@ -206,7 +220,11 @@ export class OidcLoginService implements IOidcLoginService {
       providerProfileImageUrl: userInfo.picture,
     });
 
-    if (!account) throw new UnauthorizedException('Account upsert failed.');
+    if (!account) {
+      throw new UnauthorizedException(
+        AUTH_ERROR_MESSAGES.ACCOUNT_UPSERT_FAILED,
+      );
+    }
 
     return account;
   }

--- a/src/features/user/repositories/user.repository.spec.ts
+++ b/src/features/user/repositories/user.repository.spec.ts
@@ -3,7 +3,11 @@ import type { PrismaClient } from '@prisma/client';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
-import { createAccount, createUserProfile } from '@/test/factories';
+import {
+  createAccount,
+  createAccountIdentity,
+  createUserProfile,
+} from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
 /**
@@ -70,6 +74,66 @@ describe('UserRepository (real DB)', () => {
       expect(result).not.toBeNull();
       expect(result?.id).toBe(account.id);
       expect(result?.deleted_at).not.toBeNull();
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // softDeleteAccount - 소셜 연동 은퇴 처리
+  //
+  // 탈퇴 후 같은 소셜 계정으로 재가입할 수 있어야 하는데, account_identity 의
+  // (provider, provider_subject) UNIQUE 는 soft-delete 를 보지 않는다.
+  // subject 익명화까지 함께 일어나는지를 여기서 못박는다.
+  // ─────────────────────────────────────────────
+  describe('softDeleteAccount - account_identity 은퇴', () => {
+    it('연동된 identity를 soft-delete하고 provider_subject를 익명화한다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+      await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'KAKAO',
+        provider_subject: 'kakao-withdraw',
+      });
+      const now = new Date();
+
+      await repo.softDeleteAccount({
+        accountId: account.id,
+        deletedNickname: `deleted_${account.id.toString()}`,
+        now,
+      });
+
+      // deleted_at 을 명시해야 soft-delete extension 의 자동 필터를 우회한다
+      const identity = await prisma.accountIdentity.findFirstOrThrow({
+        where: { account_id: account.id, deleted_at: { not: null } },
+      });
+      expect(identity.deleted_at).toBeInstanceOf(Date);
+      expect(identity.provider_subject).toBe(
+        `withdrawn:${account.id.toString()}:kakao-withdraw`,
+      );
+    });
+
+    it('은퇴 처리 후 같은 provider+subject로 새 identity를 만들 수 있다', async () => {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await createUserProfile(prisma, { account_id: account.id });
+      await createAccountIdentity(prisma, {
+        account_id: account.id,
+        provider: 'GOOGLE',
+        provider_subject: 'google-reuse',
+      });
+
+      await repo.softDeleteAccount({
+        accountId: account.id,
+        deletedNickname: `deleted_${account.id.toString()}`,
+        now: new Date(),
+      });
+
+      const rejoined = await createAccount(prisma, { account_type: 'USER' });
+      await expect(
+        createAccountIdentity(prisma, {
+          account_id: rejoined.id,
+          provider: 'GOOGLE',
+          provider_subject: 'google-reuse',
+        }),
+      ).resolves.toBeDefined();
     });
   });
 });

--- a/src/features/user/repositories/user.repository.spec.ts
+++ b/src/features/user/repositories/user.repository.spec.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '@prisma/client';
 
+import { buildWithdrawnProviderSubject } from '@/common/utils/withdrawn-identity';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
@@ -107,8 +108,9 @@ describe('UserRepository (real DB)', () => {
       });
       expect(identity.deleted_at).toBeInstanceOf(Date);
       expect(identity.provider_subject).toBe(
-        `withdrawn:${account.id.toString()}:kakao-withdraw`,
+        buildWithdrawnProviderSubject(account.id, 'kakao-withdraw'),
       );
+      expect(identity.provider_subject).not.toContain('kakao-withdraw');
     });
 
     it('은퇴 처리 후 같은 provider+subject로 새 identity를 만들 수 있다', async () => {

--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -8,6 +8,7 @@ import {
   Prisma,
 } from '@prisma/client';
 
+import { buildWithdrawnProviderSubject } from '@/common/utils/withdrawn-identity';
 import { PrismaService } from '@/prisma';
 
 export interface UserAccountIdentity {
@@ -198,6 +199,8 @@ export class UserRepository {
         },
       });
 
+      await this.retireAccountIdentities(tx, args.accountId, args.now);
+
       await tx.authRefreshSession.updateMany({
         where: {
           account_id: args.accountId,
@@ -210,6 +213,40 @@ export class UserRepository {
         },
       });
     });
+  }
+
+  /**
+   * 탈퇴 계정에 연결된 소셜 연동을 은퇴 처리한다.
+   *
+   * soft-delete 만 하면 `(provider, provider_subject)` UNIQUE 가 그대로 남아
+   * 같은 소셜 계정으로 재가입할 때 identity 를 새로 만들 수 없다(MySQL unique index 는
+   * deleted_at 을 보지 않는다). subject 를 익명화해 자리를 비워 준다.
+   *
+   * updateMany 로는 컬럼 값을 기존 값 기반으로 바꿀 수 없어 row 단위로 처리한다.
+   * 한 계정의 연동 수는 provider 수준(한 자릿수)이라 비용 문제는 없다.
+   */
+  private async retireAccountIdentities(
+    tx: Prisma.TransactionClient,
+    accountId: bigint,
+    now: Date,
+  ): Promise<void> {
+    const identities = await tx.accountIdentity.findMany({
+      where: { account_id: accountId, deleted_at: null },
+      select: { id: true, provider_subject: true },
+    });
+
+    for (const identity of identities) {
+      await tx.accountIdentity.update({
+        where: { id: identity.id },
+        data: {
+          provider_subject: buildWithdrawnProviderSubject(
+            accountId,
+            identity.provider_subject,
+          ),
+          deleted_at: now,
+        },
+      });
+    }
   }
 
   async getViewerCounts(accountId: bigint): Promise<{

--- a/src/test/factories/account.factory.ts
+++ b/src/test/factories/account.factory.ts
@@ -12,6 +12,7 @@ export interface AccountOverrides {
   status?: AccountStatus;
   email?: string | null;
   name?: string | null;
+  deleted_at?: Date | null;
 }
 
 export async function createAccount(
@@ -28,6 +29,7 @@ export async function createAccount(
           ? `user${seq}@example.com`
           : overrides.email,
       name: overrides.name === undefined ? `User ${seq}` : overrides.name,
+      deleted_at: overrides.deleted_at ?? null,
     },
   });
 }


### PR DESCRIPTION
## 릴리즈 내용

프론트에서 보고된 소셜 로그인 두 에러 수정 (#175).

- **카카오 500** — `account_email_key` unique 위반
- **구글 401** — `Account upsert failed.`

## 원인

`account.email` 이 전역 UNIQUE 인데 계정 식별은 `(provider, provider_subject)` 로만 한다. provider 별로 별도 account 가 생기므로 같은 사람이 구글/카카오를 모두 쓰면 이메일이 충돌한다. 여기에 두 갈래가 겹쳤다.

1. `updateExistingIdentity` 의 email 백필이 `emailVerified` 검사 없이 실행된다. 카카오는 ID 토큰에 `email_verified` 가 없어 최초 가입 시 항상 `email = null` 이므로 **2회차 로그인부터 반드시 이 백필을 탄다** → 500
2. 탈퇴가 `account_identity` 를 살려둬서, 재로그인 시 identity 는 매칭되는데(nested include 라 soft-delete 필터가 안 걸림) 마지막 `account.findFirst` 는 필터에 걸려 null → 401. 이 트랜잭션이 커밋되며 탈퇴 시 비워둔 email 을 되채워 1의 트리거가 됐다

## 정책 결정

| 항목 | 결정 |
| --- | --- |
| 탈퇴 후 재로그인 | 재가입 — 새 account/identity, 복구 없음 |
| 이메일 통합 | 안 함 |
| `account.email` 전역 UNIQUE | 제거 |
| 카카오 이메일 | 인증된 것으로 신뢰 |
| 재가입 시 identity UNIQUE | 탈퇴 시 `provider_subject` 를 SHA-256 다이제스트로 치환 + soft-delete |

## 마이그레이션 주의

`20260813183650_relax_account_email_unique_and_retire_withdrawn_identity` 는 스키마 변경 외에 **기존 데이터 정리**를 포함한다.

- 탈퇴 계정이 되찾아간 `email` 을 NULL 로 회수
- 탈퇴 계정에 매달린 살아있는 `account_identity` 를 은퇴 처리(`SHA2(provider_subject, 256)` + soft-delete)

## 검증

`yarn validate` 통과 — 174 suites / 1487 tests. 회귀 테스트 12건 추가.
Codex 리뷰 👍 (P2 1건 반영: 탈퇴 subject 를 다이제스트로 대체).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 탈퇴한 계정의 소셜 로그인 정보를 안전하게 익명화하고, 동일한 소셜 계정으로 새로 가입할 수 있습니다.
  * 이메일이 인증된 경우에만 계정 이메일을 저장하며, 제공자별 이메일 인증 정책을 적용합니다.
  * 서로 다른 로그인 제공자가 같은 이메일을 사용하는 경우에도 가입할 수 있습니다.

* **버그 수정**
  * 탈퇴 계정이 로그인 계정으로 잘못 복구되던 문제를 수정했습니다.
  * 인증 및 계정 충돌 상황에서 일관된 오류 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->