### PR TITLE
feat(store): 오늘 픽업 가능 매장 조회(todayPickupStores)

### DIFF
--- a/src/features/product/dto/inputs/random-cakes.input.ts
+++ b/src/features/product/dto/inputs/random-cakes.input.ts
@@ -1,4 +1,11 @@
-import { IsInt, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 export class RandomCakesInput {
   @IsOptional()

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1,9 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {
-  type BannerLinkType,
-  type CategoryType,
-  Prisma,
-} from '@prisma/client';
+import { type BannerLinkType, type CategoryType, Prisma } from '@prisma/client';
 
 import { RANKING_VALID_ORDER_STATUSES } from '@/features/store';
 import { PrismaService } from '@/prisma';

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -25,7 +25,12 @@ describe('ProductHomeService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [ProductHomeService, ProductRepository, ProductReviewRepository, RandomService],
+      providers: [
+        ProductHomeService,
+        ProductRepository,
+        ProductReviewRepository,
+        RandomService,
+      ],
     });
     service = module.get(ProductHomeService);
     prisma = p;

--- a/src/features/store/dto/inputs/today-pickup-stores.input.ts
+++ b/src/features/store/dto/inputs/today-pickup-stores.input.ts
@@ -1,0 +1,26 @@
+import {
+  IsArray,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class TodayPickupStoresInput {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  regionIds?: string[];
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  offset?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number;
+}

--- a/src/features/store/repositories/store.repository.ts
+++ b/src/features/store/repositories/store.repository.ts
@@ -13,6 +13,16 @@ export interface StoreCandidateRow {
   address_city: string | null;
   address_neighborhood: string | null;
   region: { name: string } | null;
+  pickup_slot_interval_minutes: number;
+  min_lead_time_minutes: number;
+}
+
+/** 특정 요일의 매장 영업시간 row(오늘 픽업 슬롯 산출용). */
+export interface StoreTodayBusinessHourRow {
+  store_id: bigint;
+  is_closed: boolean;
+  open_time: Date | null;
+  close_time: Date | null;
 }
 
 export interface StoreReviewStat {
@@ -61,8 +71,93 @@ export class StoreRepository {
         address_city: true,
         address_neighborhood: true,
         region: { select: { name: true } },
+        pickup_slot_interval_minutes: true,
+        min_lead_time_minutes: true,
       },
     });
+  }
+
+  /** 특정 요일(0=일~6=토)의 매장별 영업시간. */
+  async findBusinessHoursByWeekday(
+    storeIds: bigint[],
+    dayOfWeek: number,
+  ): Promise<StoreTodayBusinessHourRow[]> {
+    if (storeIds.length === 0) return [];
+    return this.prisma.storeBusinessHour.findMany({
+      where: {
+        store_id: { in: storeIds },
+        day_of_week: dayOfWeek,
+        deleted_at: null,
+      },
+      select: {
+        store_id: true,
+        is_closed: true,
+        open_time: true,
+        close_time: true,
+      },
+    });
+  }
+
+  /** 특정 날짜(@db.Date, UTC 자정 표현)에 특별휴무인 매장 id 집합. */
+  async findSpecialClosureStoreIds(
+    storeIds: bigint[],
+    date: Date,
+  ): Promise<Set<string>> {
+    if (storeIds.length === 0) return new Set();
+    const rows = await this.prisma.storeSpecialClosure.findMany({
+      where: {
+        store_id: { in: storeIds },
+        closure_date: date,
+        deleted_at: null,
+      },
+      select: { store_id: true },
+    });
+    return new Set(rows.map((r) => r.store_id.toString()));
+  }
+
+  /** 특정 날짜의 매장별 일일 capacity(레코드 없으면 무제한 취급은 호출부 책임). */
+  async findDailyCapacities(
+    storeIds: bigint[],
+    date: Date,
+  ): Promise<Map<bigint, number>> {
+    if (storeIds.length === 0) return new Map();
+    const rows = await this.prisma.storeDailyCapacity.findMany({
+      where: {
+        store_id: { in: storeIds },
+        capacity_date: date,
+        deleted_at: null,
+      },
+      select: { store_id: true, capacity: true },
+    });
+    return new Map(rows.map((r) => [r.store_id, r.capacity]));
+  }
+
+  /**
+   * 픽업 시각이 [rangeStart, rangeEnd)인 매장별 유효 주문 수(주문 단위 distinct).
+   * capacity 소진 판정용 — CANCELED·soft-delete 주문은 제외한다.
+   */
+  async countPickupOrdersInRange(
+    storeIds: bigint[],
+    rangeStart: Date,
+    rangeEnd: Date,
+  ): Promise<Map<bigint, number>> {
+    if (storeIds.length === 0) return new Map();
+    const rows = await this.prisma.$queryRaw<
+      { store_id: bigint; order_count: bigint }[]
+    >(Prisma.sql`
+      SELECT oi.store_id AS store_id, COUNT(DISTINCT oi.order_id) AS order_count
+      FROM order_item oi
+      JOIN \`order\` o
+        ON o.id = oi.order_id
+        AND o.deleted_at IS NULL
+        AND o.status <> 'CANCELED'
+        AND o.pickup_at >= ${rangeStart}
+        AND o.pickup_at < ${rangeEnd}
+      WHERE oi.store_id IN (${Prisma.join(storeIds)})
+        AND oi.deleted_at IS NULL
+      GROUP BY oi.store_id
+    `);
+    return new Map(rows.map((r) => [r.store_id, Number(r.order_count)]));
   }
 
   /** 활성 매장 존재 검증(찜 등). */

--- a/src/features/store/resolvers/store-today-pickup-query.resolver.spec.ts
+++ b/src/features/store/resolvers/store-today-pickup-query.resolver.spec.ts
@@ -1,0 +1,75 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
+import { StoreRepository } from '@/features/store/repositories/store.repository';
+import { StoreTodayPickupQueryResolver } from '@/features/store/resolvers/store-today-pickup-query.resolver';
+import { StoreListingService } from '@/features/store/services/store-listing.service';
+import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+// 2026-08-19(수) 16:00 KST 고정
+const NOW = new Date('2026-08-19T07:00:00.000Z');
+const TODAY_WEEKDAY = new Date(Date.UTC(2026, 7, 19)).getUTCDay();
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 통합 경로 검증.
+ * 슬롯/휴무/capacity 분기 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('StoreTodayPickup Query Resolver (real DB)', () => {
+  let resolver: StoreTodayPickupQueryResolver;
+  let clock: ClockService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        StoreTodayPickupQueryResolver,
+        StoreTodayPickupService,
+        StoreListingService,
+        StoreRepository,
+        StoreWishlistRepository,
+        ClockService,
+      ],
+    });
+    resolver = module.get(StoreTodayPickupQueryResolver);
+    clock = module.get(ClockService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    jest.spyOn(clock, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('todayPickupStores: 서비스에 위임해 오늘 픽업 가능 매장을 반환한다', async () => {
+    const store = await createStore(prisma, { store_name: '오늘영업매장' });
+    await prisma.storeBusinessHour.create({
+      data: {
+        store_id: store.id,
+        day_of_week: TODAY_WEEKDAY,
+        is_closed: false,
+        open_time: new Date(Date.UTC(1970, 0, 1, 10, 0, 0)),
+        close_time: new Date(Date.UTC(1970, 0, 1, 20, 0, 0)),
+      },
+    });
+
+    const result = await resolver.todayPickupStores(undefined);
+
+    expect(result.items.map((i) => i.storeName)).toEqual(['오늘영업매장']);
+    expect(result.items[0].slots.length).toBeGreaterThan(0);
+    expect(result.asOf).toEqual(NOW);
+  });
+});

--- a/src/features/store/resolvers/store-today-pickup-query.resolver.ts
+++ b/src/features/store/resolvers/store-today-pickup-query.resolver.ts
@@ -1,0 +1,31 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { TodayPickupStoresInput } from '@/features/store/dto/inputs/today-pickup-stores.input';
+import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
+import type { TodayPickupStoreConnection } from '@/features/store/types/store-today-pickup-output.type';
+import {
+  CurrentUser,
+  OptionalJwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+/**
+ * 오늘 픽업 가능 매장 조회 resolver. 비로그인도 접근 가능한 public query.
+ * 옵셔널 인증으로 로그인 시에만 isWishlisted를 채운다.
+ */
+@Resolver('Query')
+export class StoreTodayPickupQueryResolver {
+  constructor(private readonly service: StoreTodayPickupService) {}
+
+  @Query('todayPickupStores')
+  @UseGuards(OptionalJwtAuthGuard)
+  todayPickupStores(
+    @CurrentUser() user: JwtUser | undefined,
+    @Args('input', { nullable: true }) input?: TodayPickupStoresInput,
+  ): Promise<TodayPickupStoreConnection> {
+    const accountId = user ? parseAccountId(user) : undefined;
+    return this.service.todayPickupStores(input, accountId);
+  }
+}

--- a/src/features/store/services/store-listing.service.ts
+++ b/src/features/store/services/store-listing.service.ts
@@ -8,7 +8,10 @@ import {
 } from '@/features/store/constants/store-ranking.constants';
 import type { PopularStoresInput } from '@/features/store/dto/inputs/popular-stores.input';
 import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
-import { StoreRepository } from '@/features/store/repositories/store.repository';
+import {
+  StoreRepository,
+  type StoreCandidateRow,
+} from '@/features/store/repositories/store.repository';
 import { toPopularStore } from '@/features/store/services/store-mappers.helper';
 import {
   popularityScore,
@@ -18,6 +21,13 @@ import type { PopularStoreConnection } from '@/features/store/types/store-output
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** 점수화·정렬이 끝난 랭킹 항목. */
+export interface ScoredStore {
+  candidate: StoreCandidateRow;
+  metrics: StoreMetrics;
+  score: number;
+}
+
 @Injectable()
 export class StoreListingService {
   constructor(
@@ -26,24 +36,17 @@ export class StoreListingService {
   ) {}
 
   /**
-   * 인기 매장 리스트. 후보 매장의 주문·찜·평점을 실시간 집계해 점수화·정렬한 뒤
-   * 페이지를 잘라 대표 이미지를 채운다.
+   * 활성 매장 후보의 주문·찜·평점을 실시간 집계해 점수화·정렬한다.
+   * popularStores와 todayPickupStores가 동일 랭킹 정책을 공유한다.
    *
    * 실시간 집계는 매장 규모가 커지면 캐시/배치(스냅샷)로 최적화할 여지가 있다.
    */
-  async popularStores(
-    input?: PopularStoresInput,
-    accountId?: bigint,
-  ): Promise<PopularStoreConnection> {
-    const offset = input?.offset ?? 0;
-    const limit = input?.limit ?? DEFAULT_POPULAR_STORES_LIMIT;
-    const regionIds = input?.regionIds?.map((id) => parseId(id));
-
-    const rankedAt = new Date();
+  async rankActiveStores(
+    regionIds: bigint[] | undefined,
+    rankedAt: Date,
+  ): Promise<ScoredStore[]> {
     const candidates = await this.repo.findActiveStoresForRanking(regionIds);
-    if (candidates.length === 0) {
-      return { items: [], totalCount: 0, hasMore: false, rankedAt };
-    }
+    if (candidates.length === 0) return [];
 
     const storeIds = candidates.map((c) => c.id);
     const since = new Date(
@@ -78,6 +81,25 @@ export class StoreListingService {
       }
       return b.candidate.id > a.candidate.id ? 1 : -1;
     });
+    return scored;
+  }
+
+  /**
+   * 인기 매장 리스트. 랭킹 후 페이지를 잘라 대표 이미지·찜 여부를 채운다.
+   */
+  async popularStores(
+    input?: PopularStoresInput,
+    accountId?: bigint,
+  ): Promise<PopularStoreConnection> {
+    const offset = input?.offset ?? 0;
+    const limit = input?.limit ?? DEFAULT_POPULAR_STORES_LIMIT;
+    const regionIds = input?.regionIds?.map((id) => parseId(id));
+
+    const rankedAt = new Date();
+    const scored = await this.rankActiveStores(regionIds, rankedAt);
+    if (scored.length === 0) {
+      return { items: [], totalCount: 0, hasMore: false, rankedAt };
+    }
 
     const totalCount = scored.length;
     const page = scored.slice(offset, offset + limit);

--- a/src/features/store/services/store-mappers.helper.spec.ts
+++ b/src/features/store/services/store-mappers.helper.spec.ts
@@ -11,6 +11,8 @@ function row(overrides: Partial<StoreCandidateRow>): StoreCandidateRow {
     address_city: null,
     address_neighborhood: null,
     region: null,
+    pickup_slot_interval_minutes: 30,
+    min_lead_time_minutes: 30,
     ...overrides,
   };
 }

--- a/src/features/store/services/store-today-pickup.helper.spec.ts
+++ b/src/features/store/services/store-today-pickup.helper.spec.ts
@@ -1,0 +1,76 @@
+import {
+  buildTodaySlots,
+  timeColumnToMinutes,
+} from '@/features/store/services/store-today-pickup.helper';
+
+describe('store-today-pickup.helper', () => {
+  describe('buildTodaySlots', () => {
+    it('영업시간을 간격대로 잘라 슬롯을 만들고 리드타임 이전은 마감 처리한다', () => {
+      // 14:00~16:00, 30분 간격, 현재 14:20 + 리드 30분 → 14:50 이전 슬롯 마감
+      const slots = buildTodaySlots({
+        openMinutes: 14 * 60,
+        closeMinutes: 16 * 60,
+        intervalMinutes: 30,
+        leadTimeMinutes: 30,
+        nowMinutes: 14 * 60 + 20,
+      });
+
+      expect(slots).toEqual([
+        { time: '14:00', available: false },
+        { time: '14:30', available: false },
+        { time: '15:00', available: true },
+        { time: '15:30', available: true },
+      ]);
+    });
+
+    it('close 시각 자체는 슬롯에 포함하지 않는다(미포함 경계)', () => {
+      const slots = buildTodaySlots({
+        openMinutes: 10 * 60,
+        closeMinutes: 11 * 60,
+        intervalMinutes: 60,
+        leadTimeMinutes: 0,
+        nowMinutes: 0,
+      });
+
+      expect(slots).toEqual([{ time: '10:00', available: true }]);
+    });
+
+    it('간격이 0 이하거나 영업시간이 뒤집힌 경우 빈 배열을 반환한다', () => {
+      const base = {
+        openMinutes: 10 * 60,
+        closeMinutes: 12 * 60,
+        leadTimeMinutes: 0,
+        nowMinutes: 0,
+      };
+
+      expect(buildTodaySlots({ ...base, intervalMinutes: 0 })).toEqual([]);
+      expect(
+        buildTodaySlots({
+          ...base,
+          intervalMinutes: 30,
+          openMinutes: 12 * 60,
+          closeMinutes: 10 * 60,
+        }),
+      ).toEqual([]);
+    });
+
+    it('현재+리드타임이 영업 종료를 넘으면 전 슬롯이 마감된다', () => {
+      const slots = buildTodaySlots({
+        openMinutes: 10 * 60,
+        closeMinutes: 12 * 60,
+        intervalMinutes: 30,
+        leadTimeMinutes: 60,
+        nowMinutes: 11 * 60 + 30,
+      });
+
+      expect(slots.every((slot) => !slot.available)).toBe(true);
+    });
+  });
+
+  describe('timeColumnToMinutes', () => {
+    it('@db.Time 값(UTC 기반)을 자정 경과 분으로 변환한다', () => {
+      expect(timeColumnToMinutes(new Date('1970-01-01T10:30:00Z'))).toBe(630);
+      expect(timeColumnToMinutes(new Date('1970-01-01T00:00:00Z'))).toBe(0);
+    });
+  });
+});

--- a/src/features/store/services/store-today-pickup.helper.ts
+++ b/src/features/store/services/store-today-pickup.helper.ts
@@ -1,0 +1,45 @@
+import { formatMinutesOfDay } from '@/common/utils/kst-time';
+import type { TodayPickupSlot } from '@/features/store/types/store-today-pickup-output.type';
+
+export interface TodaySlotPolicy {
+  /** 영업 시작(자정 경과 분). */
+  openMinutes: number;
+  /** 영업 종료(자정 경과 분, 미포함 — 마지막 슬롯은 close-interval). */
+  closeMinutes: number;
+  /** 슬롯 간격(분). */
+  intervalMinutes: number;
+  /** 최소 리드타임(분). now+lead 이전 슬롯은 마감. */
+  leadTimeMinutes: number;
+  /** 현재 시각(자정 경과 분). */
+  nowMinutes: number;
+}
+
+/**
+ * 오늘 영업시간 [open, close) 를 간격대로 잘라 슬롯을 만든다.
+ * 리드타임(now+lead) 이전 슬롯은 available=false로 표기한다(UI 회색 슬롯).
+ * 슬롯 단위 예약 점유는 capacity가 일(日) 단위 모델이라 표현하지 않는다 —
+ * capacity 소진은 호출부에서 매장 자체를 제외한다(figma 명세 외 정책 결정).
+ */
+export function buildTodaySlots(policy: TodaySlotPolicy): TodayPickupSlot[] {
+  if (
+    policy.intervalMinutes <= 0 ||
+    policy.closeMinutes <= policy.openMinutes
+  ) {
+    return [];
+  }
+  const cutoff = policy.nowMinutes + policy.leadTimeMinutes;
+  const slots: TodayPickupSlot[] = [];
+  for (
+    let t = policy.openMinutes;
+    t < policy.closeMinutes;
+    t += policy.intervalMinutes
+  ) {
+    slots.push({ time: formatMinutesOfDay(t), available: t >= cutoff });
+  }
+  return slots;
+}
+
+/** Prisma @db.Time(0) 값(1970-01-01 UTC 기반)을 자정 경과 분으로 변환. */
+export function timeColumnToMinutes(value: Date): number {
+  return value.getUTCHours() * 60 + value.getUTCMinutes();
+}

--- a/src/features/store/services/store-today-pickup.service.spec.ts
+++ b/src/features/store/services/store-today-pickup.service.spec.ts
@@ -113,6 +113,24 @@ describe('StoreTodayPickupService (real DB)', () => {
       ]);
     });
 
+    it('초가 남은 시각은 다음 분으로 올려 리드타임을 보수적으로 적용한다', async () => {
+      // 16:00:30 KST + 리드 60분 → 17:00 슬롯은 59분 30초밖에 안 남아 마감
+      jest
+        .spyOn(clock, 'now')
+        .mockReturnValue(new Date('2026-08-19T07:00:30.000Z'));
+      const store = await createStore(prisma, { min_lead_time_minutes: 60 });
+      await openToday(store, 16, 18);
+
+      const [item] = (await service.todayPickupStores()).items;
+
+      expect(item.slots).toEqual([
+        { time: '16:00', available: false },
+        { time: '16:30', available: false },
+        { time: '17:00', available: false },
+        { time: '17:30', available: true },
+      ]);
+    });
+
     it('오늘 요일 휴무·영업시간 미설정·이미 영업 종료된 매장은 제외한다', async () => {
       const closedDay = await createStore(prisma, { store_name: '요일휴무' });
       await prisma.storeBusinessHour.create({

--- a/src/features/store/services/store-today-pickup.service.spec.ts
+++ b/src/features/store/services/store-today-pickup.service.spec.ts
@@ -1,0 +1,272 @@
+import type { PrismaClient, Store } from '@prisma/client';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
+import { StoreRepository } from '@/features/store/repositories/store.repository';
+import { StoreListingService } from '@/features/store/services/store-listing.service';
+import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createOrder,
+  createOrderItem,
+  createStore,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+// 2026-08-19(수) 16:00 KST 고정. 요일·자정 경계 계산이 모두 이 시각 기준.
+const NOW = new Date('2026-08-19T07:00:00.000Z');
+const TODAY_WEEKDAY = new Date(Date.UTC(2026, 7, 19)).getUTCDay();
+const TODAY_DATE_ONLY = new Date(Date.UTC(2026, 7, 19));
+/** 오늘 15:00 KST(UTC 06:00) — 픽업 예정 시각으로 사용. */
+const TODAY_PICKUP_AT = new Date('2026-08-19T06:00:00.000Z');
+
+describe('StoreTodayPickupService (real DB)', () => {
+  let service: StoreTodayPickupService;
+  let clock: ClockService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        StoreTodayPickupService,
+        StoreListingService,
+        StoreRepository,
+        StoreWishlistRepository,
+        ClockService,
+      ],
+    });
+    service = module.get(StoreTodayPickupService);
+    clock = module.get(ClockService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    jest.spyOn(clock, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** 오늘 요일 영업시간(HH 기준) 설정. */
+  async function openToday(
+    store: Store,
+    openHour: number,
+    closeHour: number,
+  ): Promise<void> {
+    await prisma.storeBusinessHour.create({
+      data: {
+        store_id: store.id,
+        day_of_week: TODAY_WEEKDAY,
+        is_closed: false,
+        open_time: new Date(Date.UTC(1970, 0, 1, openHour, 0, 0)),
+        close_time: new Date(Date.UTC(1970, 0, 1, closeHour, 0, 0)),
+      },
+    });
+  }
+
+  /** 오늘 픽업 유효 주문 n건 생성. */
+  async function bookToday(store: Store, count: number): Promise<void> {
+    for (let i = 0; i < count; i += 1) {
+      const order = await createOrder(prisma, {
+        status: 'CONFIRMED',
+        pickup_at: TODAY_PICKUP_AT,
+      });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        store_id: store.id,
+      });
+    }
+  }
+
+  describe('todayPickupStores', () => {
+    it('오늘 영업시간 슬롯을 만들고 리드타임 이전 슬롯은 available=false다', async () => {
+      const store = await createStore(prisma, {
+        store_name: '헤즈케이크',
+        min_lead_time_minutes: 60,
+      });
+      await openToday(store, 14, 18); // 14:00~18:00, 현재 16:00 + 60분 → 17:00부터 가용
+
+      const result = await service.todayPickupStores();
+
+      expect(result.totalCount).toBe(1);
+      expect(result.asOf).toEqual(NOW);
+      const [item] = result.items;
+      expect(item.storeName).toBe('헤즈케이크');
+      expect(item.slots).toEqual([
+        { time: '14:00', available: false },
+        { time: '14:30', available: false },
+        { time: '15:00', available: false },
+        { time: '15:30', available: false },
+        { time: '16:00', available: false },
+        { time: '16:30', available: false },
+        { time: '17:00', available: true },
+        { time: '17:30', available: true },
+      ]);
+    });
+
+    it('오늘 요일 휴무·영업시간 미설정·이미 영업 종료된 매장은 제외한다', async () => {
+      const closedDay = await createStore(prisma, { store_name: '요일휴무' });
+      await prisma.storeBusinessHour.create({
+        data: {
+          store_id: closedDay.id,
+          day_of_week: TODAY_WEEKDAY,
+          is_closed: true,
+        },
+      });
+      await createStore(prisma, { store_name: '시간미설정' });
+      const ended = await createStore(prisma, { store_name: '영업종료' });
+      await openToday(ended, 9, 12); // 현재 16:00 → 가용 슬롯 없음
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items).toEqual([]);
+      expect(result.totalCount).toBe(0);
+    });
+
+    it('오늘 특별휴무인 매장은 제외한다', async () => {
+      const store = await createStore(prisma, { store_name: '특별휴무' });
+      await openToday(store, 10, 20);
+      await prisma.storeSpecialClosure.create({
+        data: { store_id: store.id, closure_date: TODAY_DATE_ONLY },
+      });
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items).toEqual([]);
+    });
+
+    it('일일 capacity가 소진된 매장은 제외한다(CANCELED 주문 미집계)', async () => {
+      const full = await createStore(prisma, { store_name: '마감매장' });
+      await openToday(full, 10, 20);
+      await prisma.storeDailyCapacity.create({
+        data: {
+          store_id: full.id,
+          capacity_date: TODAY_DATE_ONLY,
+          capacity: 2,
+        },
+      });
+      await bookToday(full, 2);
+
+      const available = await createStore(prisma, { store_name: '여유매장' });
+      await openToday(available, 10, 20);
+      await prisma.storeDailyCapacity.create({
+        data: {
+          store_id: available.id,
+          capacity_date: TODAY_DATE_ONLY,
+          capacity: 2,
+        },
+      });
+      await bookToday(available, 1);
+      // CANCELED 주문은 capacity를 소모하지 않는다
+      const canceled = await createOrder(prisma, {
+        status: 'CANCELED',
+        pickup_at: TODAY_PICKUP_AT,
+      });
+      await createOrderItem(prisma, {
+        order_id: canceled.id,
+        store_id: available.id,
+      });
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items.map((i) => i.storeName)).toEqual(['여유매장']);
+    });
+
+    it('capacity 레코드가 없으면 무제한으로 간주한다', async () => {
+      const store = await createStore(prisma, { store_name: '무제한매장' });
+      await openToday(store, 10, 20);
+      await bookToday(store, 3);
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items.map((i) => i.storeName)).toEqual(['무제한매장']);
+    });
+
+    it('인기 매장 랭킹 순으로 정렬한다(찜 많은 매장 우선)', async () => {
+      const plain = await createStore(prisma, { store_name: '일반매장' });
+      await openToday(plain, 10, 20);
+      const popular = await createStore(prisma, { store_name: '인기매장' });
+      await openToday(popular, 10, 20);
+      for (let i = 0; i < 3; i += 1) {
+        const account = await createAccount(prisma, { account_type: 'USER' });
+        await prisma.storeWishlistItem.create({
+          data: { account_id: account.id, store_id: popular.id },
+        });
+      }
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items.map((i) => i.storeName)).toEqual([
+        '인기매장',
+        '일반매장',
+      ]);
+    });
+
+    it('regionIds 필터와 offset 페이지네이션을 적용한다', async () => {
+      const region = await prisma.region.create({
+        data: { level: 2, name: '청라동', slug: 'test-cheongna' },
+      });
+      const inRegion = await createStore(prisma, {
+        store_name: '청라매장',
+        region_id: region.id,
+      });
+      await openToday(inRegion, 10, 20);
+      const outRegion = await createStore(prisma, { store_name: '타지역매장' });
+      await openToday(outRegion, 10, 20);
+
+      const filtered = await service.todayPickupStores({
+        regionIds: [region.id.toString()],
+      });
+      expect(filtered.items.map((i) => i.storeName)).toEqual(['청라매장']);
+
+      const paged = await service.todayPickupStores({ offset: 1, limit: 1 });
+      expect(paged.totalCount).toBe(2);
+      expect(paged.items).toHaveLength(1);
+      expect(paged.hasMore).toBe(false);
+    });
+
+    it('로그인 사용자의 찜 여부와 매장 카드 정보를 채운다', async () => {
+      const store = await createStore(prisma, {
+        store_name: '찜매장',
+        address_city: '인천',
+        address_neighborhood: '청라동',
+      });
+      await openToday(store, 10, 20);
+      const user = await createAccount(prisma, { account_type: 'USER' });
+      await prisma.storeWishlistItem.create({
+        data: { account_id: user.id, store_id: store.id },
+      });
+
+      const [asUser, asGuest] = [
+        await service.todayPickupStores(undefined, user.id),
+        await service.todayPickupStores(),
+      ];
+
+      expect(asUser.items[0]).toMatchObject({
+        storeName: '찜매장',
+        regionLabel: '인천 청라동',
+        isWishlisted: true,
+      });
+      expect(asGuest.items[0].isWishlisted).toBe(false);
+    });
+
+    it('매장이 없으면 빈 결과를 반환한다', async () => {
+      const result = await service.todayPickupStores();
+
+      expect(result).toMatchObject({
+        items: [],
+        totalCount: 0,
+        hasMore: false,
+      });
+    });
+  });
+});

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -67,7 +67,10 @@ export class StoreTodayPickupService {
     const hourByStore = new Map(
       businessHours.map((h) => [h.store_id.toString(), h]),
     );
-    const nowMinutes = kstMinutesOfDay(asOf);
+    // 분 단위 절삭은 리드타임을 최대 59초 짧게 만들므로, 초가 남으면 다음 분으로 올린다
+    const hasSubMinute =
+      asOf.getUTCSeconds() > 0 || asOf.getUTCMilliseconds() > 0;
+    const nowMinutes = kstMinutesOfDay(asOf) + (hasSubMinute ? 1 : 0);
 
     const open: { entry: ScoredStore; slots: TodayPickupSlot[] }[] = [];
     for (const entry of scored) {

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -1,0 +1,156 @@
+import { Injectable } from '@nestjs/common';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { parseId } from '@/common/utils/id-parser';
+import {
+  kstMidnightUtc,
+  kstMinutesOfDay,
+  toKstYmd,
+} from '@/common/utils/kst-time';
+import { DEFAULT_POPULAR_STORES_LIMIT } from '@/features/store/constants/store-ranking.constants';
+import type { TodayPickupStoresInput } from '@/features/store/dto/inputs/today-pickup-stores.input';
+import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
+import { StoreRepository } from '@/features/store/repositories/store.repository';
+import {
+  StoreListingService,
+  type ScoredStore,
+} from '@/features/store/services/store-listing.service';
+import { buildRegionLabel } from '@/features/store/services/store-mappers.helper';
+import {
+  buildTodaySlots,
+  timeColumnToMinutes,
+} from '@/features/store/services/store-today-pickup.helper';
+import type {
+  TodayPickupSlot,
+  TodayPickupStoreConnection,
+} from '@/features/store/types/store-today-pickup-output.type';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class StoreTodayPickupService {
+  constructor(
+    private readonly repo: StoreRepository,
+    private readonly wishlistRepo: StoreWishlistRepository,
+    private readonly listingService: StoreListingService,
+    private readonly clock: ClockService,
+  ) {}
+
+  /**
+   * 오늘(KST) 픽업 가능 매장 리스트. 인기 매장과 동일 랭킹으로 정렬하되,
+   * 매장별 정책(요일 영업시간·특별휴무·슬롯 간격·리드타임·일일 capacity)을
+   * 모두 반영해 오늘 예약 가능 슬롯이 1개 이상인 매장만 노출한다.
+   */
+  async todayPickupStores(
+    input?: TodayPickupStoresInput,
+    accountId?: bigint,
+  ): Promise<TodayPickupStoreConnection> {
+    const offset = input?.offset ?? 0;
+    const limit = input?.limit ?? DEFAULT_POPULAR_STORES_LIMIT;
+    const regionIds = input?.regionIds?.map((id) => parseId(id));
+
+    const asOf = this.clock.now();
+    const scored = await this.listingService.rankActiveStores(regionIds, asOf);
+    if (scored.length === 0) {
+      return { items: [], totalCount: 0, hasMore: false, asOf };
+    }
+
+    const storeIds = scored.map((s) => s.candidate.id);
+    const { weekday, dateOnlyUtc, dayStartUtc, dayEndUtc } = todayKst(asOf);
+    const [businessHours, closedStoreIds, capacities, bookedCounts] =
+      await Promise.all([
+        this.repo.findBusinessHoursByWeekday(storeIds, weekday),
+        this.repo.findSpecialClosureStoreIds(storeIds, dateOnlyUtc),
+        this.repo.findDailyCapacities(storeIds, dateOnlyUtc),
+        this.repo.countPickupOrdersInRange(storeIds, dayStartUtc, dayEndUtc),
+      ]);
+    const hourByStore = new Map(
+      businessHours.map((h) => [h.store_id.toString(), h]),
+    );
+    const nowMinutes = kstMinutesOfDay(asOf);
+
+    const open: { entry: ScoredStore; slots: TodayPickupSlot[] }[] = [];
+    for (const entry of scored) {
+      const storeId = entry.candidate.id;
+      if (closedStoreIds.has(storeId.toString())) continue;
+
+      const hour = hourByStore.get(storeId.toString());
+      // 영업시간 미설정·휴무 요일이면 오늘 픽업 불가
+      if (!hour || hour.is_closed || !hour.open_time || !hour.close_time) {
+        continue;
+      }
+
+      // capacity 레코드가 없으면 무제한으로 간주(figma 명세 외 정책 결정)
+      const capacity = capacities.get(storeId);
+      const booked = bookedCounts.get(storeId) ?? 0;
+      if (capacity !== undefined && booked >= capacity) continue;
+
+      const slots = buildTodaySlots({
+        openMinutes: timeColumnToMinutes(hour.open_time),
+        closeMinutes: timeColumnToMinutes(hour.close_time),
+        intervalMinutes: entry.candidate.pickup_slot_interval_minutes,
+        leadTimeMinutes: entry.candidate.min_lead_time_minutes,
+        nowMinutes,
+      });
+      if (!slots.some((slot) => slot.available)) continue;
+
+      open.push({ entry, slots });
+    }
+
+    const totalCount = open.length;
+    const page = open.slice(offset, offset + limit);
+    const pageStoreIds = page.map((p) => p.entry.candidate.id);
+    const [imagesByStore, wishlistedIds] = await Promise.all([
+      this.repo.findStoreCakeImages(pageStoreIds),
+      accountId
+        ? this.wishlistRepo.findWishlistedStoreIds({
+            accountId,
+            storeIds: pageStoreIds,
+          })
+        : Promise.resolve(new Set<string>()),
+    ]);
+
+    const items = page.map(({ entry, slots }) => ({
+      id: entry.candidate.id.toString(),
+      storeName: entry.candidate.store_name,
+      // 소수 첫째 자리까지(인기 매장 카드와 동일 표기)
+      ratingAverage: Math.round(entry.metrics.ratingAverage * 10) / 10,
+      reviewCount: entry.metrics.reviewCount,
+      regionLabel: buildRegionLabel(entry.candidate),
+      cakeImageUrls: imagesByStore.get(entry.candidate.id) ?? [],
+      isWishlisted: wishlistedIds.has(entry.candidate.id.toString()),
+      slots,
+    }));
+
+    return {
+      items,
+      totalCount,
+      hasMore: offset + limit < totalCount,
+      asOf,
+    };
+  }
+}
+
+/**
+ * asOf 기준 KST '오늘'의 요일과 날짜 경계.
+ * - dateOnlyUtc: @db.Date 컬럼 비교용(해당 KST 달력일의 UTC 자정 표현).
+ *   seller가 저장한 closure/capacity 날짜도 UTC date 부분으로 기록되는 전제.
+ * - dayStartUtc/dayEndUtc: pickup_at(DateTime) 범위 비교용(KST 자정 경계).
+ */
+function todayKst(asOf: Date): {
+  weekday: number;
+  dateOnlyUtc: Date;
+  dayStartUtc: Date;
+  dayEndUtc: Date;
+} {
+  const { year, month, day } = toKstYmd(asOf);
+  const dateOnlyUtc = new Date(Date.UTC(year, month - 1, day));
+  const dayStartUtc = kstMidnightUtc(year, month, day);
+  const dayEndUtc = new Date(dayStartUtc.getTime() + DAY_MS);
+  return {
+    weekday: dateOnlyUtc.getUTCDay(),
+    dateOnlyUtc,
+    dayStartUtc,
+    dayEndUtc,
+  };
+}

--- a/src/features/store/store-today-pickup.graphql
+++ b/src/features/store/store-today-pickup.graphql
@@ -1,0 +1,43 @@
+extend type Query {
+  """오늘 픽업 가능 매장 리스트(인기순). 오늘 예약 가능 슬롯이 있는 매장만. 비로그인 접근 가능."""
+  todayPickupStores(input: TodayPickupStoresInput): TodayPickupStoreConnection!
+}
+
+input TodayPickupStoresInput {
+  """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
+  regionIds: [ID!]
+  offset: Int = 0
+  limit: Int = 20
+}
+
+type TodayPickupStoreConnection {
+  items: [TodayPickupStore!]!
+  """오늘 픽업 가능한 매장 총수."""
+  totalCount: Int!
+  hasMore: Boolean!
+  """슬롯 산출 기준 시각(서버 조회 시점). 화면의 'N시 기준' 표기에 사용."""
+  asOf: DateTime!
+}
+
+"""오늘 픽업 가능 매장 카드 + 슬롯 그리드."""
+type TodayPickupStore {
+  id: ID!
+  storeName: String!
+  """평균 평점(0.0~5.0, 소수 첫째 자리)."""
+  ratingAverage: Float!
+  reviewCount: Int!
+  """매장 위치 표기(예: 인천 청라동)."""
+  regionLabel: String
+  """대표 케이크 이미지(최대 4장)."""
+  cakeImageUrls: [String!]!
+  """로그인 사용자의 찜 여부(비로그인 시 false)."""
+  isWishlisted: Boolean!
+  """오늘 영업시간 내 슬롯 목록. 리드타임 마감 슬롯은 available=false."""
+  slots: [TodayPickupSlot!]!
+}
+
+"""픽업 슬롯("HH:MM")."""
+type TodayPickupSlot {
+  time: String!
+  available: Boolean!
+}

--- a/src/features/store/store.module.ts
+++ b/src/features/store/store.module.ts
@@ -6,10 +6,12 @@ import { StoreRepository } from '@/features/store/repositories/store.repository'
 import { StoreDetailQueryResolver } from '@/features/store/resolvers/store-detail-query.resolver';
 import { StoreQueryResolver } from '@/features/store/resolvers/store-query.resolver';
 import { StoreReviewQueryResolver } from '@/features/store/resolvers/store-review-query.resolver';
+import { StoreTodayPickupQueryResolver } from '@/features/store/resolvers/store-today-pickup-query.resolver';
 import { StoreWishlistMutationResolver } from '@/features/store/resolvers/store-wishlist-mutation.resolver';
 import { StoreDetailService } from '@/features/store/services/store-detail.service';
 import { StoreListingService } from '@/features/store/services/store-listing.service';
 import { StoreReviewService } from '@/features/store/services/store-review.service';
+import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
 import { StoreWishlistService } from '@/features/store/services/store-wishlist.service';
 
 @Module({
@@ -25,6 +27,8 @@ import { StoreWishlistService } from '@/features/store/services/store-wishlist.s
     StoreWishlistMutationResolver,
     StoreDetailQueryResolver,
     StoreReviewQueryResolver,
+    StoreTodayPickupService,
+    StoreTodayPickupQueryResolver,
   ],
   exports: [StoreRepository],
 })

--- a/src/features/store/types/store-today-pickup-output.type.ts
+++ b/src/features/store/types/store-today-pickup-output.type.ts
@@ -1,0 +1,27 @@
+/**
+ * store-today-pickup resolver 반환용 도메인 출력 타입.
+ * SDL(store-today-pickup.graphql)의 타입과 필드 일치.
+ */
+
+export interface TodayPickupSlot {
+  time: string;
+  available: boolean;
+}
+
+export interface TodayPickupStore {
+  id: string;
+  storeName: string;
+  ratingAverage: number;
+  reviewCount: number;
+  regionLabel: string | null;
+  cakeImageUrls: string[];
+  isWishlisted: boolean;
+  slots: TodayPickupSlot[];
+}
+
+export interface TodayPickupStoreConnection {
+  items: TodayPickupStore[];
+  totalCount: number;
+  hasMore: boolean;
+  asOf: Date;
+}

--- a/src/test/factories/store.factory.ts
+++ b/src/test/factories/store.factory.ts
@@ -19,6 +19,8 @@ export interface StoreOverrides {
   business_hours_text?: string | null;
   access_guide_text?: string | null;
   regular_closure_text?: string | null;
+  pickup_slot_interval_minutes?: number;
+  min_lead_time_minutes?: number;
 }
 
 export async function createStore(
@@ -48,6 +50,9 @@ export async function createStore(
       business_hours_text: overrides.business_hours_text ?? null,
       access_guide_text: overrides.access_guide_text ?? null,
       regular_closure_text: overrides.regular_closure_text ?? null,
+      pickup_slot_interval_minutes:
+        overrides.pickup_slot_interval_minutes ?? 30,
+      min_lead_time_minutes: overrides.min_lead_time_minutes ?? 30,
     },
   });
 }


### PR DESCRIPTION
## 개요

홈 화면(figma `.figma/home` 명세) 작업 5/5 — "오늘 픽업 가능"(TodayPickup_TimeSlot_Entry) 화면 API. #178 #179 #180 #181 후속.

> 스펙/UI: 지역 필터 + '오후 4시 기준' 표기 + 매장 카드(평점·리뷰수·지역·찜·케이크 이미지)와 타임슬롯 그리드(비활성 슬롯 회색)

## 변경점

- **SDL** `store-today-pickup.graphql` 신규: `todayPickupStores(input): TodayPickupStoreConnection!` — `asOf`(조회 시각)로 'N시 기준' 표기 지원
- **매장별 정책 완전 반영**: 오늘(KST) 요일 영업시간(`StoreBusinessHour`) × 매장별 슬롯 간격 × 최소 리드타임 × 특별휴무(`StoreSpecialClosure`) × 일일 capacity(`StoreDailyCapacity`)
  - capacity 소진 판정은 오늘 pickup_at 유효 주문 distinct 집계(CANCELED·soft-delete 제외, raw SQL)
  - **오늘 예약 가능 슬롯 ≥ 1인 매장만 노출**. 리드타임 마감 슬롯은 `available=false`(UI 회색 슬롯 대응)
  - figma 명세 외 정책 결정(커밋 본문·주석 명시): 슬롯 단위 점유는 capacity가 일(日) 단위 모델이라 미표현 — capacity 소진 시 매장 제외 / capacity 레코드 없으면 무제한 간주
- **정렬은 인기 매장 랭킹 재사용**: `StoreListingService.rankActiveStores`로 랭킹 로직 추출(popularStores와 정책 단일화, 동작 불변). regionIds 필터 + offset 페이지네이션
- `isWishlisted`는 `OptionalJwtAuthGuard`(비로그인 false), 시각은 `ClockService` 주입 + 기존 KST 유틸 재사용
- 테스트 팩토리 `createStore`에 픽업 정책 필드 override 추가

## 테스트

- `store-today-pickup.service.spec.ts` (real DB) 9건: 슬롯 생성·리드타임 마감 / 요일휴무·시간미설정·영업종료 제외 / 특별휴무 제외 / capacity 소진 제외(CANCELED 미집계) / 무제한 간주 / 랭킹 정렬 / 지역 필터·offset / isWishlisted·카드 매핑 / 빈 결과
- `store-today-pickup.helper.spec.ts` 순수 단위 5건, resolver 통합 1건
- 스택 전체 `yarn validate` 통과