### PR TITLE
feat(product): 홈 상황별 인기 케이크 조회(popularCakes)와 카테고리 배너

### DIFF
--- a/src/features/product/constants/product-home.constants.ts
+++ b/src/features/product/constants/product-home.constants.ts
@@ -1,2 +1,5 @@
 /** popularCakes 기본 카드 수(홈 섹션은 최대 3개 노출. figma 명세 기준). */
 export const DEFAULT_POPULAR_CAKES_LIMIT = 3;
+
+/** popularCakes 최대 카드 수. figma 명세 "최대 3개 케이크 노출" 계약의 상한. */
+export const MAX_POPULAR_CAKES_LIMIT = 3;

--- a/src/features/product/constants/product-home.constants.ts
+++ b/src/features/product/constants/product-home.constants.ts
@@ -1,0 +1,2 @@
+/** popularCakes 기본 카드 수(홈 섹션은 최대 3개 노출. figma 명세 기준). */
+export const DEFAULT_POPULAR_CAKES_LIMIT = 3;

--- a/src/features/product/dto/inputs/popular-cakes.input.ts
+++ b/src/features/product/dto/inputs/popular-cakes.input.ts
@@ -23,6 +23,6 @@ export class PopularCakesInput {
   @IsOptional()
   @IsInt()
   @Min(1)
-  @Max(10)
+  @Max(3)
   limit?: number;
 }

--- a/src/features/product/dto/inputs/popular-cakes.input.ts
+++ b/src/features/product/dto/inputs/popular-cakes.input.ts
@@ -1,0 +1,28 @@
+import {
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class PopularCakesInput {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  regionIds?: string[];
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  limit?: number;
+}

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -1,0 +1,45 @@
+extend type Query {
+  """홈 '상황별 인기 케이크' 섹션(배너 1건 + 인기 케이크 카드). 비로그인 접근 가능."""
+  popularCakes(input: PopularCakesInput): PopularCakesResult!
+}
+
+input PopularCakesInput {
+  """EVENT 카테고리 ID. 비우면 '전체' 칩(필터 미적용)."""
+  categoryId: ID
+  """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
+  regionIds: [ID!]
+  limit: Int = 3
+}
+
+type PopularCakesResult {
+  """카테고리 대표 배너. 등록된 배너가 없으면 null(FE placeholder 처리)."""
+  banner: HomeBanner
+  items: [PopularCake!]!
+  """랭킹 산출 기준 시각(서버 조회 시점)."""
+  rankedAt: DateTime!
+}
+
+"""홈 카테고리 대표 배너."""
+type HomeBanner {
+  id: ID!
+  imageUrl: String!
+  title: String
+  """클릭 시 FE가 카테고리 자동선택 이동에 사용. 없으면 null."""
+  linkCategoryId: ID
+}
+
+"""인기 케이크 카드(지역명·매장명·케이크명·가격·할인율)."""
+type PopularCake {
+  id: ID!
+  rank: Int!
+  name: String!
+  """대표 이미지(sort_order 최소). 없으면 null."""
+  thumbnailUrl: String
+  storeName: String!
+  """매장 위치 표기(예: 서울 청담동)."""
+  regionLabel: String
+  regularPrice: Int!
+  salePrice: Int
+  """할인율(0~100). salePrice 없으면 0."""
+  discountRate: Int!
+}

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -8,6 +8,7 @@ input PopularCakesInput {
   categoryId: ID
   """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
   regionIds: [ID!]
+  """카드 수(최대 3 — figma 명세 "최대 3개 케이크 노출")."""
   limit: Int = 3
 }
 

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -20,12 +20,28 @@ type PopularCakesResult {
   rankedAt: DateTime!
 }
 
-"""홈 카테고리 대표 배너."""
+"""배너 클릭 이동 대상 타입."""
+enum HomeBannerLinkType {
+  NONE
+  URL
+  PRODUCT
+  STORE
+  CATEGORY
+}
+
+"""홈 카테고리 대표 배너. linkType에 대응하는 링크 필드 하나만 채워진다."""
 type HomeBanner {
   id: ID!
   imageUrl: String!
   title: String
-  """클릭 시 FE가 카테고리 자동선택 이동에 사용. 없으면 null."""
+  linkType: HomeBannerLinkType!
+  """linkType=URL일 때 이동 URL."""
+  linkUrl: String
+  """linkType=PRODUCT일 때 상품 ID."""
+  linkProductId: ID
+  """linkType=STORE일 때 매장 ID."""
+  linkStoreId: ID
+  """linkType=CATEGORY일 때 카테고리 ID(FE 카테고리 자동선택 이동)."""
   linkCategoryId: ID
 }
 

--- a/src/features/product/product.module.ts
+++ b/src/features/product/product.module.ts
@@ -4,10 +4,12 @@ import { ProductReviewRepository } from '@/features/product/repositories/product
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductCategoryQueryResolver } from '@/features/product/resolvers/product-category-query.resolver';
 import { ProductDetailQueryResolver } from '@/features/product/resolvers/product-detail-query.resolver';
+import { ProductHomeQueryResolver } from '@/features/product/resolvers/product-home-query.resolver';
 import { ProductReviewQueryResolver } from '@/features/product/resolvers/product-review-query.resolver';
 import { ProductStorefrontQueryResolver } from '@/features/product/resolvers/product-storefront-query.resolver';
 import { ProductCategoryService } from '@/features/product/services/product-category.service';
 import { ProductDetailService } from '@/features/product/services/product-detail.service';
+import { ProductHomeService } from '@/features/product/services/product-home.service';
 import { ProductReviewService } from '@/features/product/services/product-review.service';
 import { ProductStorefrontService } from '@/features/product/services/product-storefront.service';
 
@@ -23,6 +25,8 @@ import { ProductStorefrontService } from '@/features/product/services/product-st
     ProductStorefrontQueryResolver,
     ProductCategoryService,
     ProductCategoryQueryResolver,
+    ProductHomeService,
+    ProductHomeQueryResolver,
   ],
   exports: [ProductRepository],
 })

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { type CategoryType, Prisma } from '@prisma/client';
+import {
+  type BannerLinkType,
+  type CategoryType,
+  Prisma,
+} from '@prisma/client';
 
 import { RANKING_VALID_ORDER_STATUSES } from '@/features/store';
 import { PrismaService } from '@/prisma';
@@ -45,6 +49,10 @@ export interface HomeBannerRow {
   id: bigint;
   image_url: string;
   title: string | null;
+  link_type: BannerLinkType;
+  link_url: string | null;
+  link_product_id: bigint | null;
+  link_store_id: bigint | null;
   link_category_id: bigint | null;
 }
 
@@ -1105,6 +1113,10 @@ export class ProductRepository {
         id: true,
         image_url: true,
         title: true,
+        link_type: true,
+        link_url: true,
+        link_product_id: true,
+        link_store_id: true,
         link_category_id: true,
       },
       orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -991,7 +991,12 @@ export class ProductRepository {
                 some: {
                   category_id: args.categoryId,
                   deleted_at: null,
-                  category: { is_active: true, deleted_at: null },
+                  // 홈 칩은 EVENT 카테고리만 — STYLE/OTHER id가 오면 빈 결과로 처리
+                  category: {
+                    is_active: true,
+                    deleted_at: null,
+                    category_type: 'EVENT',
+                  },
                 },
               },
             }
@@ -1094,6 +1099,7 @@ export class ProductRepository {
   /**
    * 홈 배너 1건. categoryId 지정 시 placement=CATEGORY + 해당 카테고리 링크,
    * 미지정('전체' 칩) 시 placement=HOME_MAIN. 활성 + 노출 기간(now) 유효만.
+   * 링크 대상(상품/매장/카테고리)이 비활성/삭제된 배너는 건너뛴다.
    */
   async findHomeBanner(args: {
     categoryId?: bigint;
@@ -1107,7 +1113,32 @@ export class ProductRepository {
           ? { placement: 'CATEGORY', link_category_id: args.categoryId }
           : { placement: 'HOME_MAIN' }),
         OR: [{ starts_at: null }, { starts_at: { lte: args.now } }],
-        AND: [{ OR: [{ ends_at: null }, { ends_at: { gt: args.now } }] }],
+        AND: [
+          { OR: [{ ends_at: null }, { ends_at: { gt: args.now } }] },
+          {
+            // 링크 대상이 내려간(비활성/삭제) 배너를 노출하면 클릭이 죽은 화면으로
+            // 떨어지므로 대상 활성까지 확인하고 다음 배너로 넘어간다
+            OR: [
+              { link_type: { in: ['NONE', 'URL'] } },
+              {
+                link_type: 'PRODUCT',
+                link_product: {
+                  is_active: true,
+                  deleted_at: null,
+                  store: { is_active: true, deleted_at: null },
+                },
+              },
+              {
+                link_type: 'STORE',
+                link_store: { is_active: true, deleted_at: null },
+              },
+              {
+                link_type: 'CATEGORY',
+                link_category: { is_active: true, deleted_at: null },
+              },
+            ],
+          },
+        ],
       },
       select: {
         id: true,

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1110,7 +1110,16 @@ export class ProductRepository {
         is_active: true,
         deleted_at: null,
         ...(args.categoryId !== undefined
-          ? { placement: 'CATEGORY', link_category_id: args.categoryId }
+          ? {
+              placement: 'CATEGORY',
+              link_category_id: args.categoryId,
+              // 랭킹과 동일하게 홈 칩은 EVENT 카테고리만 — 비EVENT id면 배너도 없음
+              link_category: {
+                is_active: true,
+                deleted_at: null,
+                category_type: 'EVENT',
+              },
+            }
           : { placement: 'HOME_MAIN' }),
         OR: [{ starts_at: null }, { starts_at: { lte: args.now } }],
         AND: [

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { type CategoryType, Prisma } from '@prisma/client';
 
+import { RANKING_VALID_ORDER_STATUSES } from '@/features/store';
 import { PrismaService } from '@/prisma';
 
 /** 구매자 매장 상품 카드 row. product-storefront 매퍼 입력. */
@@ -22,6 +23,35 @@ export interface StoreProductCategoryRow {
   category_type: CategoryType;
   sort_order: number;
   product_count: number;
+}
+
+/** 인기 케이크 랭킹 후보 row. product-home 매퍼 입력. */
+export interface CakeCandidateRow {
+  id: bigint;
+  name: string;
+  regular_price: number;
+  sale_price: number | null;
+  images: { image_url: string }[];
+  store: {
+    store_name: string;
+    address_city: string | null;
+    address_neighborhood: string | null;
+    region: { name: string } | null;
+  };
+}
+
+/** 홈 배너 row. */
+export interface HomeBannerRow {
+  id: bigint;
+  image_url: string;
+  title: string | null;
+  link_category_id: bigint | null;
+}
+
+/** 상품별 평균 평점·리뷰 수. */
+export interface ProductReviewStat {
+  average: number;
+  count: number;
 }
 
 /** 구매자 상품 상세 row. product-detail 매퍼 입력. */
@@ -925,6 +955,160 @@ export class ProductRepository {
       select: { id: true },
     });
     return Boolean(found);
+  }
+
+  /**
+   * 인기 케이크 랭킹 후보. 활성 상품(+활성 매장)만.
+   * 카테고리/지역(2차 시군구 다중) 필터. 대표 이미지 1장 + 매장 표기 정보 포함.
+   */
+  async findActiveCakesForRanking(args: {
+    categoryId?: bigint;
+    regionIds?: bigint[];
+  }): Promise<CakeCandidateRow[]> {
+    return this.prisma.product.findMany({
+      where: {
+        is_active: true,
+        deleted_at: null,
+        store: {
+          is_active: true,
+          deleted_at: null,
+          ...(args.regionIds && args.regionIds.length > 0
+            ? { region_id: { in: args.regionIds } }
+            : {}),
+        },
+        // 0n도 유효한 인자(parseId("0")=0n) → undefined로만 분기한다.
+        ...(args.categoryId !== undefined
+          ? {
+              product_categories: {
+                some: {
+                  category_id: args.categoryId,
+                  deleted_at: null,
+                  category: { is_active: true, deleted_at: null },
+                },
+              },
+            }
+          : {}),
+      },
+      select: {
+        id: true,
+        name: true,
+        regular_price: true,
+        sale_price: true,
+        images: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+          take: 1,
+          select: { image_url: true },
+        },
+        store: {
+          select: {
+            store_name: true,
+            address_city: true,
+            address_neighborhood: true,
+            region: { select: { name: true } },
+          },
+        },
+      },
+    });
+  }
+
+  /** 상품별 활성 찜 수. */
+  async aggregateProductWishlistCounts(
+    productIds: bigint[],
+  ): Promise<Map<bigint, number>> {
+    if (productIds.length === 0) return new Map();
+    const rows = await this.prisma.wishlistItem.groupBy({
+      by: ['product_id'],
+      where: { product_id: { in: productIds }, deleted_at: null },
+      _count: { _all: true },
+    });
+    return new Map(rows.map((r) => [r.product_id, r._count._all]));
+  }
+
+  /** 상품별 평균 평점·리뷰 수. */
+  async aggregateProductReviewStats(
+    productIds: bigint[],
+  ): Promise<Map<bigint, ProductReviewStat>> {
+    if (productIds.length === 0) return new Map();
+    const rows = await this.prisma.review.groupBy({
+      by: ['product_id'],
+      where: { product_id: { in: productIds }, deleted_at: null },
+      _avg: { rating: true },
+      _count: { _all: true },
+    });
+    return new Map(
+      rows.map((r) => [
+        r.product_id,
+        {
+          average: r._avg.rating !== null ? Number(r._avg.rating) : 0,
+          count: r._count._all,
+        },
+      ]),
+    );
+  }
+
+  /** 상품별 최근 N일 유효 주문(아이템) 수. */
+  async aggregateProductRecentOrderCounts(
+    productIds: bigint[],
+    since: Date,
+  ): Promise<Map<bigint, number>> {
+    if (productIds.length === 0) return new Map();
+    const rows = await this.prisma.orderItem.groupBy({
+      by: ['product_id'],
+      where: {
+        product_id: { in: productIds },
+        deleted_at: null,
+        order: {
+          status: { in: [...RANKING_VALID_ORDER_STATUSES] },
+          created_at: { gte: since },
+          // soft-delete extension은 nested relation filter에 deleted_at을 주입하지
+          // 않으므로(=root read만 보정), 삭제된 주문이 랭킹을 부풀리지 않도록 명시한다.
+          deleted_at: null,
+        },
+      },
+      _count: { _all: true },
+    });
+    return new Map(rows.map((r) => [r.product_id, r._count._all]));
+  }
+
+  /**
+   * 전체 활성 리뷰 평균 평점(베이지안 prior). 리뷰가 없으면 null.
+   * store feature의 globalReviewAverage와 동일 정의(전 도메인 공용 prior).
+   */
+  async globalReviewAverage(): Promise<number | null> {
+    const agg = await this.prisma.review.aggregate({
+      where: { deleted_at: null },
+      _avg: { rating: true },
+    });
+    return agg._avg.rating !== null ? Number(agg._avg.rating) : null;
+  }
+
+  /**
+   * 홈 배너 1건. categoryId 지정 시 placement=CATEGORY + 해당 카테고리 링크,
+   * 미지정('전체' 칩) 시 placement=HOME_MAIN. 활성 + 노출 기간(now) 유효만.
+   */
+  async findHomeBanner(args: {
+    categoryId?: bigint;
+    now: Date;
+  }): Promise<HomeBannerRow | null> {
+    return this.prisma.banner.findFirst({
+      where: {
+        is_active: true,
+        deleted_at: null,
+        ...(args.categoryId !== undefined
+          ? { placement: 'CATEGORY', link_category_id: args.categoryId }
+          : { placement: 'HOME_MAIN' }),
+        OR: [{ starts_at: null }, { starts_at: { lte: args.now } }],
+        AND: [{ OR: [{ ends_at: null }, { ends_at: { gt: args.now } }] }],
+      },
+      select: {
+        id: true,
+        image_url: true,
+        title: true,
+        link_category_id: true,
+      },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
   }
 
   /**

--- a/src/features/product/resolvers/product-home-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.spec.ts
@@ -1,0 +1,49 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductHomeQueryResolver } from '@/features/product/resolvers/product-home-query.resolver';
+import { ProductHomeService } from '@/features/product/services/product-home.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createProduct, createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 통합 경로 검증.
+ * 랭킹/배너/필터 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('ProductHome Query Resolver (real DB)', () => {
+  let resolver: ProductHomeQueryResolver;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        ProductHomeQueryResolver,
+        ProductHomeService,
+        ProductRepository,
+      ],
+    });
+    resolver = module.get(ProductHomeQueryResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('popularCakes: 서비스에 위임해 섹션 데이터를 반환한다', async () => {
+    const store = await createStore(prisma);
+    await createProduct(prisma, { store_id: store.id, name: '인기 케이크' });
+
+    const result = await resolver.popularCakes();
+
+    expect(result.items.map((i) => i.name)).toEqual(['인기 케이크']);
+    expect(result.banner).toBeNull();
+  });
+});

--- a/src/features/product/resolvers/product-home-query.resolver.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.ts
@@ -1,0 +1,20 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import { ProductHomeService } from '@/features/product/services/product-home.service';
+import type { PopularCakesResult } from '@/features/product/types/product-home-output.type';
+
+/**
+ * 홈 화면 섹션 조회 resolver. 개인화 필드가 없는 public query(인증 불필요).
+ */
+@Resolver('Query')
+export class ProductHomeQueryResolver {
+  constructor(private readonly service: ProductHomeService) {}
+
+  @Query('popularCakes')
+  popularCakes(
+    @Args('input') input?: PopularCakesInput,
+  ): Promise<PopularCakesResult> {
+    return this.service.popularCakes(input);
+  }
+}

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -1,0 +1,36 @@
+import type {
+  CakeCandidateRow,
+  HomeBannerRow,
+} from '@/features/product/repositories/product.repository';
+import { calcDiscountRate } from '@/features/product/services/product-storefront-mappers.helper';
+import type {
+  HomeBanner,
+  PopularCake,
+} from '@/features/product/types/product-home-output.type';
+import { buildRegionLabel } from '@/features/store';
+
+export function toHomeBanner(row: HomeBannerRow): HomeBanner {
+  return {
+    id: row.id.toString(),
+    imageUrl: row.image_url,
+    title: row.title,
+    linkCategoryId: row.link_category_id?.toString() ?? null,
+  };
+}
+
+export function toPopularCake(
+  row: CakeCandidateRow,
+  rank: number,
+): PopularCake {
+  return {
+    id: row.id.toString(),
+    rank,
+    name: row.name,
+    thumbnailUrl: row.images[0]?.image_url ?? null,
+    storeName: row.store.store_name,
+    regionLabel: buildRegionLabel(row.store),
+    regularPrice: row.regular_price,
+    salePrice: row.sale_price,
+    discountRate: calcDiscountRate(row.regular_price, row.sale_price),
+  };
+}

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -14,6 +14,10 @@ export function toHomeBanner(row: HomeBannerRow): HomeBanner {
     id: row.id.toString(),
     imageUrl: row.image_url,
     title: row.title,
+    linkType: row.link_type,
+    linkUrl: row.link_url,
+    linkProductId: row.link_product_id?.toString() ?? null,
+    linkStoreId: row.link_store_id?.toString() ?? null,
     linkCategoryId: row.link_category_id?.toString() ?? null,
   };
 }

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -303,6 +303,27 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.banner).toBeNull();
     });
 
+    it('EVENT가 아닌 카테고리의 배너는 반환하지 않는다', async () => {
+      const style = await createCategory(prisma, {
+        category_type: 'STYLE',
+        name: '입체',
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'CATEGORY',
+          image_url: 'https://img/style-banner.png',
+          link_type: 'CATEGORY',
+          link_category_id: style.id,
+        },
+      });
+
+      const result = await service.popularCakes({
+        categoryId: style.id.toString(),
+      });
+
+      expect(result.banner).toBeNull();
+    });
+
     it('링크 대상이 비활성인 배너는 건너뛰고 다음 유효 배너를 반환한다', async () => {
       const store = await createStore(prisma);
       const deadProduct = await createProduct(prisma, {

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -1,0 +1,291 @@
+import type { PrismaClient, Product, Store } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductHomeService } from '@/features/product/services/product-home.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createCategory,
+  createOrder,
+  createOrderItem,
+  createProduct,
+  createStore,
+  linkProductCategory,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('ProductHomeService (real DB)', () => {
+  let service: ProductHomeService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ProductHomeService, ProductRepository],
+    });
+    service = module.get(ProductHomeService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  /** 확정(CONFIRMED) 주문 n건을 만들어 상품의 최근 주문수를 채운다. */
+  async function confirmOrders(product: Product, count: number): Promise<void> {
+    for (let i = 0; i < count; i += 1) {
+      const order = await createOrder(prisma, { status: 'CONFIRMED' });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        product_id: product.id,
+      });
+    }
+  }
+
+  /** 활성 찜 n건 생성. */
+  async function wishProduct(product: Product, count: number): Promise<void> {
+    for (let i = 0; i < count; i += 1) {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await prisma.wishlistItem.create({
+        data: { account_id: account.id, product_id: product.id },
+      });
+    }
+  }
+
+  async function makeCake(
+    store: Store,
+    name: string,
+    overrides: Parameters<typeof createProduct>[1] = {},
+  ): Promise<Product> {
+    return createProduct(prisma, {
+      store_id: store.id,
+      name,
+      ...overrides,
+    });
+  }
+
+  describe('popularCakes', () => {
+    it('최근 주문수가 많은 순으로 랭킹과 rank 순번을 매긴다', async () => {
+      const store = await createStore(prisma);
+      const first = await makeCake(store, '1등 케이크');
+      const second = await makeCake(store, '2등 케이크');
+      const third = await makeCake(store, '3등 케이크');
+      await confirmOrders(first, 5);
+      await confirmOrders(second, 2);
+      await confirmOrders(third, 1);
+
+      const result = await service.popularCakes();
+
+      expect(result.items.map((i) => i.name)).toEqual([
+        '1등 케이크',
+        '2등 케이크',
+        '3등 케이크',
+      ]);
+      expect(result.items.map((i) => i.rank)).toEqual([1, 2, 3]);
+      expect(result.rankedAt).toBeInstanceOf(Date);
+    });
+
+    it('찜 수도 점수에 반영한다(주문 동일 시 찜 많은 쪽 우선)', async () => {
+      const store = await createStore(prisma);
+      const liked = await makeCake(store, '찜 많은 케이크');
+      await makeCake(store, '찜 없는 케이크');
+      await wishProduct(liked, 3);
+
+      const result = await service.popularCakes();
+
+      expect(result.items[0].name).toBe('찜 많은 케이크');
+    });
+
+    it('categoryId 지정 시 해당 카테고리 상품만 랭킹 대상이다', async () => {
+      const store = await createStore(prisma);
+      const birthday = await createCategory(prisma, { name: '생일' });
+      const inCategory = await makeCake(store, '생일 케이크');
+      await makeCake(store, '무관 케이크');
+      await linkProductCategory(prisma, {
+        productId: inCategory.id,
+        categoryId: birthday.id,
+      });
+
+      const result = await service.popularCakes({
+        categoryId: birthday.id.toString(),
+      });
+
+      expect(result.items.map((i) => i.name)).toEqual(['생일 케이크']);
+    });
+
+    it('regionIds 지정 시 해당 지역 매장 상품만 랭킹 대상이다', async () => {
+      const regionA = await prisma.region.create({
+        data: { level: 2, name: '강남구', slug: 'test-gangnam' },
+      });
+      const storeIn = await createStore(prisma, { region_id: regionA.id });
+      const storeOut = await createStore(prisma);
+      await makeCake(storeIn, '강남 케이크');
+      await makeCake(storeOut, '타지역 케이크');
+
+      const result = await service.popularCakes({
+        regionIds: [regionA.id.toString()],
+      });
+
+      expect(result.items.map((i) => i.name)).toEqual(['강남 케이크']);
+    });
+
+    it('비활성 상품과 비활성 매장 상품은 제외한다', async () => {
+      const store = await createStore(prisma);
+      await makeCake(store, '활성 케이크');
+      await makeCake(store, '비활성 케이크', { is_active: false });
+      const inactiveStore = await createStore(prisma, { is_active: false });
+      await makeCake(inactiveStore, '비활성 매장 케이크');
+
+      const result = await service.popularCakes();
+
+      expect(result.items.map((i) => i.name)).toEqual(['활성 케이크']);
+    });
+
+    it('기본 3개, limit 지정 시 해당 수만큼 자른다', async () => {
+      const store = await createStore(prisma);
+      for (let i = 0; i < 5; i += 1) {
+        await makeCake(store, `케이크 ${i}`);
+      }
+
+      const [byDefault, limited] = [
+        await service.popularCakes(),
+        await service.popularCakes({ limit: 2 }),
+      ];
+
+      expect(byDefault.items).toHaveLength(3);
+      expect(limited.items).toHaveLength(2);
+    });
+
+    it('카드에 매장명·지역명·가격·할인율·대표이미지를 매핑한다', async () => {
+      const store = await createStore(prisma, {
+        store_name: '청담 케이크샵',
+        address_city: '서울',
+        address_neighborhood: '청담동',
+      });
+      const cake = await makeCake(store, '레터링 케이크', {
+        regular_price: 40000,
+        sale_price: 30000,
+      });
+      await prisma.productImage.create({
+        data: { product_id: cake.id, image_url: 'https://img/cake.png' },
+      });
+
+      const [item] = (await service.popularCakes()).items;
+
+      expect(item).toMatchObject({
+        name: '레터링 케이크',
+        storeName: '청담 케이크샵',
+        regionLabel: '서울 청담동',
+        regularPrice: 40000,
+        salePrice: 30000,
+        discountRate: 25,
+        thumbnailUrl: 'https://img/cake.png',
+      });
+    });
+
+    it('상품이 없으면 빈 items를 반환한다', async () => {
+      const result = await service.popularCakes();
+
+      expect(result.items).toEqual([]);
+      expect(result.banner).toBeNull();
+    });
+  });
+
+  describe('popularCakes 배너 선택', () => {
+    it('categoryId 지정 시 해당 카테고리의 CATEGORY 배너를 반환한다', async () => {
+      const birthday = await createCategory(prisma, { name: '생일' });
+      const other = await createCategory(prisma, { name: '웨딩' });
+      await prisma.banner.create({
+        data: {
+          placement: 'CATEGORY',
+          image_url: 'https://img/birthday-banner.png',
+          link_type: 'CATEGORY',
+          link_category_id: birthday.id,
+        },
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'CATEGORY',
+          image_url: 'https://img/other-banner.png',
+          link_type: 'CATEGORY',
+          link_category_id: other.id,
+        },
+      });
+
+      const result = await service.popularCakes({
+        categoryId: birthday.id.toString(),
+      });
+
+      expect(result.banner).toMatchObject({
+        imageUrl: 'https://img/birthday-banner.png',
+        linkCategoryId: birthday.id.toString(),
+      });
+    });
+
+    it('categoryId 미지정(전체 칩) 시 HOME_MAIN 배너를 반환한다', async () => {
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/main-banner.png',
+          title: '메인 배너',
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner).toMatchObject({
+        imageUrl: 'https://img/main-banner.png',
+        title: '메인 배너',
+        linkCategoryId: null,
+      });
+    });
+
+    it('노출 기간을 벗어난 배너와 비활성 배너는 제외하고 없으면 null을 반환한다', async () => {
+      const past = new Date(Date.now() - 60 * 60 * 1000);
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/expired.png',
+          ends_at: past,
+        },
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/inactive.png',
+          is_active: false,
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner).toBeNull();
+    });
+
+    it('동일 placement 다건이면 sort_order가 앞선 배너 1건만 반환한다', async () => {
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/second.png',
+          sort_order: 1,
+        },
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/first.png',
+          sort_order: 0,
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner?.imageUrl).toBe('https://img/first.png');
+    });
+  });
+});

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -118,6 +118,25 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.items.map((i) => i.name)).toEqual(['생일 케이크']);
     });
 
+    it('EVENT가 아닌 카테고리 id가 오면 빈 결과를 반환한다(홈 칩은 EVENT 한정)', async () => {
+      const store = await createStore(prisma);
+      const style = await createCategory(prisma, {
+        category_type: 'STYLE',
+        name: '입체',
+      });
+      const cake = await makeCake(store, '입체 케이크');
+      await linkProductCategory(prisma, {
+        productId: cake.id,
+        categoryId: style.id,
+      });
+
+      const result = await service.popularCakes({
+        categoryId: style.id.toString(),
+      });
+
+      expect(result.items).toEqual([]);
+    });
+
     it('regionIds 지정 시 해당 지역 매장 상품만 랭킹 대상이다', async () => {
       const regionA = await prisma.region.create({
         data: { level: 2, name: '강남구', slug: 'test-gangnam' },
@@ -282,6 +301,34 @@ describe('ProductHomeService (real DB)', () => {
       const result = await service.popularCakes();
 
       expect(result.banner).toBeNull();
+    });
+
+    it('링크 대상이 비활성인 배너는 건너뛰고 다음 유효 배너를 반환한다', async () => {
+      const store = await createStore(prisma);
+      const deadProduct = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: false,
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/dead-link.png',
+          link_type: 'PRODUCT',
+          link_product_id: deadProduct.id,
+          sort_order: 0,
+        },
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/alive.png',
+          sort_order: 1,
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner?.imageUrl).toBe('https://img/alive.png');
     });
 
     it('동일 placement 다건이면 sort_order가 앞선 배너 1건만 반환한다', async () => {

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -235,6 +235,7 @@ describe('ProductHomeService (real DB)', () => {
 
       expect(result.banner).toMatchObject({
         imageUrl: 'https://img/birthday-banner.png',
+        linkType: 'CATEGORY',
         linkCategoryId: birthday.id.toString(),
       });
     });
@@ -245,6 +246,8 @@ describe('ProductHomeService (real DB)', () => {
           placement: 'HOME_MAIN',
           image_url: 'https://img/main-banner.png',
           title: '메인 배너',
+          link_type: 'URL',
+          link_url: 'https://event.caquick.dev',
         },
       });
 
@@ -253,6 +256,8 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.banner).toMatchObject({
         imageUrl: 'https://img/main-banner.png',
         title: '메인 배너',
+        linkType: 'URL',
+        linkUrl: 'https://event.caquick.dev',
         linkCategoryId: null,
       });
     });

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -161,6 +161,18 @@ describe('ProductHomeService (real DB)', () => {
       expect(limited.items).toHaveLength(2);
     });
 
+    it('limit이 상한(3)을 넘으면 3으로 클램프한다', async () => {
+      const store = await createStore(prisma);
+      for (let i = 0; i < 5; i += 1) {
+        await makeCake(store, `케이크 ${i}`);
+      }
+
+      // DTO(@Max)를 우회한 직접 호출에도 "최대 3개" 계약을 지킨다
+      const result = await service.popularCakes({ limit: 5 });
+
+      expect(result.items).toHaveLength(3);
+    });
+
     it('카드에 매장명·지역명·가격·할인율·대표이미지를 매핑한다', async () => {
       const store = await createStore(prisma, {
         store_name: '청담 케이크샵',

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+
+import { parseId } from '@/common/utils/id-parser';
+import { DEFAULT_POPULAR_CAKES_LIMIT } from '@/features/product/constants/product-home.constants';
+import type { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import {
+  toHomeBanner,
+  toPopularCake,
+} from '@/features/product/services/product-home-mappers.helper';
+import type { PopularCakesResult } from '@/features/product/types/product-home-output.type';
+import {
+  DEFAULT_GLOBAL_RATING_PRIOR,
+  popularityScore,
+  RANKING_RECENT_ORDER_DAYS,
+  type StoreMetrics,
+} from '@/features/store';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class ProductHomeService {
+  constructor(private readonly repo: ProductRepository) {}
+
+  /**
+   * 홈 '상황별 인기 케이크' 섹션. 인기 매장과 동일 산식(최근 주문·찜·베이지안 평점)을
+   * 상품 단위로 적용해 상위 카드를 뽑고, 카테고리 대표 배너를 함께 반환한다.
+   * 배너는 등록분이 없으면 null(fallback 없음 — FE placeholder 처리, 정책 확정 사항).
+   */
+  async popularCakes(input?: PopularCakesInput): Promise<PopularCakesResult> {
+    const limit = input?.limit ?? DEFAULT_POPULAR_CAKES_LIMIT;
+    const categoryId =
+      input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
+    const regionIds = input?.regionIds?.map((id) => parseId(id));
+
+    const rankedAt = new Date();
+    const [candidates, banner] = await Promise.all([
+      this.repo.findActiveCakesForRanking({ categoryId, regionIds }),
+      this.repo.findHomeBanner({ categoryId, now: rankedAt }),
+    ]);
+    const bannerOutput = banner ? toHomeBanner(banner) : null;
+    if (candidates.length === 0) {
+      return { banner: bannerOutput, items: [], rankedAt };
+    }
+
+    const productIds = candidates.map((c) => c.id);
+    const since = new Date(
+      rankedAt.getTime() - RANKING_RECENT_ORDER_DAYS * DAY_MS,
+    );
+
+    const [wishlistCounts, reviewStats, orderCounts, globalAverage] =
+      await Promise.all([
+        this.repo.aggregateProductWishlistCounts(productIds),
+        this.repo.aggregateProductReviewStats(productIds),
+        this.repo.aggregateProductRecentOrderCounts(productIds, since),
+        this.repo.globalReviewAverage(),
+      ]);
+    const prior = globalAverage ?? DEFAULT_GLOBAL_RATING_PRIOR;
+
+    const scored = candidates.map((candidate) => {
+      const review = reviewStats.get(candidate.id);
+      const metrics: StoreMetrics = {
+        recentOrderCount: orderCounts.get(candidate.id) ?? 0,
+        wishlistCount: wishlistCounts.get(candidate.id) ?? 0,
+        ratingAverage: review?.average ?? 0,
+        reviewCount: review?.count ?? 0,
+      };
+      return { candidate, metrics, score: popularityScore(metrics, prior) };
+    });
+
+    // 점수 desc → 리뷰수 desc → id desc (인기 매장과 동일한 안정적 동점 처리)
+    scored.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (b.metrics.reviewCount !== a.metrics.reviewCount) {
+        return b.metrics.reviewCount - a.metrics.reviewCount;
+      }
+      return b.candidate.id > a.candidate.id ? 1 : -1;
+    });
+
+    const items = scored
+      .slice(0, limit)
+      .map((entry, idx) => toPopularCake(entry.candidate, idx + 1));
+
+    return { banner: bannerOutput, items, rankedAt };
+  }
+}

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
-import { DEFAULT_POPULAR_CAKES_LIMIT } from '@/features/product/constants/product-home.constants';
+import {
+  DEFAULT_POPULAR_CAKES_LIMIT,
+  MAX_POPULAR_CAKES_LIMIT,
+} from '@/features/product/constants/product-home.constants';
 import type { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import {
@@ -28,7 +31,11 @@ export class ProductHomeService {
    * 배너는 등록분이 없으면 null(fallback 없음 — FE placeholder 처리, 정책 확정 사항).
    */
   async popularCakes(input?: PopularCakesInput): Promise<PopularCakesResult> {
-    const limit = input?.limit ?? DEFAULT_POPULAR_CAKES_LIMIT;
+    // DTO(@Max)가 1차로 막지만, 직접 호출 경로에서도 "최대 3개" 계약을 지키도록 클램프
+    const limit = Math.min(
+      input?.limit ?? DEFAULT_POPULAR_CAKES_LIMIT,
+      MAX_POPULAR_CAKES_LIMIT,
+    );
     const categoryId =
       input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
     const regionIds = input?.regionIds?.map((id) => parseId(id));

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -1,0 +1,29 @@
+/**
+ * product-home resolver 반환용 도메인 출력 타입.
+ * SDL(product-home.graphql)의 타입과 필드 일치.
+ */
+
+export interface HomeBanner {
+  id: string;
+  imageUrl: string;
+  title: string | null;
+  linkCategoryId: string | null;
+}
+
+export interface PopularCake {
+  id: string;
+  rank: number;
+  name: string;
+  thumbnailUrl: string | null;
+  storeName: string;
+  regionLabel: string | null;
+  regularPrice: number;
+  salePrice: number | null;
+  discountRate: number;
+}
+
+export interface PopularCakesResult {
+  banner: HomeBanner | null;
+  items: PopularCake[];
+  rankedAt: Date;
+}

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -7,6 +7,10 @@ export interface HomeBanner {
   id: string;
   imageUrl: string;
   title: string | null;
+  linkType: 'NONE' | 'URL' | 'PRODUCT' | 'STORE' | 'CATEGORY';
+  linkUrl: string | null;
+  linkProductId: string | null;
+  linkStoreId: string | null;
   linkCategoryId: string | null;
 }
 

--- a/src/features/store/index.ts
+++ b/src/features/store/index.ts
@@ -1,3 +1,14 @@
 // cross-feature 공개 API. 단일 구현 repo라 토큰/인터페이스 없이 구체 클래스로 주입(의도적).
 export { StoreModule } from '@/features/store/store.module';
 export { StoreRepository } from '@/features/store/repositories/store.repository';
+// 인기 랭킹 산식·표기 규칙. 상품 랭킹(product feature)이 동일 정책을 공유한다.
+export {
+  DEFAULT_GLOBAL_RATING_PRIOR,
+  RANKING_RECENT_ORDER_DAYS,
+  RANKING_VALID_ORDER_STATUSES,
+} from '@/features/store/constants/store-ranking.constants';
+export { buildRegionLabel } from '@/features/store/services/store-mappers.helper';
+export {
+  popularityScore,
+  type StoreMetrics,
+} from '@/features/store/services/store-ranking.helper';


### PR DESCRIPTION
## 개요

홈 화면(figma `.figma/home` 명세) 작업 2/5 — "상황별 인기 케이크" 섹션 API. #178 후속.

> 스펙: "메인 홈 데이터 로드 시 상황별 인기 케이크 API 호출 / 카테고리 및 대표 이미지 표시", "케이크 카드 노출 — 최대 3개 / 상품 카드 (지역명,매장명,케이크명,가격,할인율)", "더보기·배너 클릭 시 선택된 카테고리 값 전달"

## 변경점

- **SDL** `product-home.graphql` 신규: `popularCakes(input): PopularCakesResult!` — `banner`(1건, nullable) + `items`(최대 3, 기본) + `rankedAt` 통합 반환
- **랭킹**: 인기 매장(`popularStores`)과 동일 산식(최근 30일 유효주문 + 찜 + 베이지안 평점)을 **상품 단위**로 적용. store feature의 `popularityScore`/상수/`buildRegionLabel`을 배럴(`@/features/store`)로 공개해 재사용 (중복 구현 대신 단일 정책 유지)
- **배너**: Banner 테이블만 사용 — `categoryId` 지정 시 `placement=CATEGORY` + 해당 카테고리 링크, 미지정('전체' 칩) 시 `HOME_MAIN`. 노출 기간(starts/ends)·활성 필터, `sort_order` 우선 1건. **등록분 없으면 null** (fallback 없음 — figma 명세 외 정책 결정, FE placeholder 처리)
- `regionIds`(2차 시군구 다중) 옵션 필터 — 비우면 전국
- `ProductRepository`: 랭킹 후보 조회 + 상품 단위 주문/찜/리뷰 집계 + 홈 배너 조회 (nested relation soft-delete 가드 명시)

## 테스트

- `product-home.service.spec.ts` (real DB) 12건: 랭킹 순서·rank 순번 / 찜 가중 / 카테고리·지역 필터 / 비활성 상품·매장 제외 / limit / 카드 매핑(할인율 25%·지역명) / 빈 목록 / 배너 4건(카테고리 매칭·HOME_MAIN·기간/활성 제외·sort_order)
- `product-home-query.resolver.spec.ts` (real DB) 통합 1건
- `yarn validate` 전체 통과