### PR TITLE
feat(product): 홈 랜덤 케이크 조회(randomCakes)

### DIFF
--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -2,16 +2,18 @@ import { Global, Module } from '@nestjs/common';
 
 import { ClockService } from '@/common/providers/clock.service';
 import { IdGenerator } from '@/common/providers/id-generator.service';
+import { RandomService } from '@/common/providers/random.service';
 
 /**
  * 전역 공통 provider를 묶는 모듈.
  *
  * - ClockService: 현재 시각 추상화 (테스트 주입용)
  * - IdGenerator: UUID 등 식별자 생성 추상화 (테스트 주입용)
+ * - RandomService: 난수 추상화 (테스트 주입용)
  */
 @Global()
 @Module({
-  providers: [ClockService, IdGenerator],
-  exports: [ClockService, IdGenerator],
+  providers: [ClockService, IdGenerator, RandomService],
+  exports: [ClockService, IdGenerator, RandomService],
 })
 export class CommonModule {}

--- a/src/common/providers/random.service.spec.ts
+++ b/src/common/providers/random.service.spec.ts
@@ -1,0 +1,56 @@
+import { RandomService } from '@/common/providers/random.service';
+
+describe('RandomService', () => {
+  let service: RandomService;
+
+  beforeEach(() => {
+    service = new RandomService();
+  });
+
+  it('random은 [0, 1) 범위 값을 반환한다', () => {
+    for (let i = 0; i < 100; i += 1) {
+      const value = service.random();
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  it('int는 [0, max) 정수를 반환한다', () => {
+    for (let i = 0; i < 100; i += 1) {
+      const value = service.int(5);
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(5);
+    }
+  });
+
+  describe('sample', () => {
+    it('요청 개수만큼 중복 없이 추출한다', () => {
+      const items = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      const picked = service.sample(items, 4);
+
+      expect(picked).toHaveLength(4);
+      expect(new Set(picked).size).toBe(4);
+      for (const value of picked) {
+        expect(items).toContain(value);
+      }
+    });
+
+    it('개수가 풀보다 크면 전량을 반환하고 원본을 변경하지 않는다', () => {
+      const items = [1, 2, 3];
+
+      const picked = service.sample(items, 10);
+
+      expect([...picked].sort()).toEqual([1, 2, 3]);
+      expect(items).toEqual([1, 2, 3]);
+    });
+
+    it('주입된 난수에 따라 결정적으로 추출한다', () => {
+      // random()이 항상 0이면 앞에서부터 순서대로 뽑힌다
+      jest.spyOn(service, 'random').mockReturnValue(0);
+
+      expect(service.sample([10, 20, 30, 40], 2)).toEqual([10, 20]);
+    });
+  });
+});

--- a/src/common/providers/random.service.ts
+++ b/src/common/providers/random.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * 난수를 반환하는 서비스.
+ *
+ * 테스트에서 결정적 난수를 주입할 수 있도록 `Math.random()` 직접 호출을 대체한다
+ * (ClockService와 동일한 통제 패턴).
+ */
+@Injectable()
+export class RandomService {
+  /** [0, 1) 난수. */
+  random(): number {
+    return Math.random();
+  }
+
+  /** [0, maxExclusive) 정수 난수. */
+  int(maxExclusive: number): number {
+    return Math.floor(this.random() * maxExclusive);
+  }
+
+  /**
+   * 배열에서 최대 count개를 비복원 무작위 추출한다(부분 Fisher–Yates).
+   * 원본 배열은 변경하지 않는다.
+   */
+  sample<T>(items: readonly T[], count: number): T[] {
+    const pool = [...items];
+    const n = Math.min(count, pool.length);
+    for (let i = 0; i < n; i += 1) {
+      const j = i + this.int(pool.length - i);
+      [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+    return pool.slice(0, n);
+  }
+}

--- a/src/features/product/constants/product-home.constants.ts
+++ b/src/features/product/constants/product-home.constants.ts
@@ -6,3 +6,6 @@ export const MAX_POPULAR_CAKES_LIMIT = 3;
 
 /** customCakeShowcase 기본 카드 수(figma 시안 인디케이터 5개 기준). */
 export const DEFAULT_SHOWCASE_LIMIT = 5;
+
+/** randomCakes 기본 이미지 수(3열 그리드 9개 단위. figma 명세 기준). */
+export const DEFAULT_RANDOM_CAKES_LIMIT = 9;

--- a/src/features/product/dto/inputs/random-cakes.input.ts
+++ b/src/features/product/dto/inputs/random-cakes.input.ts
@@ -1,0 +1,14 @@
+import { IsInt, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class RandomCakesInput {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(30)
+  limit?: number;
+}

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -4,6 +4,28 @@ extend type Query {
 
   """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기(좋아요순). 없으면 빈 배열. 비로그인 접근 가능."""
   customCakeShowcase(input: CustomCakeShowcaseInput): [CustomCakeShowcaseItem!]!
+
+  """홈 '렌덤 케이크 둘러보기' 그리드(호출마다 무작위 재추출). 비로그인 접근 가능."""
+  randomCakes(input: RandomCakesInput): RandomCakesResult!
+}
+
+input RandomCakesInput {
+  """EVENT 카테고리 ID. 비우면 '전체' 칩(필터 미적용)."""
+  categoryId: ID
+  """이미지 수(3열 그리드 9개 단위 — figma 명세 기준)."""
+  limit: Int = 9
+}
+
+"""랜덤 케이크 그리드. '새로보기 1/3' 페이지 카운트는 FE 로컬 상태(서버 무관)."""
+type RandomCakesResult {
+  items: [RandomCake!]!
+}
+
+"""랜덤 케이크 그리드 셀(클릭 시 케이크 상세 이동)."""
+type RandomCake {
+  id: ID!
+  """대표 이미지(sort_order 최소)."""
+  thumbnailUrl: String!
 }
 
 input PopularCakesInput {

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1182,7 +1182,12 @@ export class ProductRepository {
                 some: {
                   category_id: categoryId,
                   deleted_at: null,
-                  category: { is_active: true, deleted_at: null },
+                  // 홈 칩은 EVENT 카테고리만 — 랭킹(findActiveCakesForRanking)과 동일 정책
+                  category: {
+                    is_active: true,
+                    deleted_at: null,
+                    category_type: 'EVENT',
+                  },
                 },
               },
             }

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1164,6 +1164,57 @@ export class ProductRepository {
   }
 
   /**
+   * 랜덤 케이크 후보 id 풀. 활성 상품(+활성 매장) 중 활성 이미지 보유분만
+   * (그리드 셀이 이미지라 썸네일 없는 상품은 후보에서 제외).
+   * id만 조회해 풀 규모 부담을 줄인다 — 상품 수 급증 시 샘플링 방식 개선 여지.
+   */
+  async listRandomCakeCandidateIds(categoryId?: bigint): Promise<bigint[]> {
+    const rows = await this.prisma.product.findMany({
+      where: {
+        is_active: true,
+        deleted_at: null,
+        store: { is_active: true, deleted_at: null },
+        images: { some: { deleted_at: null } },
+        // 0n도 유효한 인자(parseId("0")=0n) → undefined로만 분기한다.
+        ...(categoryId !== undefined
+          ? {
+              product_categories: {
+                some: {
+                  category_id: categoryId,
+                  deleted_at: null,
+                  category: { is_active: true, deleted_at: null },
+                },
+              },
+            }
+          : {}),
+      },
+      select: { id: true },
+      // 셔플 전 풀 순서를 고정해 주입 난수 기준 결정적 추출을 보장한다
+      orderBy: { id: 'asc' },
+    });
+    return rows.map((row) => row.id);
+  }
+
+  /** 랜덤 케이크 셀 데이터(대표 이미지 1장). 반환 순서는 보장하지 않는다. */
+  async findRandomCakeRows(
+    productIds: bigint[],
+  ): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
+    if (productIds.length === 0) return [];
+    return this.prisma.product.findMany({
+      where: { id: { in: productIds }, deleted_at: null },
+      select: {
+        id: true,
+        images: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+          take: 1,
+          select: { image_url: true },
+        },
+      },
+    });
+  }
+
+  /**
    * 전역 카테고리 목록(홈 칩·카테고리 진입 화면). 활성만.
    * category_type asc → sort_order asc → id asc.
    */

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1206,7 +1206,13 @@ export class ProductRepository {
   ): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
     if (productIds.length === 0) return [];
     return this.prisma.product.findMany({
-      where: { id: { in: productIds }, deleted_at: null },
+      where: {
+        id: { in: productIds },
+        // 후보 추출과 재조회 사이에 비활성화된 상품/매장이 노출되지 않게 재검증
+        is_active: true,
+        deleted_at: null,
+        store: { is_active: true, deleted_at: null },
+      },
       select: {
         id: true,
         images: {

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1201,17 +1201,33 @@ export class ProductRepository {
   }
 
   /** 랜덤 케이크 셀 데이터(대표 이미지 1장). 반환 순서는 보장하지 않는다. */
-  async findRandomCakeRows(
-    productIds: bigint[],
-  ): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
-    if (productIds.length === 0) return [];
+  async findRandomCakeRows(args: {
+    productIds: bigint[];
+    categoryId?: bigint;
+  }): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
+    if (args.productIds.length === 0) return [];
     return this.prisma.product.findMany({
       where: {
-        id: { in: productIds },
-        // 후보 추출과 재조회 사이에 비활성화된 상품/매장이 노출되지 않게 재검증
+        id: { in: args.productIds },
+        // 후보 추출과 재조회 사이에 비활성화·카테고리 해제된 상품이 노출되지 않게 재검증
         is_active: true,
         deleted_at: null,
         store: { is_active: true, deleted_at: null },
+        ...(args.categoryId !== undefined
+          ? {
+              product_categories: {
+                some: {
+                  category_id: args.categoryId,
+                  deleted_at: null,
+                  category: {
+                    is_active: true,
+                    deleted_at: null,
+                    category_type: 'EVENT',
+                  },
+                },
+              },
+            }
+          : {}),
       },
       select: {
         id: true,

--- a/src/features/product/resolvers/product-home-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.spec.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '@prisma/client';
 
+import { RandomService } from '@/common/providers/random.service';
 import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductHomeQueryResolver } from '@/features/product/resolvers/product-home-query.resolver';
@@ -29,6 +30,7 @@ describe('ProductHome Query Resolver (real DB)', () => {
         ProductHomeService,
         ProductRepository,
         ProductReviewRepository,
+        RandomService,
       ],
     });
     resolver = module.get(ProductHomeQueryResolver);
@@ -83,5 +85,19 @@ describe('ProductHome Query Resolver (real DB)', () => {
       beforeImageUrl: 'https://img/before.png',
       afterImageUrl: 'https://img/after.png',
     });
+  });
+
+  it('randomCakes: 서비스에 위임해 랜덤 그리드를 반환한다', async () => {
+    const store = await createStore(prisma);
+    const cake = await createProduct(prisma, { store_id: store.id });
+    await prisma.productImage.create({
+      data: { product_id: cake.id, image_url: 'https://img/grid.png' },
+    });
+
+    const result = await resolver.randomCakes();
+
+    expect(result.items).toEqual([
+      { id: cake.id.toString(), thumbnailUrl: 'https://img/grid.png' },
+    ]);
   });
 });

--- a/src/features/product/resolvers/product-home-query.resolver.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.ts
@@ -2,10 +2,12 @@ import { Args, Query, Resolver } from '@nestjs/graphql';
 
 import { CustomCakeShowcaseInput } from '@/features/product/dto/inputs/custom-cake-showcase.input';
 import { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import { RandomCakesInput } from '@/features/product/dto/inputs/random-cakes.input';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
 import type {
   CustomCakeShowcaseItem,
   PopularCakesResult,
+  RandomCakesResult,
 } from '@/features/product/types/product-home-output.type';
 
 /**
@@ -27,5 +29,12 @@ export class ProductHomeQueryResolver {
     @Args('input') input?: CustomCakeShowcaseInput,
   ): Promise<CustomCakeShowcaseItem[]> {
     return this.service.customCakeShowcase(input);
+  }
+
+  @Query('randomCakes')
+  randomCakes(
+    @Args('input') input?: RandomCakesInput,
+  ): Promise<RandomCakesResult> {
+    return this.service.randomCakes(input);
   }
 }

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -634,6 +634,25 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.items.map((i) => i.id)).toEqual([inCategory.id.toString()]);
     });
 
+    it('EVENT가 아닌 카테고리 id가 오면 빈 결과를 반환한다(홈 칩과 동일 정책)', async () => {
+      const store = await createStore(prisma);
+      const style = await createCategory(prisma, {
+        category_type: 'STYLE',
+        name: '포토',
+      });
+      const [cake] = await makeCakesWithImage(store, 1);
+      await linkProductCategory(prisma, {
+        productId: cake.id,
+        categoryId: style.id,
+      });
+
+      const result = await service.randomCakes({
+        categoryId: style.id.toString(),
+      });
+
+      expect(result.items).toEqual([]);
+    });
+
     it('이미지 없는 상품·비활성 상품·비활성 매장 상품은 후보에서 제외한다', async () => {
       const store = await createStore(prisma);
       await createProduct(prisma, { store_id: store.id }); // 이미지 없음

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient, Product, Store } from '@prisma/client';
 
+import { RandomService } from '@/common/providers/random.service';
 import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
@@ -24,7 +25,7 @@ describe('ProductHomeService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [ProductHomeService, ProductRepository, ProductReviewRepository],
+      providers: [ProductHomeService, ProductRepository, ProductReviewRepository, RandomService],
     });
     service = module.get(ProductHomeService);
     prisma = p;
@@ -576,6 +577,110 @@ describe('ProductHomeService (real DB)', () => {
       const result = await service.customCakeShowcase();
 
       expect(result[0].beforeImageUrl).toBe('https://img/first-crop.png');
+    });
+  });
+
+  describe('randomCakes', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    /** 대표 이미지가 있는 활성 케이크 n개 생성. */
+    async function makeCakesWithImage(
+      store: Store,
+      count: number,
+    ): Promise<Product[]> {
+      const cakes: Product[] = [];
+      for (let i = 0; i < count; i += 1) {
+        const cake = await createProduct(prisma, { store_id: store.id });
+        await prisma.productImage.create({
+          data: {
+            product_id: cake.id,
+            image_url: `https://img/random-${cake.id}.png`,
+          },
+        });
+        cakes.push(cake);
+      }
+      return cakes;
+    }
+
+    it('기본 9개를 중복 없이 반환하고 썸네일을 매핑한다', async () => {
+      const store = await createStore(prisma);
+      await makeCakesWithImage(store, 12);
+
+      const result = await service.randomCakes();
+
+      expect(result.items).toHaveLength(9);
+      expect(new Set(result.items.map((i) => i.id)).size).toBe(9);
+      for (const item of result.items) {
+        expect(item.thumbnailUrl).toBe(`https://img/random-${item.id}.png`);
+      }
+    });
+
+    it('categoryId 지정 시 해당 카테고리 케이크만 추출한다', async () => {
+      const store = await createStore(prisma);
+      const birthday = await createCategory(prisma, { name: '생일' });
+      const [inCategory] = await makeCakesWithImage(store, 1);
+      await makeCakesWithImage(store, 3);
+      await linkProductCategory(prisma, {
+        productId: inCategory.id,
+        categoryId: birthday.id,
+      });
+
+      const result = await service.randomCakes({
+        categoryId: birthday.id.toString(),
+      });
+
+      expect(result.items.map((i) => i.id)).toEqual([inCategory.id.toString()]);
+    });
+
+    it('이미지 없는 상품·비활성 상품·비활성 매장 상품은 후보에서 제외한다', async () => {
+      const store = await createStore(prisma);
+      await createProduct(prisma, { store_id: store.id }); // 이미지 없음
+      const inactive = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: false,
+      });
+      await prisma.productImage.create({
+        data: { product_id: inactive.id, image_url: 'https://img/x.png' },
+      });
+      const inactiveStore = await createStore(prisma, { is_active: false });
+      const cakeInInactiveStore = await createProduct(prisma, {
+        store_id: inactiveStore.id,
+      });
+      await prisma.productImage.create({
+        data: {
+          product_id: cakeInInactiveStore.id,
+          image_url: 'https://img/y.png',
+        },
+      });
+
+      await expect(service.randomCakes()).resolves.toEqual({ items: [] });
+    });
+
+    it('후보가 limit보다 적으면 전량을 반환한다', async () => {
+      const store = await createStore(prisma);
+      await makeCakesWithImage(store, 4);
+
+      const result = await service.randomCakes();
+
+      expect(result.items).toHaveLength(4);
+    });
+
+    it('주입된 난수에 따라 결정적으로 추출한다', async () => {
+      const store = await createStore(prisma);
+      const cakes = await makeCakesWithImage(store, 5);
+      const randomService = (service as unknown as { random: RandomService })
+        .random;
+      // random()=0이면 부분 셔플이 항등이 되어 id asc 앞에서부터 뽑힌다
+      jest.spyOn(randomService, 'random').mockReturnValue(0);
+
+      const result = await service.randomCakes({ limit: 2 });
+
+      expect(result.items.map((i) => i.id)).toEqual([
+        cakes[0].id.toString(),
+        cakes[1].id.toString(),
+      ]);
     });
   });
 });

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -634,6 +634,17 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.items.map((i) => i.id)).toEqual([inCategory.id.toString()]);
     });
 
+    it('categoryId가 명시적 null이면 필터 없음으로 처리한다', async () => {
+      const store = await createStore(prisma);
+      await makeCakesWithImage(store, 2);
+
+      const result = await service.randomCakes({
+        categoryId: null as unknown as undefined,
+      });
+
+      expect(result.items).toHaveLength(2);
+    });
+
     it('EVENT가 아닌 카테고리 id가 오면 빈 결과를 반환한다(홈 칩과 동일 정책)', async () => {
       const store = await createStore(prisma);
       const style = await createCategory(prisma, {

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -1,13 +1,16 @@
 import { Injectable } from '@nestjs/common';
 
+import { RandomService } from '@/common/providers/random.service';
 import { parseId } from '@/common/utils/id-parser';
 import {
   DEFAULT_POPULAR_CAKES_LIMIT,
+  DEFAULT_RANDOM_CAKES_LIMIT,
   DEFAULT_SHOWCASE_LIMIT,
   MAX_POPULAR_CAKES_LIMIT,
 } from '@/features/product/constants/product-home.constants';
 import type { CustomCakeShowcaseInput } from '@/features/product/dto/inputs/custom-cake-showcase.input';
 import type { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import type { RandomCakesInput } from '@/features/product/dto/inputs/random-cakes.input';
 import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import {
@@ -17,6 +20,7 @@ import {
 import type {
   CustomCakeShowcaseItem,
   PopularCakesResult,
+  RandomCakesResult,
 } from '@/features/product/types/product-home-output.type';
 import {
   DEFAULT_GLOBAL_RATING_PRIOR,
@@ -32,6 +36,7 @@ export class ProductHomeService {
   constructor(
     private readonly repo: ProductRepository,
     private readonly reviewRepo: ProductReviewRepository,
+    private readonly random: RandomService,
   ) {}
 
   /**
@@ -141,5 +146,33 @@ export class ProductHomeService {
       });
     }
     return items;
+  }
+
+  /**
+   * 홈 '렌덤 케이크 둘러보기'. 호출마다 후보 풀에서 무작위 재추출한다
+   * (호출 간 중복 허용 — '새로보기 1/3' 카운트는 FE 로컬 상태, 정책 확정 사항).
+   */
+  async randomCakes(input?: RandomCakesInput): Promise<RandomCakesResult> {
+    const limit = input?.limit ?? DEFAULT_RANDOM_CAKES_LIMIT;
+    const categoryId =
+      input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
+
+    const candidateIds = await this.repo.listRandomCakeCandidateIds(categoryId);
+    if (candidateIds.length === 0) return { items: [] };
+
+    const pickedIds = this.random.sample(candidateIds, limit);
+    const rows = await this.repo.findRandomCakeRows(pickedIds);
+    const rowById = new Map(rows.map((row) => [row.id.toString(), row]));
+
+    // 추출 순서를 유지해 그리드 배치도 무작위가 되게 한다
+    const items = pickedIds.flatMap((id) => {
+      const row = rowById.get(id.toString());
+      const thumbnailUrl = row?.images[0]?.image_url;
+      // 후보 조회가 이미지 보유를 보장하지만, 조회 사이의 삭제 경합에 대비해 방어
+      if (!thumbnailUrl) return [];
+      return [{ id: id.toString(), thumbnailUrl }];
+    });
+
+    return { items };
   }
 }

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -51,7 +51,8 @@ export class ProductHomeService {
       MAX_POPULAR_CAKES_LIMIT,
     );
     const categoryId =
-      input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
+      // GraphQL nullable 필드는 명시적 null도 허용 → null/undefined 모두 '필터 없음'
+      input?.categoryId != null ? parseId(input.categoryId) : undefined;
     const regionIds = input?.regionIds?.map((id) => parseId(id));
 
     const rankedAt = new Date();
@@ -155,13 +156,17 @@ export class ProductHomeService {
   async randomCakes(input?: RandomCakesInput): Promise<RandomCakesResult> {
     const limit = input?.limit ?? DEFAULT_RANDOM_CAKES_LIMIT;
     const categoryId =
-      input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
+      // GraphQL nullable 필드는 명시적 null도 허용 → null/undefined 모두 '필터 없음'
+      input?.categoryId != null ? parseId(input.categoryId) : undefined;
 
     const candidateIds = await this.repo.listRandomCakeCandidateIds(categoryId);
     if (candidateIds.length === 0) return { items: [] };
 
     const pickedIds = this.random.sample(candidateIds, limit);
-    const rows = await this.repo.findRandomCakeRows(pickedIds);
+    const rows = await this.repo.findRandomCakeRows({
+      productIds: pickedIds,
+      categoryId,
+    });
     const rowById = new Map(rows.map((row) => [row.id.toString(), row]));
 
     // 추출 순서를 유지해 그리드 배치도 무작위가 되게 한다

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -32,6 +32,15 @@ export interface PopularCakesResult {
   rankedAt: Date;
 }
 
+export interface RandomCake {
+  id: string;
+  thumbnailUrl: string;
+}
+
+export interface RandomCakesResult {
+  items: RandomCake[];
+}
+
 export interface CustomCakeShowcaseItem {
   reviewId: string;
   rank: number;


### PR DESCRIPTION
## 개요

홈 화면(figma `.figma/home` 명세) 작업 4/5 — "렌덤 케이크 둘러보기" 섹션 API. #178 #179 #180 후속.

> 스펙: "랜덤 케이크 데이터 API호출 및 이미지 그리드 렌더링 / 랜덤 케이크 이미지로 3열 그리드로 노출 (이미지는 9개 단위로 표시) / 새로 보기 — 현재 선택된 카테고리 기준으로 랜덤 케이크 이미지 재조회 / 페이지 카운트 변경 1/3→2/3→3/3"

## 변경점

- **SDL** `product-home.graphql`에 `randomCakes(input): RandomCakesResult!` 추가 (categoryId 옵션 — EVENT 칩과 동일 사용, limit 기본 9)
- **호출마다 후보 풀에서 무작위 재추출**(호출 간 중복 허용) — '새로보기 1/3' 페이지 카운트는 FE 로컬 상태로 확정 (figma 명세 외 정책 결정, 스펙의 순환 UX는 FE 재호출로 충족)
- 후보: 활성 상품(+활성 매장) 중 활성 이미지 보유분만(그리드 셀이 이미지). 반환은 productId+썸네일 최소형(클릭 시 `productDetail` 이동)
- **`common/providers/RandomService` 신규**(ClockService 동일 통제 패턴): 부분 Fisher–Yates 비복원 샘플링, 테스트에서 난수 주입으로 결정성 확보

## 테스트

- `product-home.service.spec.ts`에 5건 추가: 기본 9개·무중복·썸네일 매핑 / 카테고리 필터 / 이미지 없음·비활성 상품·비활성 매장 제외 / 부족 시 전량 / 주입 난수 결정성
- `random.service.spec.ts` 단위 5건, resolver 통합 1건
- 스택 전체 `yarn validate` 통과