### PR TITLE
feat(product): 홈 제작 후기 쇼케이스 조회(customCakeShowcase)

### DIFF
--- a/prisma/seed/orders.ts
+++ b/prisma/seed/orders.ts
@@ -248,6 +248,16 @@ export async function seedOrders(
       item_subtotal_price: 35000,
     },
   });
+  // o4에는 리뷰가 달리므로(seedReviews) 커스텀 크롭을 함께 둬
+  // 홈 제작 후기 쇼케이스(Before/After 페어)가 로컬에서 동작하게 한다
+  await prisma.orderItemCustomFreeEdit.create({
+    data: {
+      order_item_id: o4Item.id,
+      crop_image_url: 'https://placehold.co/300x300/png?text=Requested+Design',
+      description_text: '이 그림처럼 레터링해 주세요',
+      sort_order: 0,
+    },
+  });
 
   // ── o5: PICKED_UP (리뷰 미작성 → hasReviewableItem=true) ──
   const o5Picked = new Date(now.getTime() - 5 * day);

--- a/prisma/seed/reviews.ts
+++ b/prisma/seed/reviews.ts
@@ -19,7 +19,7 @@ export async function seedReviews(
   const [p1] = ctx.stores.products;
   const orderItemId = ctx.orders.o4OrderItemId;
 
-  await prisma.review.create({
+  const review = await prisma.review.create({
     data: {
       order_item_id: orderItemId,
       account_id: user1.id,
@@ -45,4 +45,12 @@ export async function seedReviews(
       },
     },
   });
+
+  // 홈 제작 후기 쇼케이스의 likeCount 표시 검증용 좋아요 1건(user2)
+  const user2 = ctx.users[1];
+  if (user2) {
+    await prisma.reviewLike.create({
+      data: { review_id: review.id, account_id: user2.id },
+    });
+  }
 }

--- a/src/features/product/constants/product-home.constants.ts
+++ b/src/features/product/constants/product-home.constants.ts
@@ -3,3 +3,6 @@ export const DEFAULT_POPULAR_CAKES_LIMIT = 3;
 
 /** popularCakes 최대 카드 수. figma 명세 "최대 3개 케이크 노출" 계약의 상한. */
 export const MAX_POPULAR_CAKES_LIMIT = 3;
+
+/** customCakeShowcase 기본 카드 수(figma 시안 인디케이터 5개 기준). */
+export const DEFAULT_SHOWCASE_LIMIT = 5;

--- a/src/features/product/dto/inputs/custom-cake-showcase.input.ts
+++ b/src/features/product/dto/inputs/custom-cake-showcase.input.ts
@@ -1,0 +1,9 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class CustomCakeShowcaseInput {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  limit?: number;
+}

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -1,6 +1,9 @@
 extend type Query {
   """홈 '상황별 인기 케이크' 섹션(배너 1건 + 인기 케이크 카드). 비로그인 접근 가능."""
   popularCakes(input: PopularCakesInput): PopularCakesResult!
+
+  """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기(좋아요순). 없으면 빈 배열. 비로그인 접근 가능."""
+  customCakeShowcase(input: CustomCakeShowcaseInput): [CustomCakeShowcaseItem!]!
 }
 
 input PopularCakesInput {
@@ -43,6 +46,28 @@ type HomeBanner {
   linkStoreId: ID
   """linkType=CATEGORY일 때 카테고리 ID(FE 카테고리 자동선택 이동)."""
   linkCategoryId: ID
+}
+
+"""홈 '다른 사람들은 이렇게 만들었어요' 제작 후기 카드 목록."""
+input CustomCakeShowcaseInput {
+  limit: Int = 5
+}
+
+"""제작 후기 카드. Before(요청 디자인)/After(완성 사진)가 모두 있는 리뷰만 노출."""
+type CustomCakeShowcaseItem {
+  """후기 보러가기(reviewDetail) 이동용."""
+  reviewId: ID!
+  """좋아요순 순위(1부터)."""
+  rank: Int!
+  """작성자 닉네임. 탈퇴 작성자는 null(FE 익명 표기)."""
+  authorNickname: String
+  """리뷰 본문. 없으면 null."""
+  reviewText: String
+  likeCount: Int!
+  """사용자가 요청한 디자인 이미지(주문 커스텀 자유편집 크롭)."""
+  beforeImageUrl: String!
+  """실제 완성된 케이크 이미지(리뷰 첫 이미지)."""
+  afterImageUrl: String!
 }
 
 """인기 케이크 카드(지역명·매장명·케이크명·가격·할인율)."""

--- a/src/features/product/repositories/product-review.repository.ts
+++ b/src/features/product/repositories/product-review.repository.ts
@@ -155,6 +155,95 @@ export class ProductReviewRepository {
     }));
   }
 
+  /**
+   * 홈 제작 후기 쇼케이스 후보 id(전체기간 좋아요순 desc, 동률이면 id desc).
+   *
+   * Before(주문 커스텀 자유편집 크롭)/After(리뷰 이미지)가 모두 있는 리뷰만
+   * 후보로 삼는다 — 대비 연출이 섹션의 본질이라 한쪽 없는 카드는 제외(정책 확정).
+   * soft-delete 좋아요 제외 집계 정렬이라 raw SQL(리뷰 목록 좋아요순과 동일 패턴).
+   */
+  async listShowcaseReviewIdsByLikes(
+    limit: number,
+  ): Promise<{ id: bigint; likeCount: number }[]> {
+    const rows = await this.prisma.$queryRaw<
+      { id: bigint; like_count: bigint }[]
+    >(Prisma.sql`
+      SELECT r.id AS id, COUNT(l.id) AS like_count
+      FROM review r
+      JOIN product p
+        ON p.id = r.product_id AND p.is_active = 1 AND p.deleted_at IS NULL
+      JOIN store s
+        ON s.id = p.store_id AND s.is_active = 1 AND s.deleted_at IS NULL
+      LEFT JOIN review_like l
+        ON l.review_id = r.id AND l.deleted_at IS NULL
+      WHERE r.deleted_at IS NULL
+        AND EXISTS (
+          SELECT 1 FROM review_media m
+          WHERE m.review_id = r.id
+            AND m.deleted_at IS NULL
+            AND m.media_type = 'IMAGE'
+        )
+        AND EXISTS (
+          SELECT 1 FROM order_item_custom_free_edit fe
+          WHERE fe.order_item_id = r.order_item_id AND fe.deleted_at IS NULL
+        )
+      GROUP BY r.id
+      ORDER BY like_count DESC, r.id DESC
+      LIMIT ${limit}
+    `);
+    return rows.map((row) => ({
+      id: row.id,
+      likeCount: Number(row.like_count),
+    }));
+  }
+
+  /** 쇼케이스 id 페이지의 본문 row 일괄 조회(정렬은 service에서 id 순서로 복원). */
+  async findShowcaseReviewRowsByIds(reviewIds: bigint[]): Promise<
+    {
+      id: bigint;
+      content: string | null;
+      account: {
+        user_profile: { nickname: string; deleted_at: Date | null } | null;
+      };
+      media: { media_url: string }[];
+      order_item: {
+        free_edits: { crop_image_url: string }[];
+      };
+    }[]
+  > {
+    if (reviewIds.length === 0) return [];
+    return this.prisma.review.findMany({
+      where: { id: { in: reviewIds }, deleted_at: null },
+      select: {
+        id: true,
+        content: true,
+        account: {
+          // soft-delete extension은 nested relation에 deleted_at을 주입하지 않으므로
+          // deleted_at을 함께 읽어 탈퇴 작성자 닉네임은 매퍼에서 익명화한다
+          select: {
+            user_profile: { select: { nickname: true, deleted_at: true } },
+          },
+        },
+        media: {
+          where: { deleted_at: null, media_type: 'IMAGE' },
+          orderBy: { sort_order: 'asc' },
+          take: 1,
+          select: { media_url: true },
+        },
+        order_item: {
+          select: {
+            free_edits: {
+              where: { deleted_at: null },
+              orderBy: { sort_order: 'asc' },
+              take: 1,
+              select: { crop_image_url: true },
+            },
+          },
+        },
+      },
+    });
+  }
+
   /** 상품 활성 리뷰 수(photoOnly=true면 사진 리뷰 수). */
   async countProductReviews(args: {
     productId: bigint;

--- a/src/features/product/resolvers/product-home-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.spec.ts
@@ -1,11 +1,17 @@
 import type { PrismaClient } from '@prisma/client';
 
+import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductHomeQueryResolver } from '@/features/product/resolvers/product-home-query.resolver';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
-import { createProduct, createStore } from '@/test/factories';
+import {
+  createOrderItem,
+  createProduct,
+  createReview,
+  createStore,
+} from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
 /**
@@ -22,6 +28,7 @@ describe('ProductHome Query Resolver (real DB)', () => {
         ProductHomeQueryResolver,
         ProductHomeService,
         ProductRepository,
+        ProductReviewRepository,
       ],
     });
     resolver = module.get(ProductHomeQueryResolver);
@@ -45,5 +52,36 @@ describe('ProductHome Query Resolver (real DB)', () => {
 
     expect(result.items.map((i) => i.name)).toEqual(['인기 케이크']);
     expect(result.banner).toBeNull();
+  });
+
+  it('customCakeShowcase: 서비스에 위임해 제작 후기 목록을 반환한다', async () => {
+    const orderItem = await createOrderItem(prisma);
+    await prisma.orderItemCustomFreeEdit.create({
+      data: {
+        order_item_id: orderItem.id,
+        crop_image_url: 'https://img/before.png',
+        description_text: '요청 디자인',
+      },
+    });
+    const review = await createReview(prisma, {
+      order_item_id: orderItem.id,
+      content: '제작 후기',
+    });
+    await prisma.reviewMedia.create({
+      data: {
+        review_id: review.id,
+        media_type: 'IMAGE',
+        media_url: 'https://img/after.png',
+      },
+    });
+
+    const result = await resolver.customCakeShowcase();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      reviewText: '제작 후기',
+      beforeImageUrl: 'https://img/before.png',
+      afterImageUrl: 'https://img/after.png',
+    });
   });
 });

--- a/src/features/product/resolvers/product-home-query.resolver.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.ts
@@ -1,8 +1,12 @@
 import { Args, Query, Resolver } from '@nestjs/graphql';
 
+import { CustomCakeShowcaseInput } from '@/features/product/dto/inputs/custom-cake-showcase.input';
 import { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
-import type { PopularCakesResult } from '@/features/product/types/product-home-output.type';
+import type {
+  CustomCakeShowcaseItem,
+  PopularCakesResult,
+} from '@/features/product/types/product-home-output.type';
 
 /**
  * 홈 화면 섹션 조회 resolver. 개인화 필드가 없는 public query(인증 불필요).
@@ -16,5 +20,12 @@ export class ProductHomeQueryResolver {
     @Args('input') input?: PopularCakesInput,
   ): Promise<PopularCakesResult> {
     return this.service.popularCakes(input);
+  }
+
+  @Query('customCakeShowcase')
+  customCakeShowcase(
+    @Args('input') input?: CustomCakeShowcaseInput,
+  ): Promise<CustomCakeShowcaseItem[]> {
+    return this.service.customCakeShowcase(input);
   }
 }

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient, Product, Store } from '@prisma/client';
 
+import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
@@ -10,7 +11,9 @@ import {
   createOrder,
   createOrderItem,
   createProduct,
+  createReview,
   createStore,
+  createUserProfile,
   linkProductCategory,
 } from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
@@ -21,7 +24,7 @@ describe('ProductHomeService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [ProductHomeService, ProductRepository],
+      providers: [ProductHomeService, ProductRepository, ProductReviewRepository],
     });
     service = module.get(ProductHomeService);
     prisma = p;
@@ -371,6 +374,208 @@ describe('ProductHomeService (real DB)', () => {
       const result = await service.popularCakes();
 
       expect(result.banner?.imageUrl).toBe('https://img/first.png');
+    });
+  });
+
+  describe('customCakeShowcase', () => {
+    /**
+     * Before(주문 커스텀 크롭)/After(리뷰 이미지)가 모두 있는 쇼케이스 후보 리뷰 생성.
+     * storeId를 주면 해당 매장 소속으로 만든다.
+     */
+    async function makeShowcaseReview(args?: {
+      storeId?: bigint;
+      nickname?: string;
+      content?: string;
+      before?: boolean;
+      after?: boolean;
+    }): Promise<bigint> {
+      const orderItem = await createOrderItem(
+        prisma,
+        args?.storeId !== undefined ? { store_id: args.storeId } : {},
+      );
+      if (args?.before !== false) {
+        await prisma.orderItemCustomFreeEdit.create({
+          data: {
+            order_item_id: orderItem.id,
+            crop_image_url: `https://img/before-${orderItem.id}.png`,
+            description_text: '요청 디자인',
+          },
+        });
+      }
+      const review = await createReview(prisma, {
+        order_item_id: orderItem.id,
+        content: args?.content ?? '후기 본문',
+      });
+      if (args?.after !== false) {
+        await prisma.reviewMedia.create({
+          data: {
+            review_id: review.id,
+            media_type: 'IMAGE',
+            media_url: `https://img/after-${review.id}.png`,
+          },
+        });
+      }
+      if (args?.nickname) {
+        const order = await prisma.order.findUniqueOrThrow({
+          where: { id: orderItem.order_id },
+        });
+        await createUserProfile(prisma, {
+          account_id: order.account_id,
+          nickname: args.nickname,
+        });
+      }
+      return review.id;
+    }
+
+    /** 유효 좋아요 n건 생성. */
+    async function likeReview(reviewId: bigint, count: number): Promise<void> {
+      for (let i = 0; i < count; i += 1) {
+        const account = await createAccount(prisma, { account_type: 'USER' });
+        await prisma.reviewLike.create({
+          data: { review_id: reviewId, account_id: account.id },
+        });
+      }
+    }
+
+    it('좋아요순으로 정렬하고 rank·likeCount를 매긴다(soft-delete 좋아요 미집계)', async () => {
+      const top = await makeShowcaseReview({ content: '1위 후기' });
+      const second = await makeShowcaseReview({ content: '2위 후기' });
+      await likeReview(top, 3);
+      await likeReview(second, 1);
+      // soft-delete된 좋아요는 집계에서 제외되어야 한다
+      const ghost = await createAccount(prisma, { account_type: 'USER' });
+      await prisma.reviewLike.create({
+        data: {
+          review_id: second,
+          account_id: ghost.id,
+          deleted_at: new Date(),
+        },
+      });
+
+      const result = await service.customCakeShowcase();
+
+      expect(result.map((i) => i.reviewText)).toEqual(['1위 후기', '2위 후기']);
+      expect(result.map((i) => i.rank)).toEqual([1, 2]);
+      expect(result.map((i) => i.likeCount)).toEqual([3, 1]);
+    });
+
+    it('Before(커스텀 크롭) 또는 After(리뷰 이미지)가 없는 리뷰는 제외한다', async () => {
+      await makeShowcaseReview({ content: '페어 완성 후기' });
+      await makeShowcaseReview({ content: 'before 없음', before: false });
+      await makeShowcaseReview({ content: 'after 없음', after: false });
+
+      const result = await service.customCakeShowcase();
+
+      expect(result.map((i) => i.reviewText)).toEqual(['페어 완성 후기']);
+    });
+
+    it('VIDEO만 있는 리뷰는 제외하고, IMAGE가 있으면 IMAGE를 After로 쓴다', async () => {
+      const review = await makeShowcaseReview({
+        content: '비디오+이미지',
+        after: false,
+      });
+      await prisma.reviewMedia.create({
+        data: {
+          review_id: review,
+          media_type: 'VIDEO',
+          media_url: 'https://img/video.mp4',
+          sort_order: 0,
+        },
+      });
+      await prisma.reviewMedia.create({
+        data: {
+          review_id: review,
+          media_type: 'IMAGE',
+          media_url: 'https://img/real-after.png',
+          sort_order: 1,
+        },
+      });
+      await makeShowcaseReview({ content: '비디오만', after: false }).then(
+        (id) =>
+          prisma.reviewMedia.create({
+            data: {
+              review_id: id,
+              media_type: 'VIDEO',
+              media_url: 'https://img/only-video.mp4',
+            },
+          }),
+      );
+
+      const result = await service.customCakeShowcase();
+
+      expect(result.map((i) => i.reviewText)).toEqual(['비디오+이미지']);
+      expect(result[0].afterImageUrl).toBe('https://img/real-after.png');
+    });
+
+    it('비활성 매장의 리뷰는 제외한다', async () => {
+      const inactiveStore = await createStore(prisma, { is_active: false });
+      await makeShowcaseReview({
+        storeId: inactiveStore.id,
+        content: '비활성 매장 후기',
+      });
+
+      await expect(service.customCakeShowcase()).resolves.toEqual([]);
+    });
+
+    it('작성자 닉네임을 매핑하고, 탈퇴 작성자는 null로 익명화한다', async () => {
+      const active = await makeShowcaseReview({
+        nickname: '곰돌이빵',
+        content: '활성 작성자',
+      });
+      await likeReview(active, 1);
+      const withdrawnReview = await makeShowcaseReview({
+        nickname: '탈퇴자',
+        content: '탈퇴 작성자',
+      });
+      const row = await prisma.review.findUniqueOrThrow({
+        where: { id: withdrawnReview },
+      });
+      await prisma.userProfile.update({
+        where: { account_id: row.account_id },
+        data: { deleted_at: new Date() },
+      });
+
+      const result = await service.customCakeShowcase();
+
+      expect(result.map((i) => i.authorNickname)).toEqual(['곰돌이빵', null]);
+    });
+
+    it('limit만큼 자르고, 후기가 없으면 빈 배열을 반환한다', async () => {
+      await expect(service.customCakeShowcase()).resolves.toEqual([]);
+
+      await makeShowcaseReview();
+      await makeShowcaseReview();
+      await makeShowcaseReview();
+
+      const limited = await service.customCakeShowcase({ limit: 2 });
+      expect(limited).toHaveLength(2);
+    });
+
+    it('beforeImageUrl은 sort_order가 앞선 커스텀 크롭을 사용한다', async () => {
+      const review = await makeShowcaseReview({ before: false });
+      const row = await prisma.review.findUniqueOrThrow({
+        where: { id: review },
+      });
+      await prisma.orderItemCustomFreeEdit.create({
+        data: {
+          order_item_id: row.order_item_id,
+          crop_image_url: 'https://img/second-crop.png',
+          description_text: '두 번째',
+          sort_order: 1,
+        },
+      });
+      await prisma.orderItemCustomFreeEdit.create({
+        data: {
+          order_item_id: row.order_item_id,
+          crop_image_url: 'https://img/first-crop.png',
+          description_text: '첫 번째',
+          sort_order: 0,
+        },
+      });
+
+      const result = await service.customCakeShowcase();
+
+      expect(result[0].beforeImageUrl).toBe('https://img/first-crop.png');
     });
   });
 });

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -3,15 +3,21 @@ import { Injectable } from '@nestjs/common';
 import { parseId } from '@/common/utils/id-parser';
 import {
   DEFAULT_POPULAR_CAKES_LIMIT,
+  DEFAULT_SHOWCASE_LIMIT,
   MAX_POPULAR_CAKES_LIMIT,
 } from '@/features/product/constants/product-home.constants';
+import type { CustomCakeShowcaseInput } from '@/features/product/dto/inputs/custom-cake-showcase.input';
 import type { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import {
   toHomeBanner,
   toPopularCake,
 } from '@/features/product/services/product-home-mappers.helper';
-import type { PopularCakesResult } from '@/features/product/types/product-home-output.type';
+import type {
+  CustomCakeShowcaseItem,
+  PopularCakesResult,
+} from '@/features/product/types/product-home-output.type';
 import {
   DEFAULT_GLOBAL_RATING_PRIOR,
   popularityScore,
@@ -23,7 +29,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class ProductHomeService {
-  constructor(private readonly repo: ProductRepository) {}
+  constructor(
+    private readonly repo: ProductRepository,
+    private readonly reviewRepo: ProductReviewRepository,
+  ) {}
 
   /**
    * 홈 '상황별 인기 케이크' 섹션. 인기 매장과 동일 산식(최근 주문·찜·베이지안 평점)을
@@ -89,5 +98,48 @@ export class ProductHomeService {
       .map((entry, idx) => toPopularCake(entry.candidate, idx + 1));
 
     return { banner: bannerOutput, items, rankedAt };
+  }
+
+  /**
+   * 홈 '다른 사람들은 이렇게 만들었어요' 제작 후기(전체기간 좋아요순).
+   * Before(주문 커스텀 크롭)/After(리뷰 첫 이미지)가 모두 있는 리뷰만 후보.
+   * 데이터가 없으면 빈 배열(FE가 빈 상태 문구 처리).
+   */
+  async customCakeShowcase(
+    input?: CustomCakeShowcaseInput,
+  ): Promise<CustomCakeShowcaseItem[]> {
+    const limit = input?.limit ?? DEFAULT_SHOWCASE_LIMIT;
+    const ranked = await this.reviewRepo.listShowcaseReviewIdsByLikes(limit);
+    if (ranked.length === 0) return [];
+
+    const rows = await this.reviewRepo.findShowcaseReviewRowsByIds(
+      ranked.map((r) => r.id),
+    );
+    const rowById = new Map(rows.map((row) => [row.id.toString(), row]));
+
+    const items: CustomCakeShowcaseItem[] = [];
+    for (const entry of ranked) {
+      const row = rowById.get(entry.id.toString());
+      const beforeImageUrl = row?.order_item.free_edits[0]?.crop_image_url;
+      const afterImageUrl = row?.media[0]?.media_url;
+      // 후보 SQL이 존재를 보장하지만, 조회 사이의 삭제 경합에 대비해 한 번 더 방어
+      if (!row || !beforeImageUrl || !afterImageUrl) continue;
+
+      items.push({
+        reviewId: row.id.toString(),
+        rank: items.length + 1,
+        // 탈퇴(soft-delete) 작성자는 닉네임을 노출하지 않는다(익명화 정책)
+        authorNickname:
+          row.account.user_profile &&
+          row.account.user_profile.deleted_at === null
+            ? row.account.user_profile.nickname
+            : null,
+        reviewText: row.content,
+        likeCount: entry.likeCount,
+        beforeImageUrl,
+        afterImageUrl,
+      });
+    }
+    return items;
   }
 }

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -31,3 +31,13 @@ export interface PopularCakesResult {
   items: PopularCake[];
   rankedAt: Date;
 }
+
+export interface CustomCakeShowcaseItem {
+  reviewId: string;
+  rank: number;
+  authorNickname: string | null;
+  reviewText: string | null;
+  likeCount: number;
+  beforeImageUrl: string;
+  afterImageUrl: string;
+}


### PR DESCRIPTION
## 개요

홈 화면(figma `.figma/home` 명세) 작업 3/5 — "다른 사람들은 이렇게 만들었어요" 섹션 API. #178 #179 후속.

> 스펙: "사용자가 요청한 디자인 이미지와 실제 완성된 케이크 이미지를 나란히 표시 / 정보 표시 (ranking,username,reviewtext,likecount) / 후기 데이터가 없을 경우 빈 상태 문구 표시"

## 변경점

- **SDL** `product-home.graphql`에 `customCakeShowcase(input): [CustomCakeShowcaseItem!]!` 추가
- **Before** = 리뷰가 달린 주문 아이템의 커스텀 자유편집 크롭(`OrderItemCustomFreeEdit.crop_image_url`, sort_order 1순위), **After** = 리뷰 첫 IMAGE 미디어. **둘 다 있는 리뷰만 후보** (대비 연출이 섹션의 본질 — 정책 확정 사항)
- **전체기간 유효 좋아요순**(동률 시 id desc) 상위 N(기본 5 — figma 인디케이터 기준, `@Max(20)`). soft-delete 좋아요 제외 정렬이라 기존 리뷰 좋아요순과 동일한 raw SQL 패턴
- 활성 상품·매장 리뷰만 노출, 탈퇴 작성자 닉네임 null 익명화(기존 규칙 재사용)
- 시드 보강: o4 주문 아이템에 커스텀 크롭 + 리뷰 좋아요 1건(로컬 쇼케이스 동작)

## 테스트

- `product-home.service.spec.ts`에 8건 추가: 좋아요순·rank·likeCount(soft-delete 미집계) / before·after 누락 제외 / VIDEO만 제외·IMAGE 선택 / 비활성 매장 제외 / 탈퇴 익명화 / limit·빈 배열 / 크롭 sort_order
- resolver 통합 1건
- 스택 전체 `yarn validate` 통과