### PR TITLE
feat(product): 전역 카테고리 목록 조회(categories)와 카테고리 마스터 시드

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,6 +11,7 @@
  */
 import { PrismaClient } from '@prisma/client';
 
+import { seedCategories } from './seed/categories';
 import { seedCustomDrafts } from './seed/custom-drafts';
 import { resetSeedScope } from './seed/idempotent';
 import { seedNotifications } from './seed/notifications';
@@ -39,8 +40,11 @@ async function main(): Promise<void> {
     log('지역 마스터 시드 중...');
     await seedRegions(prisma);
 
+    log('카테고리 마스터 시드 중...');
+    const categories = await seedCategories(prisma);
+
     log('매장 + 상품 시드 중...');
-    const stores = await seedStores(prisma);
+    const stores = await seedStores(prisma, { categories });
 
     log('주문 + 아이템 시드 중...');
     const orders = await seedOrders(prisma, { users, stores });

--- a/prisma/seed/categories.ts
+++ b/prisma/seed/categories.ts
@@ -1,0 +1,79 @@
+/**
+ * 카테고리(Category) 마스터 시드.
+ *
+ * figma Category_Entry 스펙(spec/*.md) 목록을 정본으로 한다.
+ * - 이벤트별 16종 + 스타일별 7종. sort_order는 스펙 나열 순.
+ * - '전체' 칩은 카테고리가 아니라 FE 가상 칩(필터 미적용)이라 시드하지 않는다.
+ * - 카테고리는 영구 마스터이므로 resetSeedScope 정리 대상이 아니다(region과 동일).
+ *   uk(category_type, name) 기준 upsert로 항상 최신 상태로 보정한다.
+ */
+import type { CategoryType, PrismaClient } from '@prisma/client';
+
+const EVENT_CATEGORY_NAMES = [
+  '생일',
+  '돌잔치',
+  '크리스마스',
+  '연인',
+  '우정',
+  '스승의날',
+  '합격/승진',
+  '웨딩',
+  '부모님',
+  '반려동물',
+  '신년',
+  '감사',
+  '개업/오픈',
+  '졸업',
+  '위로/응원',
+  '기타',
+] as const;
+
+const STYLE_CATEGORY_NAMES = [
+  '꽃장식',
+  '돈장식',
+  '입체',
+  '티아라',
+  '포토',
+  '도시락',
+  '그림일기',
+] as const;
+
+export interface SeededCategories {
+  /** `${category_type}:${name}` → id */
+  idByTypeName: Map<string, bigint>;
+}
+
+export async function seedCategories(
+  prisma: PrismaClient,
+): Promise<SeededCategories> {
+  const idByTypeName = new Map<string, bigint>();
+
+  const upsertAll = async (
+    type: CategoryType,
+    names: readonly string[],
+  ): Promise<void> => {
+    for (const [index, name] of names.entries()) {
+      const category = await prisma.category.upsert({
+        where: {
+          category_type_name: { category_type: type, name },
+        },
+        create: {
+          category_type: type,
+          name,
+          sort_order: index,
+        },
+        update: {
+          sort_order: index,
+          is_active: true,
+          deleted_at: null,
+        },
+      });
+      idByTypeName.set(`${type}:${name}`, category.id);
+    }
+  };
+
+  await upsertAll('EVENT', EVENT_CATEGORY_NAMES);
+  await upsertAll('STYLE', STYLE_CATEGORY_NAMES);
+
+  return { idByTypeName };
+}

--- a/prisma/seed/stores.ts
+++ b/prisma/seed/stores.ts
@@ -10,6 +10,7 @@
  */
 import type { PrismaClient, Product, Store } from '@prisma/client';
 
+import type { SeededCategories } from './categories';
 import { SEED_STORE_NAME_PREFIX } from './idempotent';
 
 export interface SeededStores {
@@ -18,7 +19,10 @@ export interface SeededStores {
   optionGroupIds: { p2GroupId: bigint; p2OptionItemId: bigint };
 }
 
-export async function seedStores(prisma: PrismaClient): Promise<SeededStores> {
+export async function seedStores(
+  prisma: PrismaClient,
+  deps: { categories: SeededCategories },
+): Promise<SeededStores> {
   // 매장 region 매핑 (seedRegions 선행 실행 전제). Unchecked 경로라 FK를 직접 지정.
   const gangnam = await prisma.region.findUniqueOrThrow({
     where: { slug: 'sgg-11680' },
@@ -202,6 +206,29 @@ export async function seedStores(prisma: PrismaClient): Promise<SeededStores> {
       regular_price: 10000,
       is_active: false,
     },
+  });
+
+  // 상품 ↔ 카테고리 연결 (홈 화면 섹션들이 로컬에서 동작하도록 이벤트/스타일 배정)
+  const categoryId = (key: string): bigint => {
+    const id = deps.categories.idByTypeName.get(key);
+    if (id === undefined) {
+      throw new Error(`[seed] category not found: ${key}`);
+    }
+    return id;
+  };
+  await prisma.productCategory.createMany({
+    data: [
+      { product_id: p1.id, category_id: categoryId('EVENT:생일') },
+      { product_id: p1.id, category_id: categoryId('STYLE:꽃장식') },
+      { product_id: p2.id, category_id: categoryId('EVENT:생일') },
+      { product_id: p2.id, category_id: categoryId('STYLE:입체') },
+      { product_id: p3.id, category_id: categoryId('EVENT:감사') },
+      { product_id: p3.id, category_id: categoryId('STYLE:도시락') },
+      { product_id: p4.id, category_id: categoryId('EVENT:기타') },
+      // p5(비활성)에도 연결해 활성 필터 검증 데이터로 쓴다
+      { product_id: p5.id, category_id: categoryId('EVENT:생일') },
+    ],
+    skipDuplicates: true,
   });
 
   return {

--- a/src/features/product/dto/inputs/categories.input.ts
+++ b/src/features/product/dto/inputs/categories.input.ts
@@ -1,0 +1,7 @@
+import { IsIn, IsOptional } from 'class-validator';
+
+export class CategoriesInput {
+  @IsOptional()
+  @IsIn(['EVENT', 'STYLE', 'OTHER'])
+  type?: 'EVENT' | 'STYLE' | 'OTHER';
+}

--- a/src/features/product/product-category.graphql
+++ b/src/features/product/product-category.graphql
@@ -1,0 +1,17 @@
+extend type Query {
+  """전역 카테고리 목록(홈 칩·카테고리 진입 화면). type 미지정 시 전체. 비로그인 접근 가능."""
+  categories(input: CategoriesInput): [CategoryItem!]!
+}
+
+input CategoriesInput {
+  """EVENT | STYLE | OTHER. 비우면 전체."""
+  type: CategoryType
+}
+
+"""전역 카테고리 항목. '전체' 칩은 카테고리가 아니라 FE 가상 칩(필터 미적용)이라 포함하지 않는다."""
+type CategoryItem {
+  id: ID!
+  name: String!
+  categoryType: CategoryType!
+  sortOrder: Int!
+}

--- a/src/features/product/product.module.ts
+++ b/src/features/product/product.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 
 import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductCategoryQueryResolver } from '@/features/product/resolvers/product-category-query.resolver';
 import { ProductDetailQueryResolver } from '@/features/product/resolvers/product-detail-query.resolver';
 import { ProductReviewQueryResolver } from '@/features/product/resolvers/product-review-query.resolver';
 import { ProductStorefrontQueryResolver } from '@/features/product/resolvers/product-storefront-query.resolver';
+import { ProductCategoryService } from '@/features/product/services/product-category.service';
 import { ProductDetailService } from '@/features/product/services/product-detail.service';
 import { ProductReviewService } from '@/features/product/services/product-review.service';
 import { ProductStorefrontService } from '@/features/product/services/product-storefront.service';
@@ -19,6 +21,8 @@ import { ProductStorefrontService } from '@/features/product/services/product-st
     ProductReviewQueryResolver,
     ProductStorefrontService,
     ProductStorefrontQueryResolver,
+    ProductCategoryService,
+    ProductCategoryQueryResolver,
   ],
   exports: [ProductRepository],
 })

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -928,6 +928,27 @@ export class ProductRepository {
   }
 
   /**
+   * 전역 카테고리 목록(홈 칩·카테고리 진입 화면). 활성만.
+   * category_type asc → sort_order asc → id asc.
+   */
+  async listCategories(type?: CategoryType) {
+    return this.prisma.category.findMany({
+      where: {
+        is_active: true,
+        deleted_at: null,
+        ...(type !== undefined ? { category_type: type } : {}),
+      },
+      select: {
+        id: true,
+        name: true,
+        category_type: true,
+        sort_order: true,
+      },
+      orderBy: [{ category_type: 'asc' }, { sort_order: 'asc' }, { id: 'asc' }],
+    });
+  }
+
+  /**
    * 매장이 보유한 활성 상품의 카테고리(사이드바). 빈 카테고리 제외.
    * sort_order asc, productCount는 이 매장의 활성 상품 기준.
    */

--- a/src/features/product/resolvers/product-category-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-category-query.resolver.spec.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductCategoryQueryResolver } from '@/features/product/resolvers/product-category-query.resolver';
+import { ProductCategoryService } from '@/features/product/services/product-category.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createCategory } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 통합 경로 검증.
+ * 필터/정렬 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('ProductCategory Query Resolver (real DB)', () => {
+  let resolver: ProductCategoryQueryResolver;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        ProductCategoryQueryResolver,
+        ProductCategoryService,
+        ProductRepository,
+      ],
+    });
+    resolver = module.get(ProductCategoryQueryResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('categories: 서비스에 위임해 카테고리 목록을 반환한다', async () => {
+    await createCategory(prisma, { category_type: 'EVENT', name: '생일' });
+
+    const result = await resolver.categories({ type: 'EVENT' });
+
+    expect(result.map((c) => c.name)).toEqual(['생일']);
+  });
+});

--- a/src/features/product/resolvers/product-category-query.resolver.ts
+++ b/src/features/product/resolvers/product-category-query.resolver.ts
@@ -1,0 +1,18 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { CategoriesInput } from '@/features/product/dto/inputs/categories.input';
+import { ProductCategoryService } from '@/features/product/services/product-category.service';
+import type { CategoryItem } from '@/features/product/types/product-category-output.type';
+
+/**
+ * 전역 카테고리 조회 resolver. 개인화 필드가 없는 public query(인증 불필요).
+ */
+@Resolver('Query')
+export class ProductCategoryQueryResolver {
+  constructor(private readonly service: ProductCategoryService) {}
+
+  @Query('categories')
+  categories(@Args('input') input?: CategoriesInput): Promise<CategoryItem[]> {
+    return this.service.categories(input);
+  }
+}

--- a/src/features/product/services/product-category.service.spec.ts
+++ b/src/features/product/services/product-category.service.spec.ts
@@ -1,0 +1,106 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductCategoryService } from '@/features/product/services/product-category.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createCategory } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('ProductCategoryService (real DB)', () => {
+  let service: ProductCategoryService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ProductCategoryService, ProductRepository],
+    });
+    service = module.get(ProductCategoryService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  describe('categories', () => {
+    it('type 미지정 시 전체 카테고리를 type→sort_order 순으로 반환한다', async () => {
+      await createCategory(prisma, {
+        category_type: 'STYLE',
+        name: '꽃장식',
+        sort_order: 0,
+      });
+      await createCategory(prisma, {
+        category_type: 'EVENT',
+        name: '크리스마스',
+        sort_order: 1,
+      });
+      await createCategory(prisma, {
+        category_type: 'EVENT',
+        name: '생일',
+        sort_order: 0,
+      });
+
+      const result = await service.categories();
+
+      expect(result.map((c) => c.name)).toEqual([
+        '생일',
+        '크리스마스',
+        '꽃장식',
+      ]);
+      expect(result.map((c) => c.categoryType)).toEqual([
+        'EVENT',
+        'EVENT',
+        'STYLE',
+      ]);
+    });
+
+    it('type 지정 시 해당 타입만 반환한다', async () => {
+      await createCategory(prisma, { category_type: 'EVENT', name: '생일' });
+      await createCategory(prisma, { category_type: 'STYLE', name: '입체' });
+
+      const result = await service.categories({ type: 'STYLE' });
+
+      expect(result.map((c) => c.name)).toEqual(['입체']);
+    });
+
+    it('비활성/soft-delete 카테고리는 제외한다', async () => {
+      await createCategory(prisma, { name: '활성', sort_order: 0 });
+      await createCategory(prisma, {
+        name: '비활성',
+        sort_order: 1,
+        is_active: false,
+      });
+      await createCategory(prisma, {
+        name: '삭제됨',
+        sort_order: 2,
+        deleted_at: new Date(),
+      });
+
+      const result = await service.categories();
+
+      expect(result.map((c) => c.name)).toEqual(['활성']);
+    });
+
+    it('카테고리가 없으면 빈 배열을 반환한다', async () => {
+      await expect(service.categories()).resolves.toEqual([]);
+    });
+
+    it('id와 sortOrder를 문자열/숫자로 매핑한다', async () => {
+      const category = await createCategory(prisma, {
+        name: '생일',
+        sort_order: 3,
+      });
+
+      const [item] = await service.categories();
+
+      expect(item.id).toBe(category.id.toString());
+      expect(item.sortOrder).toBe(3);
+    });
+  });
+});

--- a/src/features/product/services/product-category.service.ts
+++ b/src/features/product/services/product-category.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+
+import type { CategoriesInput } from '@/features/product/dto/inputs/categories.input';
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import type { CategoryItem } from '@/features/product/types/product-category-output.type';
+
+@Injectable()
+export class ProductCategoryService {
+  constructor(private readonly repo: ProductRepository) {}
+
+  /** 전역 카테고리 목록. type 필터 옵션, 활성만. */
+  async categories(input?: CategoriesInput): Promise<CategoryItem[]> {
+    const rows = await this.repo.listCategories(input?.type);
+    return rows.map((row) => ({
+      id: row.id.toString(),
+      name: row.name,
+      categoryType: row.category_type,
+      sortOrder: row.sort_order,
+    }));
+  }
+}

--- a/src/features/product/types/product-category-output.type.ts
+++ b/src/features/product/types/product-category-output.type.ts
@@ -1,0 +1,11 @@
+/**
+ * product-category resolver 반환용 도메인 출력 타입.
+ * SDL(product-category.graphql)의 타입과 필드 일치.
+ */
+
+export interface CategoryItem {
+  id: string;
+  name: string;
+  categoryType: 'EVENT' | 'STYLE' | 'OTHER';
+  sortOrder: number;
+}

--- a/src/test/factories/category.factory.ts
+++ b/src/test/factories/category.factory.ts
@@ -1,0 +1,41 @@
+import type { Category, CategoryType, PrismaClient } from '@prisma/client';
+
+import { nextSeq } from '@/test/factories/sequence';
+
+export interface CategoryOverrides {
+  category_type?: CategoryType;
+  name?: string;
+  sort_order?: number;
+  is_active?: boolean;
+  deleted_at?: Date | null;
+}
+
+export async function createCategory(
+  prisma: PrismaClient,
+  overrides: CategoryOverrides = {},
+): Promise<Category> {
+  const seq = nextSeq();
+
+  return prisma.category.create({
+    data: {
+      category_type: overrides.category_type ?? 'EVENT',
+      name: overrides.name ?? `Category ${seq}`,
+      sort_order: overrides.sort_order ?? seq,
+      is_active: overrides.is_active ?? true,
+      deleted_at: overrides.deleted_at ?? null,
+    },
+  });
+}
+
+/** 상품 ↔ 카테고리 연결. */
+export async function linkProductCategory(
+  prisma: PrismaClient,
+  args: { productId: bigint; categoryId: bigint },
+): Promise<void> {
+  await prisma.productCategory.create({
+    data: {
+      product_id: args.productId,
+      category_id: args.categoryId,
+    },
+  });
+}

--- a/src/test/factories/index.ts
+++ b/src/test/factories/index.ts
@@ -1,5 +1,6 @@
 export * from './account.factory';
 export * from './auth.factory';
+export * from './category.factory';
 export * from './notification.factory';
 export * from './order.factory';
 export * from './product.factory';


### PR DESCRIPTION
## 개요

홈 화면(figma `.figma/home` 명세) 작업 1/5 — 카테고리 칩·Category_Entry 화면용 전역 카테고리 조회 API와 Category 마스터 시드.

기존에는 매장 단위 `storeProductCategories`만 있어 홈 칩/카테고리 진입 화면이 쓸 전역 목록 쿼리가 없었다.

## 변경점

- **SDL** `product-category.graphql` 신규: `categories(input: CategoriesInput): [CategoryItem!]!`
  - `type`(EVENT/STYLE/OTHER) 필터 옵션, 활성만, `category_type → sort_order → id` 정렬
- `CategoriesInput` DTO + `ProductCategoryService` / `ProductCategoryQueryResolver` + `ProductRepository.listCategories`
- **Category 마스터 시드**: figma Category_Entry 스펙 정본 기준 이벤트 16종 + 스타일 7종
  - region 시드와 동일한 영구 마스터 패턴 — uk(category_type, name) upsert(멱등), `resetSeedScope` 비대상
  - '전체' 칩은 카테고리가 아니라 FE 가상 칩(필터 미적용)이라 시드하지 않음 (figma 명세 외 정책 결정)
- 시드 상품 ↔ 카테고리 연결(홈 섹션 로컬 동작용), 테스트 팩토리 `createCategory`/`linkProductCategory` 추가

## 테스트

- `product-category.service.spec.ts` (real DB) 5건: type 필터 / 전체 정렬(type→sort_order) / 비활성·soft-delete 제외 / 빈 목록 / id·sortOrder 매핑
- `product-category-query.resolver.spec.ts` (real DB) 통합 1건
- `yarn validate` 전체 통과