### PR TITLE
chore: 릴리즈 — 홈 화면 API 5건 (카테고리·인기 케이크·제작 후기·랜덤 케이크·오늘 픽업)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -11,6 +11,7 @@
  */
 import { PrismaClient } from '@prisma/client';
 
+import { seedCategories } from './seed/categories';
 import { seedCustomDrafts } from './seed/custom-drafts';
 import { resetSeedScope } from './seed/idempotent';
 import { seedNotifications } from './seed/notifications';
@@ -39,8 +40,11 @@ async function main(): Promise<void> {
     log('지역 마스터 시드 중...');
     await seedRegions(prisma);
 
+    log('카테고리 마스터 시드 중...');
+    const categories = await seedCategories(prisma);
+
     log('매장 + 상품 시드 중...');
-    const stores = await seedStores(prisma);
+    const stores = await seedStores(prisma, { categories });
 
     log('주문 + 아이템 시드 중...');
     const orders = await seedOrders(prisma, { users, stores });

--- a/prisma/seed/categories.ts
+++ b/prisma/seed/categories.ts
@@ -1,0 +1,79 @@
+/**
+ * 카테고리(Category) 마스터 시드.
+ *
+ * figma Category_Entry 스펙(spec/*.md) 목록을 정본으로 한다.
+ * - 이벤트별 16종 + 스타일별 7종. sort_order는 스펙 나열 순.
+ * - '전체' 칩은 카테고리가 아니라 FE 가상 칩(필터 미적용)이라 시드하지 않는다.
+ * - 카테고리는 영구 마스터이므로 resetSeedScope 정리 대상이 아니다(region과 동일).
+ *   uk(category_type, name) 기준 upsert로 항상 최신 상태로 보정한다.
+ */
+import type { CategoryType, PrismaClient } from '@prisma/client';
+
+const EVENT_CATEGORY_NAMES = [
+  '생일',
+  '돌잔치',
+  '크리스마스',
+  '연인',
+  '우정',
+  '스승의날',
+  '합격/승진',
+  '웨딩',
+  '부모님',
+  '반려동물',
+  '신년',
+  '감사',
+  '개업/오픈',
+  '졸업',
+  '위로/응원',
+  '기타',
+] as const;
+
+const STYLE_CATEGORY_NAMES = [
+  '꽃장식',
+  '돈장식',
+  '입체',
+  '티아라',
+  '포토',
+  '도시락',
+  '그림일기',
+] as const;
+
+export interface SeededCategories {
+  /** `${category_type}:${name}` → id */
+  idByTypeName: Map<string, bigint>;
+}
+
+export async function seedCategories(
+  prisma: PrismaClient,
+): Promise<SeededCategories> {
+  const idByTypeName = new Map<string, bigint>();
+
+  const upsertAll = async (
+    type: CategoryType,
+    names: readonly string[],
+  ): Promise<void> => {
+    for (const [index, name] of names.entries()) {
+      const category = await prisma.category.upsert({
+        where: {
+          category_type_name: { category_type: type, name },
+        },
+        create: {
+          category_type: type,
+          name,
+          sort_order: index,
+        },
+        update: {
+          sort_order: index,
+          is_active: true,
+          deleted_at: null,
+        },
+      });
+      idByTypeName.set(`${type}:${name}`, category.id);
+    }
+  };
+
+  await upsertAll('EVENT', EVENT_CATEGORY_NAMES);
+  await upsertAll('STYLE', STYLE_CATEGORY_NAMES);
+
+  return { idByTypeName };
+}

--- a/prisma/seed/orders.ts
+++ b/prisma/seed/orders.ts
@@ -248,6 +248,16 @@ export async function seedOrders(
       item_subtotal_price: 35000,
     },
   });
+  // o4에는 리뷰가 달리므로(seedReviews) 커스텀 크롭을 함께 둬
+  // 홈 제작 후기 쇼케이스(Before/After 페어)가 로컬에서 동작하게 한다
+  await prisma.orderItemCustomFreeEdit.create({
+    data: {
+      order_item_id: o4Item.id,
+      crop_image_url: 'https://placehold.co/300x300/png?text=Requested+Design',
+      description_text: '이 그림처럼 레터링해 주세요',
+      sort_order: 0,
+    },
+  });
 
   // ── o5: PICKED_UP (리뷰 미작성 → hasReviewableItem=true) ──
   const o5Picked = new Date(now.getTime() - 5 * day);

--- a/prisma/seed/reviews.ts
+++ b/prisma/seed/reviews.ts
@@ -19,7 +19,7 @@ export async function seedReviews(
   const [p1] = ctx.stores.products;
   const orderItemId = ctx.orders.o4OrderItemId;
 
-  await prisma.review.create({
+  const review = await prisma.review.create({
     data: {
       order_item_id: orderItemId,
       account_id: user1.id,
@@ -45,4 +45,12 @@ export async function seedReviews(
       },
     },
   });
+
+  // 홈 제작 후기 쇼케이스의 likeCount 표시 검증용 좋아요 1건(user2)
+  const user2 = ctx.users[1];
+  if (user2) {
+    await prisma.reviewLike.create({
+      data: { review_id: review.id, account_id: user2.id },
+    });
+  }
 }

--- a/prisma/seed/stores.ts
+++ b/prisma/seed/stores.ts
@@ -111,6 +111,20 @@ export async function seedStores(
       is_active: true,
     },
   });
+  // 매장 B 구조화 영업시간: 평일 11~21시, 주말 휴무(텍스트 표기와 일치).
+  // A가 화요일 휴무라, B가 화요일을 커버해 요일과 무관하게 todayPickupStores 확인 가능.
+  await prisma.storeBusinessHour.createMany({
+    data: [0, 1, 2, 3, 4, 5, 6].map((dayOfWeek) => {
+      const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+      return {
+        store_id: storeB.id,
+        day_of_week: dayOfWeek,
+        is_closed: isWeekend,
+        open_time: isWeekend ? null : new Date(Date.UTC(1970, 0, 1, 11, 0)),
+        close_time: isWeekend ? null : new Date(Date.UTC(1970, 0, 1, 21, 0)),
+      };
+    }),
+  });
 
   // 상품
   const p1 = await prisma.product.create({

--- a/prisma/seed/stores.ts
+++ b/prisma/seed/stores.ts
@@ -10,6 +10,7 @@
  */
 import type { PrismaClient, Product, Store } from '@prisma/client';
 
+import type { SeededCategories } from './categories';
 import { SEED_STORE_NAME_PREFIX } from './idempotent';
 
 export interface SeededStores {
@@ -18,7 +19,10 @@ export interface SeededStores {
   optionGroupIds: { p2GroupId: bigint; p2OptionItemId: bigint };
 }
 
-export async function seedStores(prisma: PrismaClient): Promise<SeededStores> {
+export async function seedStores(
+  prisma: PrismaClient,
+  deps: { categories: SeededCategories },
+): Promise<SeededStores> {
   // 매장 region 매핑 (seedRegions 선행 실행 전제). Unchecked 경로라 FK를 직접 지정.
   const gangnam = await prisma.region.findUniqueOrThrow({
     where: { slug: 'sgg-11680' },
@@ -202,6 +206,29 @@ export async function seedStores(prisma: PrismaClient): Promise<SeededStores> {
       regular_price: 10000,
       is_active: false,
     },
+  });
+
+  // 상품 ↔ 카테고리 연결 (홈 화면 섹션들이 로컬에서 동작하도록 이벤트/스타일 배정)
+  const categoryId = (key: string): bigint => {
+    const id = deps.categories.idByTypeName.get(key);
+    if (id === undefined) {
+      throw new Error(`[seed] category not found: ${key}`);
+    }
+    return id;
+  };
+  await prisma.productCategory.createMany({
+    data: [
+      { product_id: p1.id, category_id: categoryId('EVENT:생일') },
+      { product_id: p1.id, category_id: categoryId('STYLE:꽃장식') },
+      { product_id: p2.id, category_id: categoryId('EVENT:생일') },
+      { product_id: p2.id, category_id: categoryId('STYLE:입체') },
+      { product_id: p3.id, category_id: categoryId('EVENT:감사') },
+      { product_id: p3.id, category_id: categoryId('STYLE:도시락') },
+      { product_id: p4.id, category_id: categoryId('EVENT:기타') },
+      // p5(비활성)에도 연결해 활성 필터 검증 데이터로 쓴다
+      { product_id: p5.id, category_id: categoryId('EVENT:생일') },
+    ],
+    skipDuplicates: true,
   });
 
   return {

--- a/prisma/seed/stores.ts
+++ b/prisma/seed/stores.ts
@@ -75,6 +75,19 @@ export async function seedStores(
     },
   });
 
+  // 매장 A 구조화 영업시간: 화요일 정기 휴무(텍스트 표기와 일치), 나머지 09~18시.
+  // todayPickupStores가 구조화 영업시간(StoreBusinessHour) 기준이라 시드에 필수.
+  await prisma.storeBusinessHour.createMany({
+    data: [0, 1, 2, 3, 4, 5, 6].map((dayOfWeek) => ({
+      store_id: storeA.id,
+      day_of_week: dayOfWeek,
+      is_closed: dayOfWeek === 2,
+      open_time: dayOfWeek === 2 ? null : new Date(Date.UTC(1970, 0, 1, 9, 0)),
+      close_time:
+        dayOfWeek === 2 ? null : new Date(Date.UTC(1970, 0, 1, 18, 0)),
+    })),
+  });
+
   // 매장 2: 도넛샵 B
   const sellerB = await prisma.account.create({
     data: {

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -2,16 +2,18 @@ import { Global, Module } from '@nestjs/common';
 
 import { ClockService } from '@/common/providers/clock.service';
 import { IdGenerator } from '@/common/providers/id-generator.service';
+import { RandomService } from '@/common/providers/random.service';
 
 /**
  * 전역 공통 provider를 묶는 모듈.
  *
  * - ClockService: 현재 시각 추상화 (테스트 주입용)
  * - IdGenerator: UUID 등 식별자 생성 추상화 (테스트 주입용)
+ * - RandomService: 난수 추상화 (테스트 주입용)
  */
 @Global()
 @Module({
-  providers: [ClockService, IdGenerator],
-  exports: [ClockService, IdGenerator],
+  providers: [ClockService, IdGenerator, RandomService],
+  exports: [ClockService, IdGenerator, RandomService],
 })
 export class CommonModule {}

--- a/src/common/providers/random.service.spec.ts
+++ b/src/common/providers/random.service.spec.ts
@@ -1,0 +1,56 @@
+import { RandomService } from '@/common/providers/random.service';
+
+describe('RandomService', () => {
+  let service: RandomService;
+
+  beforeEach(() => {
+    service = new RandomService();
+  });
+
+  it('random은 [0, 1) 범위 값을 반환한다', () => {
+    for (let i = 0; i < 100; i += 1) {
+      const value = service.random();
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  it('int는 [0, max) 정수를 반환한다', () => {
+    for (let i = 0; i < 100; i += 1) {
+      const value = service.int(5);
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(5);
+    }
+  });
+
+  describe('sample', () => {
+    it('요청 개수만큼 중복 없이 추출한다', () => {
+      const items = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+      const picked = service.sample(items, 4);
+
+      expect(picked).toHaveLength(4);
+      expect(new Set(picked).size).toBe(4);
+      for (const value of picked) {
+        expect(items).toContain(value);
+      }
+    });
+
+    it('개수가 풀보다 크면 전량을 반환하고 원본을 변경하지 않는다', () => {
+      const items = [1, 2, 3];
+
+      const picked = service.sample(items, 10);
+
+      expect([...picked].sort()).toEqual([1, 2, 3]);
+      expect(items).toEqual([1, 2, 3]);
+    });
+
+    it('주입된 난수에 따라 결정적으로 추출한다', () => {
+      // random()이 항상 0이면 앞에서부터 순서대로 뽑힌다
+      jest.spyOn(service, 'random').mockReturnValue(0);
+
+      expect(service.sample([10, 20, 30, 40], 2)).toEqual([10, 20]);
+    });
+  });
+});

--- a/src/common/providers/random.service.ts
+++ b/src/common/providers/random.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * 난수를 반환하는 서비스.
+ *
+ * 테스트에서 결정적 난수를 주입할 수 있도록 `Math.random()` 직접 호출을 대체한다
+ * (ClockService와 동일한 통제 패턴).
+ */
+@Injectable()
+export class RandomService {
+  /** [0, 1) 난수. */
+  random(): number {
+    return Math.random();
+  }
+
+  /** [0, maxExclusive) 정수 난수. */
+  int(maxExclusive: number): number {
+    return Math.floor(this.random() * maxExclusive);
+  }
+
+  /**
+   * 배열에서 최대 count개를 비복원 무작위 추출한다(부분 Fisher–Yates).
+   * 원본 배열은 변경하지 않는다.
+   */
+  sample<T>(items: readonly T[], count: number): T[] {
+    const pool = [...items];
+    const n = Math.min(count, pool.length);
+    for (let i = 0; i < n; i += 1) {
+      const j = i + this.int(pool.length - i);
+      [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+    return pool.slice(0, n);
+  }
+}

--- a/src/features/product/constants/product-home.constants.ts
+++ b/src/features/product/constants/product-home.constants.ts
@@ -6,3 +6,6 @@ export const MAX_POPULAR_CAKES_LIMIT = 3;
 
 /** customCakeShowcase 기본 카드 수(figma 시안 인디케이터 5개 기준). */
 export const DEFAULT_SHOWCASE_LIMIT = 5;
+
+/** randomCakes 기본 이미지 수(3열 그리드 9개 단위. figma 명세 기준). */
+export const DEFAULT_RANDOM_CAKES_LIMIT = 9;

--- a/src/features/product/constants/product-home.constants.ts
+++ b/src/features/product/constants/product-home.constants.ts
@@ -3,3 +3,6 @@ export const DEFAULT_POPULAR_CAKES_LIMIT = 3;
 
 /** popularCakes 최대 카드 수. figma 명세 "최대 3개 케이크 노출" 계약의 상한. */
 export const MAX_POPULAR_CAKES_LIMIT = 3;
+
+/** customCakeShowcase 기본 카드 수(figma 시안 인디케이터 5개 기준). */
+export const DEFAULT_SHOWCASE_LIMIT = 5;

--- a/src/features/product/constants/product-home.constants.ts
+++ b/src/features/product/constants/product-home.constants.ts
@@ -1,2 +1,5 @@
 /** popularCakes 기본 카드 수(홈 섹션은 최대 3개 노출. figma 명세 기준). */
 export const DEFAULT_POPULAR_CAKES_LIMIT = 3;
+
+/** popularCakes 최대 카드 수. figma 명세 "최대 3개 케이크 노출" 계약의 상한. */
+export const MAX_POPULAR_CAKES_LIMIT = 3;

--- a/src/features/product/constants/product-home.constants.ts
+++ b/src/features/product/constants/product-home.constants.ts
@@ -1,0 +1,2 @@
+/** popularCakes 기본 카드 수(홈 섹션은 최대 3개 노출. figma 명세 기준). */
+export const DEFAULT_POPULAR_CAKES_LIMIT = 3;

--- a/src/features/product/dto/inputs/categories.input.ts
+++ b/src/features/product/dto/inputs/categories.input.ts
@@ -1,0 +1,7 @@
+import { IsIn, IsOptional } from 'class-validator';
+
+export class CategoriesInput {
+  @IsOptional()
+  @IsIn(['EVENT', 'STYLE', 'OTHER'])
+  type?: 'EVENT' | 'STYLE' | 'OTHER';
+}

--- a/src/features/product/dto/inputs/custom-cake-showcase.input.ts
+++ b/src/features/product/dto/inputs/custom-cake-showcase.input.ts
@@ -1,0 +1,9 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class CustomCakeShowcaseInput {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  limit?: number;
+}

--- a/src/features/product/dto/inputs/popular-cakes.input.ts
+++ b/src/features/product/dto/inputs/popular-cakes.input.ts
@@ -23,6 +23,6 @@ export class PopularCakesInput {
   @IsOptional()
   @IsInt()
   @Min(1)
-  @Max(10)
+  @Max(3)
   limit?: number;
 }

--- a/src/features/product/dto/inputs/popular-cakes.input.ts
+++ b/src/features/product/dto/inputs/popular-cakes.input.ts
@@ -1,0 +1,28 @@
+import {
+  IsArray,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class PopularCakesInput {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  regionIds?: string[];
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  limit?: number;
+}

--- a/src/features/product/dto/inputs/random-cakes.input.ts
+++ b/src/features/product/dto/inputs/random-cakes.input.ts
@@ -1,0 +1,14 @@
+import { IsInt, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class RandomCakesInput {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(30)
+  limit?: number;
+}

--- a/src/features/product/dto/inputs/random-cakes.input.ts
+++ b/src/features/product/dto/inputs/random-cakes.input.ts
@@ -1,4 +1,11 @@
-import { IsInt, IsNotEmpty, IsOptional, IsString, Max, Min } from 'class-validator';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 export class RandomCakesInput {
   @IsOptional()

--- a/src/features/product/product-category.graphql
+++ b/src/features/product/product-category.graphql
@@ -1,0 +1,17 @@
+extend type Query {
+  """전역 카테고리 목록(홈 칩·카테고리 진입 화면). type 미지정 시 전체. 비로그인 접근 가능."""
+  categories(input: CategoriesInput): [CategoryItem!]!
+}
+
+input CategoriesInput {
+  """EVENT | STYLE | OTHER. 비우면 전체."""
+  type: CategoryType
+}
+
+"""전역 카테고리 항목. '전체' 칩은 카테고리가 아니라 FE 가상 칩(필터 미적용)이라 포함하지 않는다."""
+type CategoryItem {
+  id: ID!
+  name: String!
+  categoryType: CategoryType!
+  sortOrder: Int!
+}

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -1,0 +1,45 @@
+extend type Query {
+  """홈 '상황별 인기 케이크' 섹션(배너 1건 + 인기 케이크 카드). 비로그인 접근 가능."""
+  popularCakes(input: PopularCakesInput): PopularCakesResult!
+}
+
+input PopularCakesInput {
+  """EVENT 카테고리 ID. 비우면 '전체' 칩(필터 미적용)."""
+  categoryId: ID
+  """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
+  regionIds: [ID!]
+  limit: Int = 3
+}
+
+type PopularCakesResult {
+  """카테고리 대표 배너. 등록된 배너가 없으면 null(FE placeholder 처리)."""
+  banner: HomeBanner
+  items: [PopularCake!]!
+  """랭킹 산출 기준 시각(서버 조회 시점)."""
+  rankedAt: DateTime!
+}
+
+"""홈 카테고리 대표 배너."""
+type HomeBanner {
+  id: ID!
+  imageUrl: String!
+  title: String
+  """클릭 시 FE가 카테고리 자동선택 이동에 사용. 없으면 null."""
+  linkCategoryId: ID
+}
+
+"""인기 케이크 카드(지역명·매장명·케이크명·가격·할인율)."""
+type PopularCake {
+  id: ID!
+  rank: Int!
+  name: String!
+  """대표 이미지(sort_order 최소). 없으면 null."""
+  thumbnailUrl: String
+  storeName: String!
+  """매장 위치 표기(예: 서울 청담동)."""
+  regionLabel: String
+  regularPrice: Int!
+  salePrice: Int
+  """할인율(0~100). salePrice 없으면 0."""
+  discountRate: Int!
+}

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -8,6 +8,7 @@ input PopularCakesInput {
   categoryId: ID
   """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
   regionIds: [ID!]
+  """카드 수(최대 3 — figma 명세 "최대 3개 케이크 노출")."""
   limit: Int = 3
 }
 

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -5,7 +5,7 @@ extend type Query {
   """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기(좋아요순). 없으면 빈 배열. 비로그인 접근 가능."""
   customCakeShowcase(input: CustomCakeShowcaseInput): [CustomCakeShowcaseItem!]!
 
-  """홈 '렌덤 케이크 둘러보기' 그리드(호출마다 무작위 재추출). 비로그인 접근 가능."""
+  """홈 '랜덤 케이크 둘러보기' 그리드(호출마다 무작위 재추출). 비로그인 접근 가능."""
   randomCakes(input: RandomCakesInput): RandomCakesResult!
 }
 

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -20,12 +20,28 @@ type PopularCakesResult {
   rankedAt: DateTime!
 }
 
-"""홈 카테고리 대표 배너."""
+"""배너 클릭 이동 대상 타입."""
+enum HomeBannerLinkType {
+  NONE
+  URL
+  PRODUCT
+  STORE
+  CATEGORY
+}
+
+"""홈 카테고리 대표 배너. linkType에 대응하는 링크 필드 하나만 채워진다."""
 type HomeBanner {
   id: ID!
   imageUrl: String!
   title: String
-  """클릭 시 FE가 카테고리 자동선택 이동에 사용. 없으면 null."""
+  linkType: HomeBannerLinkType!
+  """linkType=URL일 때 이동 URL."""
+  linkUrl: String
+  """linkType=PRODUCT일 때 상품 ID."""
+  linkProductId: ID
+  """linkType=STORE일 때 매장 ID."""
+  linkStoreId: ID
+  """linkType=CATEGORY일 때 카테고리 ID(FE 카테고리 자동선택 이동)."""
   linkCategoryId: ID
 }
 

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -4,6 +4,28 @@ extend type Query {
 
   """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기(좋아요순). 없으면 빈 배열. 비로그인 접근 가능."""
   customCakeShowcase(input: CustomCakeShowcaseInput): [CustomCakeShowcaseItem!]!
+
+  """홈 '렌덤 케이크 둘러보기' 그리드(호출마다 무작위 재추출). 비로그인 접근 가능."""
+  randomCakes(input: RandomCakesInput): RandomCakesResult!
+}
+
+input RandomCakesInput {
+  """EVENT 카테고리 ID. 비우면 '전체' 칩(필터 미적용)."""
+  categoryId: ID
+  """이미지 수(3열 그리드 9개 단위 — figma 명세 기준)."""
+  limit: Int = 9
+}
+
+"""랜덤 케이크 그리드. '새로보기 1/3' 페이지 카운트는 FE 로컬 상태(서버 무관)."""
+type RandomCakesResult {
+  items: [RandomCake!]!
+}
+
+"""랜덤 케이크 그리드 셀(클릭 시 케이크 상세 이동)."""
+type RandomCake {
+  id: ID!
+  """대표 이미지(sort_order 최소)."""
+  thumbnailUrl: String!
 }
 
 input PopularCakesInput {

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -1,6 +1,9 @@
 extend type Query {
   """홈 '상황별 인기 케이크' 섹션(배너 1건 + 인기 케이크 카드). 비로그인 접근 가능."""
   popularCakes(input: PopularCakesInput): PopularCakesResult!
+
+  """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기(좋아요순). 없으면 빈 배열. 비로그인 접근 가능."""
+  customCakeShowcase(input: CustomCakeShowcaseInput): [CustomCakeShowcaseItem!]!
 }
 
 input PopularCakesInput {
@@ -43,6 +46,28 @@ type HomeBanner {
   linkStoreId: ID
   """linkType=CATEGORY일 때 카테고리 ID(FE 카테고리 자동선택 이동)."""
   linkCategoryId: ID
+}
+
+"""홈 '다른 사람들은 이렇게 만들었어요' 제작 후기 카드 목록."""
+input CustomCakeShowcaseInput {
+  limit: Int = 5
+}
+
+"""제작 후기 카드. Before(요청 디자인)/After(완성 사진)가 모두 있는 리뷰만 노출."""
+type CustomCakeShowcaseItem {
+  """후기 보러가기(reviewDetail) 이동용."""
+  reviewId: ID!
+  """좋아요순 순위(1부터)."""
+  rank: Int!
+  """작성자 닉네임. 탈퇴 작성자는 null(FE 익명 표기)."""
+  authorNickname: String
+  """리뷰 본문. 없으면 null."""
+  reviewText: String
+  likeCount: Int!
+  """사용자가 요청한 디자인 이미지(주문 커스텀 자유편집 크롭)."""
+  beforeImageUrl: String!
+  """실제 완성된 케이크 이미지(리뷰 첫 이미지)."""
+  afterImageUrl: String!
 }
 
 """인기 케이크 카드(지역명·매장명·케이크명·가격·할인율)."""

--- a/src/features/product/product.module.ts
+++ b/src/features/product/product.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 
 import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductCategoryQueryResolver } from '@/features/product/resolvers/product-category-query.resolver';
 import { ProductDetailQueryResolver } from '@/features/product/resolvers/product-detail-query.resolver';
 import { ProductReviewQueryResolver } from '@/features/product/resolvers/product-review-query.resolver';
 import { ProductStorefrontQueryResolver } from '@/features/product/resolvers/product-storefront-query.resolver';
+import { ProductCategoryService } from '@/features/product/services/product-category.service';
 import { ProductDetailService } from '@/features/product/services/product-detail.service';
 import { ProductReviewService } from '@/features/product/services/product-review.service';
 import { ProductStorefrontService } from '@/features/product/services/product-storefront.service';
@@ -19,6 +21,8 @@ import { ProductStorefrontService } from '@/features/product/services/product-st
     ProductReviewQueryResolver,
     ProductStorefrontService,
     ProductStorefrontQueryResolver,
+    ProductCategoryService,
+    ProductCategoryQueryResolver,
   ],
   exports: [ProductRepository],
 })

--- a/src/features/product/product.module.ts
+++ b/src/features/product/product.module.ts
@@ -4,10 +4,12 @@ import { ProductReviewRepository } from '@/features/product/repositories/product
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductCategoryQueryResolver } from '@/features/product/resolvers/product-category-query.resolver';
 import { ProductDetailQueryResolver } from '@/features/product/resolvers/product-detail-query.resolver';
+import { ProductHomeQueryResolver } from '@/features/product/resolvers/product-home-query.resolver';
 import { ProductReviewQueryResolver } from '@/features/product/resolvers/product-review-query.resolver';
 import { ProductStorefrontQueryResolver } from '@/features/product/resolvers/product-storefront-query.resolver';
 import { ProductCategoryService } from '@/features/product/services/product-category.service';
 import { ProductDetailService } from '@/features/product/services/product-detail.service';
+import { ProductHomeService } from '@/features/product/services/product-home.service';
 import { ProductReviewService } from '@/features/product/services/product-review.service';
 import { ProductStorefrontService } from '@/features/product/services/product-storefront.service';
 
@@ -23,6 +25,8 @@ import { ProductStorefrontService } from '@/features/product/services/product-st
     ProductStorefrontQueryResolver,
     ProductCategoryService,
     ProductCategoryQueryResolver,
+    ProductHomeService,
+    ProductHomeQueryResolver,
   ],
   exports: [ProductRepository],
 })

--- a/src/features/product/repositories/product-review.repository.ts
+++ b/src/features/product/repositories/product-review.repository.ts
@@ -155,6 +155,95 @@ export class ProductReviewRepository {
     }));
   }
 
+  /**
+   * 홈 제작 후기 쇼케이스 후보 id(전체기간 좋아요순 desc, 동률이면 id desc).
+   *
+   * Before(주문 커스텀 자유편집 크롭)/After(리뷰 이미지)가 모두 있는 리뷰만
+   * 후보로 삼는다 — 대비 연출이 섹션의 본질이라 한쪽 없는 카드는 제외(정책 확정).
+   * soft-delete 좋아요 제외 집계 정렬이라 raw SQL(리뷰 목록 좋아요순과 동일 패턴).
+   */
+  async listShowcaseReviewIdsByLikes(
+    limit: number,
+  ): Promise<{ id: bigint; likeCount: number }[]> {
+    const rows = await this.prisma.$queryRaw<
+      { id: bigint; like_count: bigint }[]
+    >(Prisma.sql`
+      SELECT r.id AS id, COUNT(l.id) AS like_count
+      FROM review r
+      JOIN product p
+        ON p.id = r.product_id AND p.is_active = 1 AND p.deleted_at IS NULL
+      JOIN store s
+        ON s.id = p.store_id AND s.is_active = 1 AND s.deleted_at IS NULL
+      LEFT JOIN review_like l
+        ON l.review_id = r.id AND l.deleted_at IS NULL
+      WHERE r.deleted_at IS NULL
+        AND EXISTS (
+          SELECT 1 FROM review_media m
+          WHERE m.review_id = r.id
+            AND m.deleted_at IS NULL
+            AND m.media_type = 'IMAGE'
+        )
+        AND EXISTS (
+          SELECT 1 FROM order_item_custom_free_edit fe
+          WHERE fe.order_item_id = r.order_item_id AND fe.deleted_at IS NULL
+        )
+      GROUP BY r.id
+      ORDER BY like_count DESC, r.id DESC
+      LIMIT ${limit}
+    `);
+    return rows.map((row) => ({
+      id: row.id,
+      likeCount: Number(row.like_count),
+    }));
+  }
+
+  /** 쇼케이스 id 페이지의 본문 row 일괄 조회(정렬은 service에서 id 순서로 복원). */
+  async findShowcaseReviewRowsByIds(reviewIds: bigint[]): Promise<
+    {
+      id: bigint;
+      content: string | null;
+      account: {
+        user_profile: { nickname: string; deleted_at: Date | null } | null;
+      };
+      media: { media_url: string }[];
+      order_item: {
+        free_edits: { crop_image_url: string }[];
+      };
+    }[]
+  > {
+    if (reviewIds.length === 0) return [];
+    return this.prisma.review.findMany({
+      where: { id: { in: reviewIds }, deleted_at: null },
+      select: {
+        id: true,
+        content: true,
+        account: {
+          // soft-delete extension은 nested relation에 deleted_at을 주입하지 않으므로
+          // deleted_at을 함께 읽어 탈퇴 작성자 닉네임은 매퍼에서 익명화한다
+          select: {
+            user_profile: { select: { nickname: true, deleted_at: true } },
+          },
+        },
+        media: {
+          where: { deleted_at: null, media_type: 'IMAGE' },
+          orderBy: { sort_order: 'asc' },
+          take: 1,
+          select: { media_url: true },
+        },
+        order_item: {
+          select: {
+            free_edits: {
+              where: { deleted_at: null },
+              orderBy: { sort_order: 'asc' },
+              take: 1,
+              select: { crop_image_url: true },
+            },
+          },
+        },
+      },
+    });
+  }
+
   /** 상품 활성 리뷰 수(photoOnly=true면 사진 리뷰 수). */
   async countProductReviews(args: {
     productId: bigint;

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1182,7 +1182,12 @@ export class ProductRepository {
                 some: {
                   category_id: categoryId,
                   deleted_at: null,
-                  category: { is_active: true, deleted_at: null },
+                  // 홈 칩은 EVENT 카테고리만 — 랭킹(findActiveCakesForRanking)과 동일 정책
+                  category: {
+                    is_active: true,
+                    deleted_at: null,
+                    category_type: 'EVENT',
+                  },
                 },
               },
             }

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1164,6 +1164,57 @@ export class ProductRepository {
   }
 
   /**
+   * 랜덤 케이크 후보 id 풀. 활성 상품(+활성 매장) 중 활성 이미지 보유분만
+   * (그리드 셀이 이미지라 썸네일 없는 상품은 후보에서 제외).
+   * id만 조회해 풀 규모 부담을 줄인다 — 상품 수 급증 시 샘플링 방식 개선 여지.
+   */
+  async listRandomCakeCandidateIds(categoryId?: bigint): Promise<bigint[]> {
+    const rows = await this.prisma.product.findMany({
+      where: {
+        is_active: true,
+        deleted_at: null,
+        store: { is_active: true, deleted_at: null },
+        images: { some: { deleted_at: null } },
+        // 0n도 유효한 인자(parseId("0")=0n) → undefined로만 분기한다.
+        ...(categoryId !== undefined
+          ? {
+              product_categories: {
+                some: {
+                  category_id: categoryId,
+                  deleted_at: null,
+                  category: { is_active: true, deleted_at: null },
+                },
+              },
+            }
+          : {}),
+      },
+      select: { id: true },
+      // 셔플 전 풀 순서를 고정해 주입 난수 기준 결정적 추출을 보장한다
+      orderBy: { id: 'asc' },
+    });
+    return rows.map((row) => row.id);
+  }
+
+  /** 랜덤 케이크 셀 데이터(대표 이미지 1장). 반환 순서는 보장하지 않는다. */
+  async findRandomCakeRows(
+    productIds: bigint[],
+  ): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
+    if (productIds.length === 0) return [];
+    return this.prisma.product.findMany({
+      where: { id: { in: productIds }, deleted_at: null },
+      select: {
+        id: true,
+        images: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+          take: 1,
+          select: { image_url: true },
+        },
+      },
+    });
+  }
+
+  /**
    * 전역 카테고리 목록(홈 칩·카테고리 진입 화면). 활성만.
    * category_type asc → sort_order asc → id asc.
    */

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1206,7 +1206,13 @@ export class ProductRepository {
   ): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
     if (productIds.length === 0) return [];
     return this.prisma.product.findMany({
-      where: { id: { in: productIds }, deleted_at: null },
+      where: {
+        id: { in: productIds },
+        // 후보 추출과 재조회 사이에 비활성화된 상품/매장이 노출되지 않게 재검증
+        is_active: true,
+        deleted_at: null,
+        store: { is_active: true, deleted_at: null },
+      },
       select: {
         id: true,
         images: {

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -928,6 +928,27 @@ export class ProductRepository {
   }
 
   /**
+   * 전역 카테고리 목록(홈 칩·카테고리 진입 화면). 활성만.
+   * category_type asc → sort_order asc → id asc.
+   */
+  async listCategories(type?: CategoryType) {
+    return this.prisma.category.findMany({
+      where: {
+        is_active: true,
+        deleted_at: null,
+        ...(type !== undefined ? { category_type: type } : {}),
+      },
+      select: {
+        id: true,
+        name: true,
+        category_type: true,
+        sort_order: true,
+      },
+      orderBy: [{ category_type: 'asc' }, { sort_order: 'asc' }, { id: 'asc' }],
+    });
+  }
+
+  /**
    * 매장이 보유한 활성 상품의 카테고리(사이드바). 빈 카테고리 제외.
    * sort_order asc, productCount는 이 매장의 활성 상품 기준.
    */

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1201,17 +1201,33 @@ export class ProductRepository {
   }
 
   /** 랜덤 케이크 셀 데이터(대표 이미지 1장). 반환 순서는 보장하지 않는다. */
-  async findRandomCakeRows(
-    productIds: bigint[],
-  ): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
-    if (productIds.length === 0) return [];
+  async findRandomCakeRows(args: {
+    productIds: bigint[];
+    categoryId?: bigint;
+  }): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
+    if (args.productIds.length === 0) return [];
     return this.prisma.product.findMany({
       where: {
-        id: { in: productIds },
-        // 후보 추출과 재조회 사이에 비활성화된 상품/매장이 노출되지 않게 재검증
+        id: { in: args.productIds },
+        // 후보 추출과 재조회 사이에 비활성화·카테고리 해제된 상품이 노출되지 않게 재검증
         is_active: true,
         deleted_at: null,
         store: { is_active: true, deleted_at: null },
+        ...(args.categoryId !== undefined
+          ? {
+              product_categories: {
+                some: {
+                  category_id: args.categoryId,
+                  deleted_at: null,
+                  category: {
+                    is_active: true,
+                    deleted_at: null,
+                    category_type: 'EVENT',
+                  },
+                },
+              },
+            }
+          : {}),
       },
       select: {
         id: true,

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1,9 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import {
-  type BannerLinkType,
-  type CategoryType,
-  Prisma,
-} from '@prisma/client';
+import { type BannerLinkType, type CategoryType, Prisma } from '@prisma/client';
 
 import { RANKING_VALID_ORDER_STATUSES } from '@/features/store';
 import { PrismaService } from '@/prisma';

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1,5 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { type CategoryType, Prisma } from '@prisma/client';
+import {
+  type BannerLinkType,
+  type CategoryType,
+  Prisma,
+} from '@prisma/client';
 
 import { RANKING_VALID_ORDER_STATUSES } from '@/features/store';
 import { PrismaService } from '@/prisma';
@@ -45,6 +49,10 @@ export interface HomeBannerRow {
   id: bigint;
   image_url: string;
   title: string | null;
+  link_type: BannerLinkType;
+  link_url: string | null;
+  link_product_id: bigint | null;
+  link_store_id: bigint | null;
   link_category_id: bigint | null;
 }
 
@@ -1105,6 +1113,10 @@ export class ProductRepository {
         id: true,
         image_url: true,
         title: true,
+        link_type: true,
+        link_url: true,
+        link_product_id: true,
+        link_store_id: true,
         link_category_id: true,
       },
       orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -991,7 +991,12 @@ export class ProductRepository {
                 some: {
                   category_id: args.categoryId,
                   deleted_at: null,
-                  category: { is_active: true, deleted_at: null },
+                  // 홈 칩은 EVENT 카테고리만 — STYLE/OTHER id가 오면 빈 결과로 처리
+                  category: {
+                    is_active: true,
+                    deleted_at: null,
+                    category_type: 'EVENT',
+                  },
                 },
               },
             }
@@ -1094,6 +1099,7 @@ export class ProductRepository {
   /**
    * 홈 배너 1건. categoryId 지정 시 placement=CATEGORY + 해당 카테고리 링크,
    * 미지정('전체' 칩) 시 placement=HOME_MAIN. 활성 + 노출 기간(now) 유효만.
+   * 링크 대상(상품/매장/카테고리)이 비활성/삭제된 배너는 건너뛴다.
    */
   async findHomeBanner(args: {
     categoryId?: bigint;
@@ -1107,7 +1113,32 @@ export class ProductRepository {
           ? { placement: 'CATEGORY', link_category_id: args.categoryId }
           : { placement: 'HOME_MAIN' }),
         OR: [{ starts_at: null }, { starts_at: { lte: args.now } }],
-        AND: [{ OR: [{ ends_at: null }, { ends_at: { gt: args.now } }] }],
+        AND: [
+          { OR: [{ ends_at: null }, { ends_at: { gt: args.now } }] },
+          {
+            // 링크 대상이 내려간(비활성/삭제) 배너를 노출하면 클릭이 죽은 화면으로
+            // 떨어지므로 대상 활성까지 확인하고 다음 배너로 넘어간다
+            OR: [
+              { link_type: { in: ['NONE', 'URL'] } },
+              {
+                link_type: 'PRODUCT',
+                link_product: {
+                  is_active: true,
+                  deleted_at: null,
+                  store: { is_active: true, deleted_at: null },
+                },
+              },
+              {
+                link_type: 'STORE',
+                link_store: { is_active: true, deleted_at: null },
+              },
+              {
+                link_type: 'CATEGORY',
+                link_category: { is_active: true, deleted_at: null },
+              },
+            ],
+          },
+        ],
       },
       select: {
         id: true,

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1110,7 +1110,16 @@ export class ProductRepository {
         is_active: true,
         deleted_at: null,
         ...(args.categoryId !== undefined
-          ? { placement: 'CATEGORY', link_category_id: args.categoryId }
+          ? {
+              placement: 'CATEGORY',
+              link_category_id: args.categoryId,
+              // 랭킹과 동일하게 홈 칩은 EVENT 카테고리만 — 비EVENT id면 배너도 없음
+              link_category: {
+                is_active: true,
+                deleted_at: null,
+                category_type: 'EVENT',
+              },
+            }
           : { placement: 'HOME_MAIN' }),
         OR: [{ starts_at: null }, { starts_at: { lte: args.now } }],
         AND: [

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { type CategoryType, Prisma } from '@prisma/client';
 
+import { RANKING_VALID_ORDER_STATUSES } from '@/features/store';
 import { PrismaService } from '@/prisma';
 
 /** 구매자 매장 상품 카드 row. product-storefront 매퍼 입력. */
@@ -22,6 +23,35 @@ export interface StoreProductCategoryRow {
   category_type: CategoryType;
   sort_order: number;
   product_count: number;
+}
+
+/** 인기 케이크 랭킹 후보 row. product-home 매퍼 입력. */
+export interface CakeCandidateRow {
+  id: bigint;
+  name: string;
+  regular_price: number;
+  sale_price: number | null;
+  images: { image_url: string }[];
+  store: {
+    store_name: string;
+    address_city: string | null;
+    address_neighborhood: string | null;
+    region: { name: string } | null;
+  };
+}
+
+/** 홈 배너 row. */
+export interface HomeBannerRow {
+  id: bigint;
+  image_url: string;
+  title: string | null;
+  link_category_id: bigint | null;
+}
+
+/** 상품별 평균 평점·리뷰 수. */
+export interface ProductReviewStat {
+  average: number;
+  count: number;
 }
 
 /** 구매자 상품 상세 row. product-detail 매퍼 입력. */
@@ -925,6 +955,160 @@ export class ProductRepository {
       select: { id: true },
     });
     return Boolean(found);
+  }
+
+  /**
+   * 인기 케이크 랭킹 후보. 활성 상품(+활성 매장)만.
+   * 카테고리/지역(2차 시군구 다중) 필터. 대표 이미지 1장 + 매장 표기 정보 포함.
+   */
+  async findActiveCakesForRanking(args: {
+    categoryId?: bigint;
+    regionIds?: bigint[];
+  }): Promise<CakeCandidateRow[]> {
+    return this.prisma.product.findMany({
+      where: {
+        is_active: true,
+        deleted_at: null,
+        store: {
+          is_active: true,
+          deleted_at: null,
+          ...(args.regionIds && args.regionIds.length > 0
+            ? { region_id: { in: args.regionIds } }
+            : {}),
+        },
+        // 0n도 유효한 인자(parseId("0")=0n) → undefined로만 분기한다.
+        ...(args.categoryId !== undefined
+          ? {
+              product_categories: {
+                some: {
+                  category_id: args.categoryId,
+                  deleted_at: null,
+                  category: { is_active: true, deleted_at: null },
+                },
+              },
+            }
+          : {}),
+      },
+      select: {
+        id: true,
+        name: true,
+        regular_price: true,
+        sale_price: true,
+        images: {
+          where: { deleted_at: null },
+          orderBy: { sort_order: 'asc' },
+          take: 1,
+          select: { image_url: true },
+        },
+        store: {
+          select: {
+            store_name: true,
+            address_city: true,
+            address_neighborhood: true,
+            region: { select: { name: true } },
+          },
+        },
+      },
+    });
+  }
+
+  /** 상품별 활성 찜 수. */
+  async aggregateProductWishlistCounts(
+    productIds: bigint[],
+  ): Promise<Map<bigint, number>> {
+    if (productIds.length === 0) return new Map();
+    const rows = await this.prisma.wishlistItem.groupBy({
+      by: ['product_id'],
+      where: { product_id: { in: productIds }, deleted_at: null },
+      _count: { _all: true },
+    });
+    return new Map(rows.map((r) => [r.product_id, r._count._all]));
+  }
+
+  /** 상품별 평균 평점·리뷰 수. */
+  async aggregateProductReviewStats(
+    productIds: bigint[],
+  ): Promise<Map<bigint, ProductReviewStat>> {
+    if (productIds.length === 0) return new Map();
+    const rows = await this.prisma.review.groupBy({
+      by: ['product_id'],
+      where: { product_id: { in: productIds }, deleted_at: null },
+      _avg: { rating: true },
+      _count: { _all: true },
+    });
+    return new Map(
+      rows.map((r) => [
+        r.product_id,
+        {
+          average: r._avg.rating !== null ? Number(r._avg.rating) : 0,
+          count: r._count._all,
+        },
+      ]),
+    );
+  }
+
+  /** 상품별 최근 N일 유효 주문(아이템) 수. */
+  async aggregateProductRecentOrderCounts(
+    productIds: bigint[],
+    since: Date,
+  ): Promise<Map<bigint, number>> {
+    if (productIds.length === 0) return new Map();
+    const rows = await this.prisma.orderItem.groupBy({
+      by: ['product_id'],
+      where: {
+        product_id: { in: productIds },
+        deleted_at: null,
+        order: {
+          status: { in: [...RANKING_VALID_ORDER_STATUSES] },
+          created_at: { gte: since },
+          // soft-delete extension은 nested relation filter에 deleted_at을 주입하지
+          // 않으므로(=root read만 보정), 삭제된 주문이 랭킹을 부풀리지 않도록 명시한다.
+          deleted_at: null,
+        },
+      },
+      _count: { _all: true },
+    });
+    return new Map(rows.map((r) => [r.product_id, r._count._all]));
+  }
+
+  /**
+   * 전체 활성 리뷰 평균 평점(베이지안 prior). 리뷰가 없으면 null.
+   * store feature의 globalReviewAverage와 동일 정의(전 도메인 공용 prior).
+   */
+  async globalReviewAverage(): Promise<number | null> {
+    const agg = await this.prisma.review.aggregate({
+      where: { deleted_at: null },
+      _avg: { rating: true },
+    });
+    return agg._avg.rating !== null ? Number(agg._avg.rating) : null;
+  }
+
+  /**
+   * 홈 배너 1건. categoryId 지정 시 placement=CATEGORY + 해당 카테고리 링크,
+   * 미지정('전체' 칩) 시 placement=HOME_MAIN. 활성 + 노출 기간(now) 유효만.
+   */
+  async findHomeBanner(args: {
+    categoryId?: bigint;
+    now: Date;
+  }): Promise<HomeBannerRow | null> {
+    return this.prisma.banner.findFirst({
+      where: {
+        is_active: true,
+        deleted_at: null,
+        ...(args.categoryId !== undefined
+          ? { placement: 'CATEGORY', link_category_id: args.categoryId }
+          : { placement: 'HOME_MAIN' }),
+        OR: [{ starts_at: null }, { starts_at: { lte: args.now } }],
+        AND: [{ OR: [{ ends_at: null }, { ends_at: { gt: args.now } }] }],
+      },
+      select: {
+        id: true,
+        image_url: true,
+        title: true,
+        link_category_id: true,
+      },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+    });
   }
 
   /**

--- a/src/features/product/resolvers/product-category-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-category-query.resolver.spec.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductCategoryQueryResolver } from '@/features/product/resolvers/product-category-query.resolver';
+import { ProductCategoryService } from '@/features/product/services/product-category.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createCategory } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 통합 경로 검증.
+ * 필터/정렬 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('ProductCategory Query Resolver (real DB)', () => {
+  let resolver: ProductCategoryQueryResolver;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        ProductCategoryQueryResolver,
+        ProductCategoryService,
+        ProductRepository,
+      ],
+    });
+    resolver = module.get(ProductCategoryQueryResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('categories: 서비스에 위임해 카테고리 목록을 반환한다', async () => {
+    await createCategory(prisma, { category_type: 'EVENT', name: '생일' });
+
+    const result = await resolver.categories({ type: 'EVENT' });
+
+    expect(result.map((c) => c.name)).toEqual(['생일']);
+  });
+});

--- a/src/features/product/resolvers/product-category-query.resolver.ts
+++ b/src/features/product/resolvers/product-category-query.resolver.ts
@@ -1,0 +1,18 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { CategoriesInput } from '@/features/product/dto/inputs/categories.input';
+import { ProductCategoryService } from '@/features/product/services/product-category.service';
+import type { CategoryItem } from '@/features/product/types/product-category-output.type';
+
+/**
+ * 전역 카테고리 조회 resolver. 개인화 필드가 없는 public query(인증 불필요).
+ */
+@Resolver('Query')
+export class ProductCategoryQueryResolver {
+  constructor(private readonly service: ProductCategoryService) {}
+
+  @Query('categories')
+  categories(@Args('input') input?: CategoriesInput): Promise<CategoryItem[]> {
+    return this.service.categories(input);
+  }
+}

--- a/src/features/product/resolvers/product-home-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.spec.ts
@@ -1,0 +1,49 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductHomeQueryResolver } from '@/features/product/resolvers/product-home-query.resolver';
+import { ProductHomeService } from '@/features/product/services/product-home.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createProduct, createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 통합 경로 검증.
+ * 랭킹/배너/필터 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('ProductHome Query Resolver (real DB)', () => {
+  let resolver: ProductHomeQueryResolver;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        ProductHomeQueryResolver,
+        ProductHomeService,
+        ProductRepository,
+      ],
+    });
+    resolver = module.get(ProductHomeQueryResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('popularCakes: 서비스에 위임해 섹션 데이터를 반환한다', async () => {
+    const store = await createStore(prisma);
+    await createProduct(prisma, { store_id: store.id, name: '인기 케이크' });
+
+    const result = await resolver.popularCakes();
+
+    expect(result.items.map((i) => i.name)).toEqual(['인기 케이크']);
+    expect(result.banner).toBeNull();
+  });
+});

--- a/src/features/product/resolvers/product-home-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.spec.ts
@@ -1,11 +1,17 @@
 import type { PrismaClient } from '@prisma/client';
 
+import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductHomeQueryResolver } from '@/features/product/resolvers/product-home-query.resolver';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
-import { createProduct, createStore } from '@/test/factories';
+import {
+  createOrderItem,
+  createProduct,
+  createReview,
+  createStore,
+} from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
 
 /**
@@ -22,6 +28,7 @@ describe('ProductHome Query Resolver (real DB)', () => {
         ProductHomeQueryResolver,
         ProductHomeService,
         ProductRepository,
+        ProductReviewRepository,
       ],
     });
     resolver = module.get(ProductHomeQueryResolver);
@@ -45,5 +52,36 @@ describe('ProductHome Query Resolver (real DB)', () => {
 
     expect(result.items.map((i) => i.name)).toEqual(['인기 케이크']);
     expect(result.banner).toBeNull();
+  });
+
+  it('customCakeShowcase: 서비스에 위임해 제작 후기 목록을 반환한다', async () => {
+    const orderItem = await createOrderItem(prisma);
+    await prisma.orderItemCustomFreeEdit.create({
+      data: {
+        order_item_id: orderItem.id,
+        crop_image_url: 'https://img/before.png',
+        description_text: '요청 디자인',
+      },
+    });
+    const review = await createReview(prisma, {
+      order_item_id: orderItem.id,
+      content: '제작 후기',
+    });
+    await prisma.reviewMedia.create({
+      data: {
+        review_id: review.id,
+        media_type: 'IMAGE',
+        media_url: 'https://img/after.png',
+      },
+    });
+
+    const result = await resolver.customCakeShowcase();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      reviewText: '제작 후기',
+      beforeImageUrl: 'https://img/before.png',
+      afterImageUrl: 'https://img/after.png',
+    });
   });
 });

--- a/src/features/product/resolvers/product-home-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.spec.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '@prisma/client';
 
+import { RandomService } from '@/common/providers/random.service';
 import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductHomeQueryResolver } from '@/features/product/resolvers/product-home-query.resolver';
@@ -29,6 +30,7 @@ describe('ProductHome Query Resolver (real DB)', () => {
         ProductHomeService,
         ProductRepository,
         ProductReviewRepository,
+        RandomService,
       ],
     });
     resolver = module.get(ProductHomeQueryResolver);
@@ -83,5 +85,19 @@ describe('ProductHome Query Resolver (real DB)', () => {
       beforeImageUrl: 'https://img/before.png',
       afterImageUrl: 'https://img/after.png',
     });
+  });
+
+  it('randomCakes: 서비스에 위임해 랜덤 그리드를 반환한다', async () => {
+    const store = await createStore(prisma);
+    const cake = await createProduct(prisma, { store_id: store.id });
+    await prisma.productImage.create({
+      data: { product_id: cake.id, image_url: 'https://img/grid.png' },
+    });
+
+    const result = await resolver.randomCakes();
+
+    expect(result.items).toEqual([
+      { id: cake.id.toString(), thumbnailUrl: 'https://img/grid.png' },
+    ]);
   });
 });

--- a/src/features/product/resolvers/product-home-query.resolver.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.ts
@@ -1,8 +1,12 @@
 import { Args, Query, Resolver } from '@nestjs/graphql';
 
+import { CustomCakeShowcaseInput } from '@/features/product/dto/inputs/custom-cake-showcase.input';
 import { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
-import type { PopularCakesResult } from '@/features/product/types/product-home-output.type';
+import type {
+  CustomCakeShowcaseItem,
+  PopularCakesResult,
+} from '@/features/product/types/product-home-output.type';
 
 /**
  * 홈 화면 섹션 조회 resolver. 개인화 필드가 없는 public query(인증 불필요).
@@ -16,5 +20,12 @@ export class ProductHomeQueryResolver {
     @Args('input') input?: PopularCakesInput,
   ): Promise<PopularCakesResult> {
     return this.service.popularCakes(input);
+  }
+
+  @Query('customCakeShowcase')
+  customCakeShowcase(
+    @Args('input') input?: CustomCakeShowcaseInput,
+  ): Promise<CustomCakeShowcaseItem[]> {
+    return this.service.customCakeShowcase(input);
   }
 }

--- a/src/features/product/resolvers/product-home-query.resolver.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.ts
@@ -1,0 +1,20 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import { ProductHomeService } from '@/features/product/services/product-home.service';
+import type { PopularCakesResult } from '@/features/product/types/product-home-output.type';
+
+/**
+ * 홈 화면 섹션 조회 resolver. 개인화 필드가 없는 public query(인증 불필요).
+ */
+@Resolver('Query')
+export class ProductHomeQueryResolver {
+  constructor(private readonly service: ProductHomeService) {}
+
+  @Query('popularCakes')
+  popularCakes(
+    @Args('input') input?: PopularCakesInput,
+  ): Promise<PopularCakesResult> {
+    return this.service.popularCakes(input);
+  }
+}

--- a/src/features/product/resolvers/product-home-query.resolver.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.ts
@@ -2,10 +2,12 @@ import { Args, Query, Resolver } from '@nestjs/graphql';
 
 import { CustomCakeShowcaseInput } from '@/features/product/dto/inputs/custom-cake-showcase.input';
 import { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import { RandomCakesInput } from '@/features/product/dto/inputs/random-cakes.input';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
 import type {
   CustomCakeShowcaseItem,
   PopularCakesResult,
+  RandomCakesResult,
 } from '@/features/product/types/product-home-output.type';
 
 /**
@@ -27,5 +29,12 @@ export class ProductHomeQueryResolver {
     @Args('input') input?: CustomCakeShowcaseInput,
   ): Promise<CustomCakeShowcaseItem[]> {
     return this.service.customCakeShowcase(input);
+  }
+
+  @Query('randomCakes')
+  randomCakes(
+    @Args('input') input?: RandomCakesInput,
+  ): Promise<RandomCakesResult> {
+    return this.service.randomCakes(input);
   }
 }

--- a/src/features/product/services/product-category.service.spec.ts
+++ b/src/features/product/services/product-category.service.spec.ts
@@ -1,0 +1,106 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductCategoryService } from '@/features/product/services/product-category.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createCategory } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('ProductCategoryService (real DB)', () => {
+  let service: ProductCategoryService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ProductCategoryService, ProductRepository],
+    });
+    service = module.get(ProductCategoryService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  describe('categories', () => {
+    it('type 미지정 시 전체 카테고리를 type→sort_order 순으로 반환한다', async () => {
+      await createCategory(prisma, {
+        category_type: 'STYLE',
+        name: '꽃장식',
+        sort_order: 0,
+      });
+      await createCategory(prisma, {
+        category_type: 'EVENT',
+        name: '크리스마스',
+        sort_order: 1,
+      });
+      await createCategory(prisma, {
+        category_type: 'EVENT',
+        name: '생일',
+        sort_order: 0,
+      });
+
+      const result = await service.categories();
+
+      expect(result.map((c) => c.name)).toEqual([
+        '생일',
+        '크리스마스',
+        '꽃장식',
+      ]);
+      expect(result.map((c) => c.categoryType)).toEqual([
+        'EVENT',
+        'EVENT',
+        'STYLE',
+      ]);
+    });
+
+    it('type 지정 시 해당 타입만 반환한다', async () => {
+      await createCategory(prisma, { category_type: 'EVENT', name: '생일' });
+      await createCategory(prisma, { category_type: 'STYLE', name: '입체' });
+
+      const result = await service.categories({ type: 'STYLE' });
+
+      expect(result.map((c) => c.name)).toEqual(['입체']);
+    });
+
+    it('비활성/soft-delete 카테고리는 제외한다', async () => {
+      await createCategory(prisma, { name: '활성', sort_order: 0 });
+      await createCategory(prisma, {
+        name: '비활성',
+        sort_order: 1,
+        is_active: false,
+      });
+      await createCategory(prisma, {
+        name: '삭제됨',
+        sort_order: 2,
+        deleted_at: new Date(),
+      });
+
+      const result = await service.categories();
+
+      expect(result.map((c) => c.name)).toEqual(['활성']);
+    });
+
+    it('카테고리가 없으면 빈 배열을 반환한다', async () => {
+      await expect(service.categories()).resolves.toEqual([]);
+    });
+
+    it('id와 sortOrder를 문자열/숫자로 매핑한다', async () => {
+      const category = await createCategory(prisma, {
+        name: '생일',
+        sort_order: 3,
+      });
+
+      const [item] = await service.categories();
+
+      expect(item.id).toBe(category.id.toString());
+      expect(item.sortOrder).toBe(3);
+    });
+  });
+});

--- a/src/features/product/services/product-category.service.ts
+++ b/src/features/product/services/product-category.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+
+import type { CategoriesInput } from '@/features/product/dto/inputs/categories.input';
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import type { CategoryItem } from '@/features/product/types/product-category-output.type';
+
+@Injectable()
+export class ProductCategoryService {
+  constructor(private readonly repo: ProductRepository) {}
+
+  /** 전역 카테고리 목록. type 필터 옵션, 활성만. */
+  async categories(input?: CategoriesInput): Promise<CategoryItem[]> {
+    const rows = await this.repo.listCategories(input?.type);
+    return rows.map((row) => ({
+      id: row.id.toString(),
+      name: row.name,
+      categoryType: row.category_type,
+      sortOrder: row.sort_order,
+    }));
+  }
+}

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -1,0 +1,36 @@
+import type {
+  CakeCandidateRow,
+  HomeBannerRow,
+} from '@/features/product/repositories/product.repository';
+import { calcDiscountRate } from '@/features/product/services/product-storefront-mappers.helper';
+import type {
+  HomeBanner,
+  PopularCake,
+} from '@/features/product/types/product-home-output.type';
+import { buildRegionLabel } from '@/features/store';
+
+export function toHomeBanner(row: HomeBannerRow): HomeBanner {
+  return {
+    id: row.id.toString(),
+    imageUrl: row.image_url,
+    title: row.title,
+    linkCategoryId: row.link_category_id?.toString() ?? null,
+  };
+}
+
+export function toPopularCake(
+  row: CakeCandidateRow,
+  rank: number,
+): PopularCake {
+  return {
+    id: row.id.toString(),
+    rank,
+    name: row.name,
+    thumbnailUrl: row.images[0]?.image_url ?? null,
+    storeName: row.store.store_name,
+    regionLabel: buildRegionLabel(row.store),
+    regularPrice: row.regular_price,
+    salePrice: row.sale_price,
+    discountRate: calcDiscountRate(row.regular_price, row.sale_price),
+  };
+}

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -14,6 +14,10 @@ export function toHomeBanner(row: HomeBannerRow): HomeBanner {
     id: row.id.toString(),
     imageUrl: row.image_url,
     title: row.title,
+    linkType: row.link_type,
+    linkUrl: row.link_url,
+    linkProductId: row.link_product_id?.toString() ?? null,
+    linkStoreId: row.link_store_id?.toString() ?? null,
     linkCategoryId: row.link_category_id?.toString() ?? null,
   };
 }

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -303,6 +303,27 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.banner).toBeNull();
     });
 
+    it('EVENT가 아닌 카테고리의 배너는 반환하지 않는다', async () => {
+      const style = await createCategory(prisma, {
+        category_type: 'STYLE',
+        name: '입체',
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'CATEGORY',
+          image_url: 'https://img/style-banner.png',
+          link_type: 'CATEGORY',
+          link_category_id: style.id,
+        },
+      });
+
+      const result = await service.popularCakes({
+        categoryId: style.id.toString(),
+      });
+
+      expect(result.banner).toBeNull();
+    });
+
     it('링크 대상이 비활성인 배너는 건너뛰고 다음 유효 배너를 반환한다', async () => {
       const store = await createStore(prisma);
       const deadProduct = await createProduct(prisma, {

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -634,6 +634,25 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.items.map((i) => i.id)).toEqual([inCategory.id.toString()]);
     });
 
+    it('EVENT가 아닌 카테고리 id가 오면 빈 결과를 반환한다(홈 칩과 동일 정책)', async () => {
+      const store = await createStore(prisma);
+      const style = await createCategory(prisma, {
+        category_type: 'STYLE',
+        name: '포토',
+      });
+      const [cake] = await makeCakesWithImage(store, 1);
+      await linkProductCategory(prisma, {
+        productId: cake.id,
+        categoryId: style.id,
+      });
+
+      const result = await service.randomCakes({
+        categoryId: style.id.toString(),
+      });
+
+      expect(result.items).toEqual([]);
+    });
+
     it('이미지 없는 상품·비활성 상품·비활성 매장 상품은 후보에서 제외한다', async () => {
       const store = await createStore(prisma);
       await createProduct(prisma, { store_id: store.id }); // 이미지 없음

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient, Product, Store } from '@prisma/client';
 
+import { RandomService } from '@/common/providers/random.service';
 import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
@@ -24,7 +25,7 @@ describe('ProductHomeService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [ProductHomeService, ProductRepository, ProductReviewRepository],
+      providers: [ProductHomeService, ProductRepository, ProductReviewRepository, RandomService],
     });
     service = module.get(ProductHomeService);
     prisma = p;
@@ -576,6 +577,110 @@ describe('ProductHomeService (real DB)', () => {
       const result = await service.customCakeShowcase();
 
       expect(result[0].beforeImageUrl).toBe('https://img/first-crop.png');
+    });
+  });
+
+  describe('randomCakes', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    /** 대표 이미지가 있는 활성 케이크 n개 생성. */
+    async function makeCakesWithImage(
+      store: Store,
+      count: number,
+    ): Promise<Product[]> {
+      const cakes: Product[] = [];
+      for (let i = 0; i < count; i += 1) {
+        const cake = await createProduct(prisma, { store_id: store.id });
+        await prisma.productImage.create({
+          data: {
+            product_id: cake.id,
+            image_url: `https://img/random-${cake.id}.png`,
+          },
+        });
+        cakes.push(cake);
+      }
+      return cakes;
+    }
+
+    it('기본 9개를 중복 없이 반환하고 썸네일을 매핑한다', async () => {
+      const store = await createStore(prisma);
+      await makeCakesWithImage(store, 12);
+
+      const result = await service.randomCakes();
+
+      expect(result.items).toHaveLength(9);
+      expect(new Set(result.items.map((i) => i.id)).size).toBe(9);
+      for (const item of result.items) {
+        expect(item.thumbnailUrl).toBe(`https://img/random-${item.id}.png`);
+      }
+    });
+
+    it('categoryId 지정 시 해당 카테고리 케이크만 추출한다', async () => {
+      const store = await createStore(prisma);
+      const birthday = await createCategory(prisma, { name: '생일' });
+      const [inCategory] = await makeCakesWithImage(store, 1);
+      await makeCakesWithImage(store, 3);
+      await linkProductCategory(prisma, {
+        productId: inCategory.id,
+        categoryId: birthday.id,
+      });
+
+      const result = await service.randomCakes({
+        categoryId: birthday.id.toString(),
+      });
+
+      expect(result.items.map((i) => i.id)).toEqual([inCategory.id.toString()]);
+    });
+
+    it('이미지 없는 상품·비활성 상품·비활성 매장 상품은 후보에서 제외한다', async () => {
+      const store = await createStore(prisma);
+      await createProduct(prisma, { store_id: store.id }); // 이미지 없음
+      const inactive = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: false,
+      });
+      await prisma.productImage.create({
+        data: { product_id: inactive.id, image_url: 'https://img/x.png' },
+      });
+      const inactiveStore = await createStore(prisma, { is_active: false });
+      const cakeInInactiveStore = await createProduct(prisma, {
+        store_id: inactiveStore.id,
+      });
+      await prisma.productImage.create({
+        data: {
+          product_id: cakeInInactiveStore.id,
+          image_url: 'https://img/y.png',
+        },
+      });
+
+      await expect(service.randomCakes()).resolves.toEqual({ items: [] });
+    });
+
+    it('후보가 limit보다 적으면 전량을 반환한다', async () => {
+      const store = await createStore(prisma);
+      await makeCakesWithImage(store, 4);
+
+      const result = await service.randomCakes();
+
+      expect(result.items).toHaveLength(4);
+    });
+
+    it('주입된 난수에 따라 결정적으로 추출한다', async () => {
+      const store = await createStore(prisma);
+      const cakes = await makeCakesWithImage(store, 5);
+      const randomService = (service as unknown as { random: RandomService })
+        .random;
+      // random()=0이면 부분 셔플이 항등이 되어 id asc 앞에서부터 뽑힌다
+      jest.spyOn(randomService, 'random').mockReturnValue(0);
+
+      const result = await service.randomCakes({ limit: 2 });
+
+      expect(result.items.map((i) => i.id)).toEqual([
+        cakes[0].id.toString(),
+        cakes[1].id.toString(),
+      ]);
     });
   });
 });

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -634,6 +634,17 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.items.map((i) => i.id)).toEqual([inCategory.id.toString()]);
     });
 
+    it('categoryId가 명시적 null이면 필터 없음으로 처리한다', async () => {
+      const store = await createStore(prisma);
+      await makeCakesWithImage(store, 2);
+
+      const result = await service.randomCakes({
+        categoryId: null as unknown as undefined,
+      });
+
+      expect(result.items).toHaveLength(2);
+    });
+
     it('EVENT가 아닌 카테고리 id가 오면 빈 결과를 반환한다(홈 칩과 동일 정책)', async () => {
       const store = await createStore(prisma);
       const style = await createCategory(prisma, {

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -1,0 +1,291 @@
+import type { PrismaClient, Product, Store } from '@prisma/client';
+
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import { ProductHomeService } from '@/features/product/services/product-home.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createCategory,
+  createOrder,
+  createOrderItem,
+  createProduct,
+  createStore,
+  linkProductCategory,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('ProductHomeService (real DB)', () => {
+  let service: ProductHomeService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ProductHomeService, ProductRepository],
+    });
+    service = module.get(ProductHomeService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  /** 확정(CONFIRMED) 주문 n건을 만들어 상품의 최근 주문수를 채운다. */
+  async function confirmOrders(product: Product, count: number): Promise<void> {
+    for (let i = 0; i < count; i += 1) {
+      const order = await createOrder(prisma, { status: 'CONFIRMED' });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        product_id: product.id,
+      });
+    }
+  }
+
+  /** 활성 찜 n건 생성. */
+  async function wishProduct(product: Product, count: number): Promise<void> {
+    for (let i = 0; i < count; i += 1) {
+      const account = await createAccount(prisma, { account_type: 'USER' });
+      await prisma.wishlistItem.create({
+        data: { account_id: account.id, product_id: product.id },
+      });
+    }
+  }
+
+  async function makeCake(
+    store: Store,
+    name: string,
+    overrides: Parameters<typeof createProduct>[1] = {},
+  ): Promise<Product> {
+    return createProduct(prisma, {
+      store_id: store.id,
+      name,
+      ...overrides,
+    });
+  }
+
+  describe('popularCakes', () => {
+    it('최근 주문수가 많은 순으로 랭킹과 rank 순번을 매긴다', async () => {
+      const store = await createStore(prisma);
+      const first = await makeCake(store, '1등 케이크');
+      const second = await makeCake(store, '2등 케이크');
+      const third = await makeCake(store, '3등 케이크');
+      await confirmOrders(first, 5);
+      await confirmOrders(second, 2);
+      await confirmOrders(third, 1);
+
+      const result = await service.popularCakes();
+
+      expect(result.items.map((i) => i.name)).toEqual([
+        '1등 케이크',
+        '2등 케이크',
+        '3등 케이크',
+      ]);
+      expect(result.items.map((i) => i.rank)).toEqual([1, 2, 3]);
+      expect(result.rankedAt).toBeInstanceOf(Date);
+    });
+
+    it('찜 수도 점수에 반영한다(주문 동일 시 찜 많은 쪽 우선)', async () => {
+      const store = await createStore(prisma);
+      const liked = await makeCake(store, '찜 많은 케이크');
+      await makeCake(store, '찜 없는 케이크');
+      await wishProduct(liked, 3);
+
+      const result = await service.popularCakes();
+
+      expect(result.items[0].name).toBe('찜 많은 케이크');
+    });
+
+    it('categoryId 지정 시 해당 카테고리 상품만 랭킹 대상이다', async () => {
+      const store = await createStore(prisma);
+      const birthday = await createCategory(prisma, { name: '생일' });
+      const inCategory = await makeCake(store, '생일 케이크');
+      await makeCake(store, '무관 케이크');
+      await linkProductCategory(prisma, {
+        productId: inCategory.id,
+        categoryId: birthday.id,
+      });
+
+      const result = await service.popularCakes({
+        categoryId: birthday.id.toString(),
+      });
+
+      expect(result.items.map((i) => i.name)).toEqual(['생일 케이크']);
+    });
+
+    it('regionIds 지정 시 해당 지역 매장 상품만 랭킹 대상이다', async () => {
+      const regionA = await prisma.region.create({
+        data: { level: 2, name: '강남구', slug: 'test-gangnam' },
+      });
+      const storeIn = await createStore(prisma, { region_id: regionA.id });
+      const storeOut = await createStore(prisma);
+      await makeCake(storeIn, '강남 케이크');
+      await makeCake(storeOut, '타지역 케이크');
+
+      const result = await service.popularCakes({
+        regionIds: [regionA.id.toString()],
+      });
+
+      expect(result.items.map((i) => i.name)).toEqual(['강남 케이크']);
+    });
+
+    it('비활성 상품과 비활성 매장 상품은 제외한다', async () => {
+      const store = await createStore(prisma);
+      await makeCake(store, '활성 케이크');
+      await makeCake(store, '비활성 케이크', { is_active: false });
+      const inactiveStore = await createStore(prisma, { is_active: false });
+      await makeCake(inactiveStore, '비활성 매장 케이크');
+
+      const result = await service.popularCakes();
+
+      expect(result.items.map((i) => i.name)).toEqual(['활성 케이크']);
+    });
+
+    it('기본 3개, limit 지정 시 해당 수만큼 자른다', async () => {
+      const store = await createStore(prisma);
+      for (let i = 0; i < 5; i += 1) {
+        await makeCake(store, `케이크 ${i}`);
+      }
+
+      const [byDefault, limited] = [
+        await service.popularCakes(),
+        await service.popularCakes({ limit: 2 }),
+      ];
+
+      expect(byDefault.items).toHaveLength(3);
+      expect(limited.items).toHaveLength(2);
+    });
+
+    it('카드에 매장명·지역명·가격·할인율·대표이미지를 매핑한다', async () => {
+      const store = await createStore(prisma, {
+        store_name: '청담 케이크샵',
+        address_city: '서울',
+        address_neighborhood: '청담동',
+      });
+      const cake = await makeCake(store, '레터링 케이크', {
+        regular_price: 40000,
+        sale_price: 30000,
+      });
+      await prisma.productImage.create({
+        data: { product_id: cake.id, image_url: 'https://img/cake.png' },
+      });
+
+      const [item] = (await service.popularCakes()).items;
+
+      expect(item).toMatchObject({
+        name: '레터링 케이크',
+        storeName: '청담 케이크샵',
+        regionLabel: '서울 청담동',
+        regularPrice: 40000,
+        salePrice: 30000,
+        discountRate: 25,
+        thumbnailUrl: 'https://img/cake.png',
+      });
+    });
+
+    it('상품이 없으면 빈 items를 반환한다', async () => {
+      const result = await service.popularCakes();
+
+      expect(result.items).toEqual([]);
+      expect(result.banner).toBeNull();
+    });
+  });
+
+  describe('popularCakes 배너 선택', () => {
+    it('categoryId 지정 시 해당 카테고리의 CATEGORY 배너를 반환한다', async () => {
+      const birthday = await createCategory(prisma, { name: '생일' });
+      const other = await createCategory(prisma, { name: '웨딩' });
+      await prisma.banner.create({
+        data: {
+          placement: 'CATEGORY',
+          image_url: 'https://img/birthday-banner.png',
+          link_type: 'CATEGORY',
+          link_category_id: birthday.id,
+        },
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'CATEGORY',
+          image_url: 'https://img/other-banner.png',
+          link_type: 'CATEGORY',
+          link_category_id: other.id,
+        },
+      });
+
+      const result = await service.popularCakes({
+        categoryId: birthday.id.toString(),
+      });
+
+      expect(result.banner).toMatchObject({
+        imageUrl: 'https://img/birthday-banner.png',
+        linkCategoryId: birthday.id.toString(),
+      });
+    });
+
+    it('categoryId 미지정(전체 칩) 시 HOME_MAIN 배너를 반환한다', async () => {
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/main-banner.png',
+          title: '메인 배너',
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner).toMatchObject({
+        imageUrl: 'https://img/main-banner.png',
+        title: '메인 배너',
+        linkCategoryId: null,
+      });
+    });
+
+    it('노출 기간을 벗어난 배너와 비활성 배너는 제외하고 없으면 null을 반환한다', async () => {
+      const past = new Date(Date.now() - 60 * 60 * 1000);
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/expired.png',
+          ends_at: past,
+        },
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/inactive.png',
+          is_active: false,
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner).toBeNull();
+    });
+
+    it('동일 placement 다건이면 sort_order가 앞선 배너 1건만 반환한다', async () => {
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/second.png',
+          sort_order: 1,
+        },
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/first.png',
+          sort_order: 0,
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner?.imageUrl).toBe('https://img/first.png');
+    });
+  });
+});

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -25,7 +25,12 @@ describe('ProductHomeService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [ProductHomeService, ProductRepository, ProductReviewRepository, RandomService],
+      providers: [
+        ProductHomeService,
+        ProductRepository,
+        ProductReviewRepository,
+        RandomService,
+      ],
     });
     service = module.get(ProductHomeService);
     prisma = p;

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -118,6 +118,25 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.items.map((i) => i.name)).toEqual(['생일 케이크']);
     });
 
+    it('EVENT가 아닌 카테고리 id가 오면 빈 결과를 반환한다(홈 칩은 EVENT 한정)', async () => {
+      const store = await createStore(prisma);
+      const style = await createCategory(prisma, {
+        category_type: 'STYLE',
+        name: '입체',
+      });
+      const cake = await makeCake(store, '입체 케이크');
+      await linkProductCategory(prisma, {
+        productId: cake.id,
+        categoryId: style.id,
+      });
+
+      const result = await service.popularCakes({
+        categoryId: style.id.toString(),
+      });
+
+      expect(result.items).toEqual([]);
+    });
+
     it('regionIds 지정 시 해당 지역 매장 상품만 랭킹 대상이다', async () => {
       const regionA = await prisma.region.create({
         data: { level: 2, name: '강남구', slug: 'test-gangnam' },
@@ -282,6 +301,34 @@ describe('ProductHomeService (real DB)', () => {
       const result = await service.popularCakes();
 
       expect(result.banner).toBeNull();
+    });
+
+    it('링크 대상이 비활성인 배너는 건너뛰고 다음 유효 배너를 반환한다', async () => {
+      const store = await createStore(prisma);
+      const deadProduct = await createProduct(prisma, {
+        store_id: store.id,
+        is_active: false,
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/dead-link.png',
+          link_type: 'PRODUCT',
+          link_product_id: deadProduct.id,
+          sort_order: 0,
+        },
+      });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/alive.png',
+          sort_order: 1,
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner?.imageUrl).toBe('https://img/alive.png');
     });
 
     it('동일 placement 다건이면 sort_order가 앞선 배너 1건만 반환한다', async () => {

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -235,6 +235,7 @@ describe('ProductHomeService (real DB)', () => {
 
       expect(result.banner).toMatchObject({
         imageUrl: 'https://img/birthday-banner.png',
+        linkType: 'CATEGORY',
         linkCategoryId: birthday.id.toString(),
       });
     });
@@ -245,6 +246,8 @@ describe('ProductHomeService (real DB)', () => {
           placement: 'HOME_MAIN',
           image_url: 'https://img/main-banner.png',
           title: '메인 배너',
+          link_type: 'URL',
+          link_url: 'https://event.caquick.dev',
         },
       });
 
@@ -253,6 +256,8 @@ describe('ProductHomeService (real DB)', () => {
       expect(result.banner).toMatchObject({
         imageUrl: 'https://img/main-banner.png',
         title: '메인 배너',
+        linkType: 'URL',
+        linkUrl: 'https://event.caquick.dev',
         linkCategoryId: null,
       });
     });

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -161,6 +161,18 @@ describe('ProductHomeService (real DB)', () => {
       expect(limited.items).toHaveLength(2);
     });
 
+    it('limit이 상한(3)을 넘으면 3으로 클램프한다', async () => {
+      const store = await createStore(prisma);
+      for (let i = 0; i < 5; i += 1) {
+        await makeCake(store, `케이크 ${i}`);
+      }
+
+      // DTO(@Max)를 우회한 직접 호출에도 "최대 3개" 계약을 지킨다
+      const result = await service.popularCakes({ limit: 5 });
+
+      expect(result.items).toHaveLength(3);
+    });
+
     it('카드에 매장명·지역명·가격·할인율·대표이미지를 매핑한다', async () => {
       const store = await createStore(prisma, {
         store_name: '청담 케이크샵',

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient, Product, Store } from '@prisma/client';
 
+import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import { ProductHomeService } from '@/features/product/services/product-home.service';
 import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
@@ -10,7 +11,9 @@ import {
   createOrder,
   createOrderItem,
   createProduct,
+  createReview,
   createStore,
+  createUserProfile,
   linkProductCategory,
 } from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
@@ -21,7 +24,7 @@ describe('ProductHomeService (real DB)', () => {
 
   beforeAll(async () => {
     const { module, prisma: p } = await createTestingModuleWithRealDb({
-      providers: [ProductHomeService, ProductRepository],
+      providers: [ProductHomeService, ProductRepository, ProductReviewRepository],
     });
     service = module.get(ProductHomeService);
     prisma = p;
@@ -371,6 +374,208 @@ describe('ProductHomeService (real DB)', () => {
       const result = await service.popularCakes();
 
       expect(result.banner?.imageUrl).toBe('https://img/first.png');
+    });
+  });
+
+  describe('customCakeShowcase', () => {
+    /**
+     * Before(주문 커스텀 크롭)/After(리뷰 이미지)가 모두 있는 쇼케이스 후보 리뷰 생성.
+     * storeId를 주면 해당 매장 소속으로 만든다.
+     */
+    async function makeShowcaseReview(args?: {
+      storeId?: bigint;
+      nickname?: string;
+      content?: string;
+      before?: boolean;
+      after?: boolean;
+    }): Promise<bigint> {
+      const orderItem = await createOrderItem(
+        prisma,
+        args?.storeId !== undefined ? { store_id: args.storeId } : {},
+      );
+      if (args?.before !== false) {
+        await prisma.orderItemCustomFreeEdit.create({
+          data: {
+            order_item_id: orderItem.id,
+            crop_image_url: `https://img/before-${orderItem.id}.png`,
+            description_text: '요청 디자인',
+          },
+        });
+      }
+      const review = await createReview(prisma, {
+        order_item_id: orderItem.id,
+        content: args?.content ?? '후기 본문',
+      });
+      if (args?.after !== false) {
+        await prisma.reviewMedia.create({
+          data: {
+            review_id: review.id,
+            media_type: 'IMAGE',
+            media_url: `https://img/after-${review.id}.png`,
+          },
+        });
+      }
+      if (args?.nickname) {
+        const order = await prisma.order.findUniqueOrThrow({
+          where: { id: orderItem.order_id },
+        });
+        await createUserProfile(prisma, {
+          account_id: order.account_id,
+          nickname: args.nickname,
+        });
+      }
+      return review.id;
+    }
+
+    /** 유효 좋아요 n건 생성. */
+    async function likeReview(reviewId: bigint, count: number): Promise<void> {
+      for (let i = 0; i < count; i += 1) {
+        const account = await createAccount(prisma, { account_type: 'USER' });
+        await prisma.reviewLike.create({
+          data: { review_id: reviewId, account_id: account.id },
+        });
+      }
+    }
+
+    it('좋아요순으로 정렬하고 rank·likeCount를 매긴다(soft-delete 좋아요 미집계)', async () => {
+      const top = await makeShowcaseReview({ content: '1위 후기' });
+      const second = await makeShowcaseReview({ content: '2위 후기' });
+      await likeReview(top, 3);
+      await likeReview(second, 1);
+      // soft-delete된 좋아요는 집계에서 제외되어야 한다
+      const ghost = await createAccount(prisma, { account_type: 'USER' });
+      await prisma.reviewLike.create({
+        data: {
+          review_id: second,
+          account_id: ghost.id,
+          deleted_at: new Date(),
+        },
+      });
+
+      const result = await service.customCakeShowcase();
+
+      expect(result.map((i) => i.reviewText)).toEqual(['1위 후기', '2위 후기']);
+      expect(result.map((i) => i.rank)).toEqual([1, 2]);
+      expect(result.map((i) => i.likeCount)).toEqual([3, 1]);
+    });
+
+    it('Before(커스텀 크롭) 또는 After(리뷰 이미지)가 없는 리뷰는 제외한다', async () => {
+      await makeShowcaseReview({ content: '페어 완성 후기' });
+      await makeShowcaseReview({ content: 'before 없음', before: false });
+      await makeShowcaseReview({ content: 'after 없음', after: false });
+
+      const result = await service.customCakeShowcase();
+
+      expect(result.map((i) => i.reviewText)).toEqual(['페어 완성 후기']);
+    });
+
+    it('VIDEO만 있는 리뷰는 제외하고, IMAGE가 있으면 IMAGE를 After로 쓴다', async () => {
+      const review = await makeShowcaseReview({
+        content: '비디오+이미지',
+        after: false,
+      });
+      await prisma.reviewMedia.create({
+        data: {
+          review_id: review,
+          media_type: 'VIDEO',
+          media_url: 'https://img/video.mp4',
+          sort_order: 0,
+        },
+      });
+      await prisma.reviewMedia.create({
+        data: {
+          review_id: review,
+          media_type: 'IMAGE',
+          media_url: 'https://img/real-after.png',
+          sort_order: 1,
+        },
+      });
+      await makeShowcaseReview({ content: '비디오만', after: false }).then(
+        (id) =>
+          prisma.reviewMedia.create({
+            data: {
+              review_id: id,
+              media_type: 'VIDEO',
+              media_url: 'https://img/only-video.mp4',
+            },
+          }),
+      );
+
+      const result = await service.customCakeShowcase();
+
+      expect(result.map((i) => i.reviewText)).toEqual(['비디오+이미지']);
+      expect(result[0].afterImageUrl).toBe('https://img/real-after.png');
+    });
+
+    it('비활성 매장의 리뷰는 제외한다', async () => {
+      const inactiveStore = await createStore(prisma, { is_active: false });
+      await makeShowcaseReview({
+        storeId: inactiveStore.id,
+        content: '비활성 매장 후기',
+      });
+
+      await expect(service.customCakeShowcase()).resolves.toEqual([]);
+    });
+
+    it('작성자 닉네임을 매핑하고, 탈퇴 작성자는 null로 익명화한다', async () => {
+      const active = await makeShowcaseReview({
+        nickname: '곰돌이빵',
+        content: '활성 작성자',
+      });
+      await likeReview(active, 1);
+      const withdrawnReview = await makeShowcaseReview({
+        nickname: '탈퇴자',
+        content: '탈퇴 작성자',
+      });
+      const row = await prisma.review.findUniqueOrThrow({
+        where: { id: withdrawnReview },
+      });
+      await prisma.userProfile.update({
+        where: { account_id: row.account_id },
+        data: { deleted_at: new Date() },
+      });
+
+      const result = await service.customCakeShowcase();
+
+      expect(result.map((i) => i.authorNickname)).toEqual(['곰돌이빵', null]);
+    });
+
+    it('limit만큼 자르고, 후기가 없으면 빈 배열을 반환한다', async () => {
+      await expect(service.customCakeShowcase()).resolves.toEqual([]);
+
+      await makeShowcaseReview();
+      await makeShowcaseReview();
+      await makeShowcaseReview();
+
+      const limited = await service.customCakeShowcase({ limit: 2 });
+      expect(limited).toHaveLength(2);
+    });
+
+    it('beforeImageUrl은 sort_order가 앞선 커스텀 크롭을 사용한다', async () => {
+      const review = await makeShowcaseReview({ before: false });
+      const row = await prisma.review.findUniqueOrThrow({
+        where: { id: review },
+      });
+      await prisma.orderItemCustomFreeEdit.create({
+        data: {
+          order_item_id: row.order_item_id,
+          crop_image_url: 'https://img/second-crop.png',
+          description_text: '두 번째',
+          sort_order: 1,
+        },
+      });
+      await prisma.orderItemCustomFreeEdit.create({
+        data: {
+          order_item_id: row.order_item_id,
+          crop_image_url: 'https://img/first-crop.png',
+          description_text: '첫 번째',
+          sort_order: 0,
+        },
+      });
+
+      const result = await service.customCakeShowcase();
+
+      expect(result[0].beforeImageUrl).toBe('https://img/first-crop.png');
     });
   });
 });

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -1,13 +1,16 @@
 import { Injectable } from '@nestjs/common';
 
+import { RandomService } from '@/common/providers/random.service';
 import { parseId } from '@/common/utils/id-parser';
 import {
   DEFAULT_POPULAR_CAKES_LIMIT,
+  DEFAULT_RANDOM_CAKES_LIMIT,
   DEFAULT_SHOWCASE_LIMIT,
   MAX_POPULAR_CAKES_LIMIT,
 } from '@/features/product/constants/product-home.constants';
 import type { CustomCakeShowcaseInput } from '@/features/product/dto/inputs/custom-cake-showcase.input';
 import type { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import type { RandomCakesInput } from '@/features/product/dto/inputs/random-cakes.input';
 import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import {
@@ -17,6 +20,7 @@ import {
 import type {
   CustomCakeShowcaseItem,
   PopularCakesResult,
+  RandomCakesResult,
 } from '@/features/product/types/product-home-output.type';
 import {
   DEFAULT_GLOBAL_RATING_PRIOR,
@@ -32,6 +36,7 @@ export class ProductHomeService {
   constructor(
     private readonly repo: ProductRepository,
     private readonly reviewRepo: ProductReviewRepository,
+    private readonly random: RandomService,
   ) {}
 
   /**
@@ -141,5 +146,33 @@ export class ProductHomeService {
       });
     }
     return items;
+  }
+
+  /**
+   * 홈 '렌덤 케이크 둘러보기'. 호출마다 후보 풀에서 무작위 재추출한다
+   * (호출 간 중복 허용 — '새로보기 1/3' 카운트는 FE 로컬 상태, 정책 확정 사항).
+   */
+  async randomCakes(input?: RandomCakesInput): Promise<RandomCakesResult> {
+    const limit = input?.limit ?? DEFAULT_RANDOM_CAKES_LIMIT;
+    const categoryId =
+      input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
+
+    const candidateIds = await this.repo.listRandomCakeCandidateIds(categoryId);
+    if (candidateIds.length === 0) return { items: [] };
+
+    const pickedIds = this.random.sample(candidateIds, limit);
+    const rows = await this.repo.findRandomCakeRows(pickedIds);
+    const rowById = new Map(rows.map((row) => [row.id.toString(), row]));
+
+    // 추출 순서를 유지해 그리드 배치도 무작위가 되게 한다
+    const items = pickedIds.flatMap((id) => {
+      const row = rowById.get(id.toString());
+      const thumbnailUrl = row?.images[0]?.image_url;
+      // 후보 조회가 이미지 보유를 보장하지만, 조회 사이의 삭제 경합에 대비해 방어
+      if (!thumbnailUrl) return [];
+      return [{ id: id.toString(), thumbnailUrl }];
+    });
+
+    return { items };
   }
 }

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -3,15 +3,21 @@ import { Injectable } from '@nestjs/common';
 import { parseId } from '@/common/utils/id-parser';
 import {
   DEFAULT_POPULAR_CAKES_LIMIT,
+  DEFAULT_SHOWCASE_LIMIT,
   MAX_POPULAR_CAKES_LIMIT,
 } from '@/features/product/constants/product-home.constants';
+import type { CustomCakeShowcaseInput } from '@/features/product/dto/inputs/custom-cake-showcase.input';
 import type { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import { ProductReviewRepository } from '@/features/product/repositories/product-review.repository';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import {
   toHomeBanner,
   toPopularCake,
 } from '@/features/product/services/product-home-mappers.helper';
-import type { PopularCakesResult } from '@/features/product/types/product-home-output.type';
+import type {
+  CustomCakeShowcaseItem,
+  PopularCakesResult,
+} from '@/features/product/types/product-home-output.type';
 import {
   DEFAULT_GLOBAL_RATING_PRIOR,
   popularityScore,
@@ -23,7 +29,10 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class ProductHomeService {
-  constructor(private readonly repo: ProductRepository) {}
+  constructor(
+    private readonly repo: ProductRepository,
+    private readonly reviewRepo: ProductReviewRepository,
+  ) {}
 
   /**
    * 홈 '상황별 인기 케이크' 섹션. 인기 매장과 동일 산식(최근 주문·찜·베이지안 평점)을
@@ -89,5 +98,48 @@ export class ProductHomeService {
       .map((entry, idx) => toPopularCake(entry.candidate, idx + 1));
 
     return { banner: bannerOutput, items, rankedAt };
+  }
+
+  /**
+   * 홈 '다른 사람들은 이렇게 만들었어요' 제작 후기(전체기간 좋아요순).
+   * Before(주문 커스텀 크롭)/After(리뷰 첫 이미지)가 모두 있는 리뷰만 후보.
+   * 데이터가 없으면 빈 배열(FE가 빈 상태 문구 처리).
+   */
+  async customCakeShowcase(
+    input?: CustomCakeShowcaseInput,
+  ): Promise<CustomCakeShowcaseItem[]> {
+    const limit = input?.limit ?? DEFAULT_SHOWCASE_LIMIT;
+    const ranked = await this.reviewRepo.listShowcaseReviewIdsByLikes(limit);
+    if (ranked.length === 0) return [];
+
+    const rows = await this.reviewRepo.findShowcaseReviewRowsByIds(
+      ranked.map((r) => r.id),
+    );
+    const rowById = new Map(rows.map((row) => [row.id.toString(), row]));
+
+    const items: CustomCakeShowcaseItem[] = [];
+    for (const entry of ranked) {
+      const row = rowById.get(entry.id.toString());
+      const beforeImageUrl = row?.order_item.free_edits[0]?.crop_image_url;
+      const afterImageUrl = row?.media[0]?.media_url;
+      // 후보 SQL이 존재를 보장하지만, 조회 사이의 삭제 경합에 대비해 한 번 더 방어
+      if (!row || !beforeImageUrl || !afterImageUrl) continue;
+
+      items.push({
+        reviewId: row.id.toString(),
+        rank: items.length + 1,
+        // 탈퇴(soft-delete) 작성자는 닉네임을 노출하지 않는다(익명화 정책)
+        authorNickname:
+          row.account.user_profile &&
+          row.account.user_profile.deleted_at === null
+            ? row.account.user_profile.nickname
+            : null,
+        reviewText: row.content,
+        likeCount: entry.likeCount,
+        beforeImageUrl,
+        afterImageUrl,
+      });
+    }
+    return items;
   }
 }

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -51,7 +51,8 @@ export class ProductHomeService {
       MAX_POPULAR_CAKES_LIMIT,
     );
     const categoryId =
-      input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
+      // GraphQL nullable 필드는 명시적 null도 허용 → null/undefined 모두 '필터 없음'
+      input?.categoryId != null ? parseId(input.categoryId) : undefined;
     const regionIds = input?.regionIds?.map((id) => parseId(id));
 
     const rankedAt = new Date();
@@ -155,13 +156,17 @@ export class ProductHomeService {
   async randomCakes(input?: RandomCakesInput): Promise<RandomCakesResult> {
     const limit = input?.limit ?? DEFAULT_RANDOM_CAKES_LIMIT;
     const categoryId =
-      input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
+      // GraphQL nullable 필드는 명시적 null도 허용 → null/undefined 모두 '필터 없음'
+      input?.categoryId != null ? parseId(input.categoryId) : undefined;
 
     const candidateIds = await this.repo.listRandomCakeCandidateIds(categoryId);
     if (candidateIds.length === 0) return { items: [] };
 
     const pickedIds = this.random.sample(candidateIds, limit);
-    const rows = await this.repo.findRandomCakeRows(pickedIds);
+    const rows = await this.repo.findRandomCakeRows({
+      productIds: pickedIds,
+      categoryId,
+    });
     const rowById = new Map(rows.map((row) => [row.id.toString(), row]));
 
     // 추출 순서를 유지해 그리드 배치도 무작위가 되게 한다

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -1,0 +1,86 @@
+import { Injectable } from '@nestjs/common';
+
+import { parseId } from '@/common/utils/id-parser';
+import { DEFAULT_POPULAR_CAKES_LIMIT } from '@/features/product/constants/product-home.constants';
+import type { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
+import { ProductRepository } from '@/features/product/repositories/product.repository';
+import {
+  toHomeBanner,
+  toPopularCake,
+} from '@/features/product/services/product-home-mappers.helper';
+import type { PopularCakesResult } from '@/features/product/types/product-home-output.type';
+import {
+  DEFAULT_GLOBAL_RATING_PRIOR,
+  popularityScore,
+  RANKING_RECENT_ORDER_DAYS,
+  type StoreMetrics,
+} from '@/features/store';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class ProductHomeService {
+  constructor(private readonly repo: ProductRepository) {}
+
+  /**
+   * 홈 '상황별 인기 케이크' 섹션. 인기 매장과 동일 산식(최근 주문·찜·베이지안 평점)을
+   * 상품 단위로 적용해 상위 카드를 뽑고, 카테고리 대표 배너를 함께 반환한다.
+   * 배너는 등록분이 없으면 null(fallback 없음 — FE placeholder 처리, 정책 확정 사항).
+   */
+  async popularCakes(input?: PopularCakesInput): Promise<PopularCakesResult> {
+    const limit = input?.limit ?? DEFAULT_POPULAR_CAKES_LIMIT;
+    const categoryId =
+      input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
+    const regionIds = input?.regionIds?.map((id) => parseId(id));
+
+    const rankedAt = new Date();
+    const [candidates, banner] = await Promise.all([
+      this.repo.findActiveCakesForRanking({ categoryId, regionIds }),
+      this.repo.findHomeBanner({ categoryId, now: rankedAt }),
+    ]);
+    const bannerOutput = banner ? toHomeBanner(banner) : null;
+    if (candidates.length === 0) {
+      return { banner: bannerOutput, items: [], rankedAt };
+    }
+
+    const productIds = candidates.map((c) => c.id);
+    const since = new Date(
+      rankedAt.getTime() - RANKING_RECENT_ORDER_DAYS * DAY_MS,
+    );
+
+    const [wishlistCounts, reviewStats, orderCounts, globalAverage] =
+      await Promise.all([
+        this.repo.aggregateProductWishlistCounts(productIds),
+        this.repo.aggregateProductReviewStats(productIds),
+        this.repo.aggregateProductRecentOrderCounts(productIds, since),
+        this.repo.globalReviewAverage(),
+      ]);
+    const prior = globalAverage ?? DEFAULT_GLOBAL_RATING_PRIOR;
+
+    const scored = candidates.map((candidate) => {
+      const review = reviewStats.get(candidate.id);
+      const metrics: StoreMetrics = {
+        recentOrderCount: orderCounts.get(candidate.id) ?? 0,
+        wishlistCount: wishlistCounts.get(candidate.id) ?? 0,
+        ratingAverage: review?.average ?? 0,
+        reviewCount: review?.count ?? 0,
+      };
+      return { candidate, metrics, score: popularityScore(metrics, prior) };
+    });
+
+    // 점수 desc → 리뷰수 desc → id desc (인기 매장과 동일한 안정적 동점 처리)
+    scored.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (b.metrics.reviewCount !== a.metrics.reviewCount) {
+        return b.metrics.reviewCount - a.metrics.reviewCount;
+      }
+      return b.candidate.id > a.candidate.id ? 1 : -1;
+    });
+
+    const items = scored
+      .slice(0, limit)
+      .map((entry, idx) => toPopularCake(entry.candidate, idx + 1));
+
+    return { banner: bannerOutput, items, rankedAt };
+  }
+}

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
-import { DEFAULT_POPULAR_CAKES_LIMIT } from '@/features/product/constants/product-home.constants';
+import {
+  DEFAULT_POPULAR_CAKES_LIMIT,
+  MAX_POPULAR_CAKES_LIMIT,
+} from '@/features/product/constants/product-home.constants';
 import type { PopularCakesInput } from '@/features/product/dto/inputs/popular-cakes.input';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
 import {
@@ -28,7 +31,11 @@ export class ProductHomeService {
    * 배너는 등록분이 없으면 null(fallback 없음 — FE placeholder 처리, 정책 확정 사항).
    */
   async popularCakes(input?: PopularCakesInput): Promise<PopularCakesResult> {
-    const limit = input?.limit ?? DEFAULT_POPULAR_CAKES_LIMIT;
+    // DTO(@Max)가 1차로 막지만, 직접 호출 경로에서도 "최대 3개" 계약을 지키도록 클램프
+    const limit = Math.min(
+      input?.limit ?? DEFAULT_POPULAR_CAKES_LIMIT,
+      MAX_POPULAR_CAKES_LIMIT,
+    );
     const categoryId =
       input?.categoryId !== undefined ? parseId(input.categoryId) : undefined;
     const regionIds = input?.regionIds?.map((id) => parseId(id));

--- a/src/features/product/types/product-category-output.type.ts
+++ b/src/features/product/types/product-category-output.type.ts
@@ -1,0 +1,11 @@
+/**
+ * product-category resolver 반환용 도메인 출력 타입.
+ * SDL(product-category.graphql)의 타입과 필드 일치.
+ */
+
+export interface CategoryItem {
+  id: string;
+  name: string;
+  categoryType: 'EVENT' | 'STYLE' | 'OTHER';
+  sortOrder: number;
+}

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -1,0 +1,29 @@
+/**
+ * product-home resolver 반환용 도메인 출력 타입.
+ * SDL(product-home.graphql)의 타입과 필드 일치.
+ */
+
+export interface HomeBanner {
+  id: string;
+  imageUrl: string;
+  title: string | null;
+  linkCategoryId: string | null;
+}
+
+export interface PopularCake {
+  id: string;
+  rank: number;
+  name: string;
+  thumbnailUrl: string | null;
+  storeName: string;
+  regionLabel: string | null;
+  regularPrice: number;
+  salePrice: number | null;
+  discountRate: number;
+}
+
+export interface PopularCakesResult {
+  banner: HomeBanner | null;
+  items: PopularCake[];
+  rankedAt: Date;
+}

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -31,3 +31,13 @@ export interface PopularCakesResult {
   items: PopularCake[];
   rankedAt: Date;
 }
+
+export interface CustomCakeShowcaseItem {
+  reviewId: string;
+  rank: number;
+  authorNickname: string | null;
+  reviewText: string | null;
+  likeCount: number;
+  beforeImageUrl: string;
+  afterImageUrl: string;
+}

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -7,6 +7,10 @@ export interface HomeBanner {
   id: string;
   imageUrl: string;
   title: string | null;
+  linkType: 'NONE' | 'URL' | 'PRODUCT' | 'STORE' | 'CATEGORY';
+  linkUrl: string | null;
+  linkProductId: string | null;
+  linkStoreId: string | null;
   linkCategoryId: string | null;
 }
 

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -32,6 +32,15 @@ export interface PopularCakesResult {
   rankedAt: Date;
 }
 
+export interface RandomCake {
+  id: string;
+  thumbnailUrl: string;
+}
+
+export interface RandomCakesResult {
+  items: RandomCake[];
+}
+
 export interface CustomCakeShowcaseItem {
   reviewId: string;
   rank: number;

--- a/src/features/store/dto/inputs/today-pickup-stores.input.ts
+++ b/src/features/store/dto/inputs/today-pickup-stores.input.ts
@@ -1,0 +1,26 @@
+import {
+  IsArray,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class TodayPickupStoresInput {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  regionIds?: string[];
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  offset?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  limit?: number;
+}

--- a/src/features/store/index.ts
+++ b/src/features/store/index.ts
@@ -1,3 +1,14 @@
 // cross-feature 공개 API. 단일 구현 repo라 토큰/인터페이스 없이 구체 클래스로 주입(의도적).
 export { StoreModule } from '@/features/store/store.module';
 export { StoreRepository } from '@/features/store/repositories/store.repository';
+// 인기 랭킹 산식·표기 규칙. 상품 랭킹(product feature)이 동일 정책을 공유한다.
+export {
+  DEFAULT_GLOBAL_RATING_PRIOR,
+  RANKING_RECENT_ORDER_DAYS,
+  RANKING_VALID_ORDER_STATUSES,
+} from '@/features/store/constants/store-ranking.constants';
+export { buildRegionLabel } from '@/features/store/services/store-mappers.helper';
+export {
+  popularityScore,
+  type StoreMetrics,
+} from '@/features/store/services/store-ranking.helper';

--- a/src/features/store/repositories/store.repository.ts
+++ b/src/features/store/repositories/store.repository.ts
@@ -13,6 +13,16 @@ export interface StoreCandidateRow {
   address_city: string | null;
   address_neighborhood: string | null;
   region: { name: string } | null;
+  pickup_slot_interval_minutes: number;
+  min_lead_time_minutes: number;
+}
+
+/** 특정 요일의 매장 영업시간 row(오늘 픽업 슬롯 산출용). */
+export interface StoreTodayBusinessHourRow {
+  store_id: bigint;
+  is_closed: boolean;
+  open_time: Date | null;
+  close_time: Date | null;
 }
 
 export interface StoreReviewStat {
@@ -61,8 +71,93 @@ export class StoreRepository {
         address_city: true,
         address_neighborhood: true,
         region: { select: { name: true } },
+        pickup_slot_interval_minutes: true,
+        min_lead_time_minutes: true,
       },
     });
+  }
+
+  /** 특정 요일(0=일~6=토)의 매장별 영업시간. */
+  async findBusinessHoursByWeekday(
+    storeIds: bigint[],
+    dayOfWeek: number,
+  ): Promise<StoreTodayBusinessHourRow[]> {
+    if (storeIds.length === 0) return [];
+    return this.prisma.storeBusinessHour.findMany({
+      where: {
+        store_id: { in: storeIds },
+        day_of_week: dayOfWeek,
+        deleted_at: null,
+      },
+      select: {
+        store_id: true,
+        is_closed: true,
+        open_time: true,
+        close_time: true,
+      },
+    });
+  }
+
+  /** 특정 날짜(@db.Date, UTC 자정 표현)에 특별휴무인 매장 id 집합. */
+  async findSpecialClosureStoreIds(
+    storeIds: bigint[],
+    date: Date,
+  ): Promise<Set<string>> {
+    if (storeIds.length === 0) return new Set();
+    const rows = await this.prisma.storeSpecialClosure.findMany({
+      where: {
+        store_id: { in: storeIds },
+        closure_date: date,
+        deleted_at: null,
+      },
+      select: { store_id: true },
+    });
+    return new Set(rows.map((r) => r.store_id.toString()));
+  }
+
+  /** 특정 날짜의 매장별 일일 capacity(레코드 없으면 무제한 취급은 호출부 책임). */
+  async findDailyCapacities(
+    storeIds: bigint[],
+    date: Date,
+  ): Promise<Map<bigint, number>> {
+    if (storeIds.length === 0) return new Map();
+    const rows = await this.prisma.storeDailyCapacity.findMany({
+      where: {
+        store_id: { in: storeIds },
+        capacity_date: date,
+        deleted_at: null,
+      },
+      select: { store_id: true, capacity: true },
+    });
+    return new Map(rows.map((r) => [r.store_id, r.capacity]));
+  }
+
+  /**
+   * 픽업 시각이 [rangeStart, rangeEnd)인 매장별 유효 주문 수(주문 단위 distinct).
+   * capacity 소진 판정용 — CANCELED·soft-delete 주문은 제외한다.
+   */
+  async countPickupOrdersInRange(
+    storeIds: bigint[],
+    rangeStart: Date,
+    rangeEnd: Date,
+  ): Promise<Map<bigint, number>> {
+    if (storeIds.length === 0) return new Map();
+    const rows = await this.prisma.$queryRaw<
+      { store_id: bigint; order_count: bigint }[]
+    >(Prisma.sql`
+      SELECT oi.store_id AS store_id, COUNT(DISTINCT oi.order_id) AS order_count
+      FROM order_item oi
+      JOIN \`order\` o
+        ON o.id = oi.order_id
+        AND o.deleted_at IS NULL
+        AND o.status <> 'CANCELED'
+        AND o.pickup_at >= ${rangeStart}
+        AND o.pickup_at < ${rangeEnd}
+      WHERE oi.store_id IN (${Prisma.join(storeIds)})
+        AND oi.deleted_at IS NULL
+      GROUP BY oi.store_id
+    `);
+    return new Map(rows.map((r) => [r.store_id, Number(r.order_count)]));
   }
 
   /** 활성 매장 존재 검증(찜 등). */

--- a/src/features/store/repositories/store.repository.ts
+++ b/src/features/store/repositories/store.repository.ts
@@ -133,19 +133,20 @@ export class StoreRepository {
   }
 
   /**
-   * 픽업 시각이 [rangeStart, rangeEnd)인 매장별 유효 주문 수(주문 단위 distinct).
-   * capacity 소진 판정용 — CANCELED·soft-delete 주문은 제외한다.
+   * 픽업 시각이 [rangeStart, rangeEnd)인 매장별 예약 제작 수량(아이템 quantity 합).
+   * capacity(일별 생산 가능 '수량') 소진 판정용 — CANCELED·soft-delete 주문은 제외한다.
    */
-  async countPickupOrdersInRange(
+  async sumPickupQuantitiesInRange(
     storeIds: bigint[],
     rangeStart: Date,
     rangeEnd: Date,
   ): Promise<Map<bigint, number>> {
     if (storeIds.length === 0) return new Map();
     const rows = await this.prisma.$queryRaw<
-      { store_id: bigint; order_count: bigint }[]
+      { store_id: bigint; booked_quantity: bigint }[]
     >(Prisma.sql`
-      SELECT oi.store_id AS store_id, COUNT(DISTINCT oi.order_id) AS order_count
+      SELECT oi.store_id AS store_id,
+             CAST(COALESCE(SUM(oi.quantity), 0) AS UNSIGNED) AS booked_quantity
       FROM order_item oi
       JOIN \`order\` o
         ON o.id = oi.order_id
@@ -157,7 +158,7 @@ export class StoreRepository {
         AND oi.deleted_at IS NULL
       GROUP BY oi.store_id
     `);
-    return new Map(rows.map((r) => [r.store_id, Number(r.order_count)]));
+    return new Map(rows.map((r) => [r.store_id, Number(r.booked_quantity)]));
   }
 
   /** 활성 매장 존재 검증(찜 등). */

--- a/src/features/store/resolvers/store-today-pickup-query.resolver.spec.ts
+++ b/src/features/store/resolvers/store-today-pickup-query.resolver.spec.ts
@@ -1,0 +1,75 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
+import { StoreRepository } from '@/features/store/repositories/store.repository';
+import { StoreTodayPickupQueryResolver } from '@/features/store/resolvers/store-today-pickup-query.resolver';
+import { StoreListingService } from '@/features/store/services/store-listing.service';
+import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+// 2026-08-19(수) 16:00 KST 고정
+const NOW = new Date('2026-08-19T07:00:00.000Z');
+const TODAY_WEEKDAY = new Date(Date.UTC(2026, 7, 19)).getUTCDay();
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 통합 경로 검증.
+ * 슬롯/휴무/capacity 분기 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('StoreTodayPickup Query Resolver (real DB)', () => {
+  let resolver: StoreTodayPickupQueryResolver;
+  let clock: ClockService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        StoreTodayPickupQueryResolver,
+        StoreTodayPickupService,
+        StoreListingService,
+        StoreRepository,
+        StoreWishlistRepository,
+        ClockService,
+      ],
+    });
+    resolver = module.get(StoreTodayPickupQueryResolver);
+    clock = module.get(ClockService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    jest.spyOn(clock, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('todayPickupStores: 서비스에 위임해 오늘 픽업 가능 매장을 반환한다', async () => {
+    const store = await createStore(prisma, { store_name: '오늘영업매장' });
+    await prisma.storeBusinessHour.create({
+      data: {
+        store_id: store.id,
+        day_of_week: TODAY_WEEKDAY,
+        is_closed: false,
+        open_time: new Date(Date.UTC(1970, 0, 1, 10, 0, 0)),
+        close_time: new Date(Date.UTC(1970, 0, 1, 20, 0, 0)),
+      },
+    });
+
+    const result = await resolver.todayPickupStores(undefined);
+
+    expect(result.items.map((i) => i.storeName)).toEqual(['오늘영업매장']);
+    expect(result.items[0].slots.length).toBeGreaterThan(0);
+    expect(result.asOf).toEqual(NOW);
+  });
+});

--- a/src/features/store/resolvers/store-today-pickup-query.resolver.ts
+++ b/src/features/store/resolvers/store-today-pickup-query.resolver.ts
@@ -1,0 +1,31 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { TodayPickupStoresInput } from '@/features/store/dto/inputs/today-pickup-stores.input';
+import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
+import type { TodayPickupStoreConnection } from '@/features/store/types/store-today-pickup-output.type';
+import {
+  CurrentUser,
+  OptionalJwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+/**
+ * 오늘 픽업 가능 매장 조회 resolver. 비로그인도 접근 가능한 public query.
+ * 옵셔널 인증으로 로그인 시에만 isWishlisted를 채운다.
+ */
+@Resolver('Query')
+export class StoreTodayPickupQueryResolver {
+  constructor(private readonly service: StoreTodayPickupService) {}
+
+  @Query('todayPickupStores')
+  @UseGuards(OptionalJwtAuthGuard)
+  todayPickupStores(
+    @CurrentUser() user: JwtUser | undefined,
+    @Args('input', { nullable: true }) input?: TodayPickupStoresInput,
+  ): Promise<TodayPickupStoreConnection> {
+    const accountId = user ? parseAccountId(user) : undefined;
+    return this.service.todayPickupStores(input, accountId);
+  }
+}

--- a/src/features/store/services/store-listing.service.ts
+++ b/src/features/store/services/store-listing.service.ts
@@ -106,7 +106,8 @@ export class StoreListingService {
     const pageStoreIds = page.map((s) => s.candidate.id);
     const [imagesByStore, wishlistedIds] = await Promise.all([
       this.repo.findStoreCakeImages(pageStoreIds),
-      accountId
+      // 0n도 유효한 계정 id — truthy 체크는 0n을 비로그인으로 떨궈 undefined로만 분기한다
+      accountId !== undefined
         ? this.wishlistRepo.findWishlistedStoreIds({
             accountId,
             storeIds: pageStoreIds,

--- a/src/features/store/services/store-listing.service.ts
+++ b/src/features/store/services/store-listing.service.ts
@@ -8,7 +8,10 @@ import {
 } from '@/features/store/constants/store-ranking.constants';
 import type { PopularStoresInput } from '@/features/store/dto/inputs/popular-stores.input';
 import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
-import { StoreRepository } from '@/features/store/repositories/store.repository';
+import {
+  StoreRepository,
+  type StoreCandidateRow,
+} from '@/features/store/repositories/store.repository';
 import { toPopularStore } from '@/features/store/services/store-mappers.helper';
 import {
   popularityScore,
@@ -18,6 +21,13 @@ import type { PopularStoreConnection } from '@/features/store/types/store-output
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** 점수화·정렬이 끝난 랭킹 항목. */
+export interface ScoredStore {
+  candidate: StoreCandidateRow;
+  metrics: StoreMetrics;
+  score: number;
+}
+
 @Injectable()
 export class StoreListingService {
   constructor(
@@ -26,24 +36,17 @@ export class StoreListingService {
   ) {}
 
   /**
-   * 인기 매장 리스트. 후보 매장의 주문·찜·평점을 실시간 집계해 점수화·정렬한 뒤
-   * 페이지를 잘라 대표 이미지를 채운다.
+   * 활성 매장 후보의 주문·찜·평점을 실시간 집계해 점수화·정렬한다.
+   * popularStores와 todayPickupStores가 동일 랭킹 정책을 공유한다.
    *
    * 실시간 집계는 매장 규모가 커지면 캐시/배치(스냅샷)로 최적화할 여지가 있다.
    */
-  async popularStores(
-    input?: PopularStoresInput,
-    accountId?: bigint,
-  ): Promise<PopularStoreConnection> {
-    const offset = input?.offset ?? 0;
-    const limit = input?.limit ?? DEFAULT_POPULAR_STORES_LIMIT;
-    const regionIds = input?.regionIds?.map((id) => parseId(id));
-
-    const rankedAt = new Date();
+  async rankActiveStores(
+    regionIds: bigint[] | undefined,
+    rankedAt: Date,
+  ): Promise<ScoredStore[]> {
     const candidates = await this.repo.findActiveStoresForRanking(regionIds);
-    if (candidates.length === 0) {
-      return { items: [], totalCount: 0, hasMore: false, rankedAt };
-    }
+    if (candidates.length === 0) return [];
 
     const storeIds = candidates.map((c) => c.id);
     const since = new Date(
@@ -78,6 +81,25 @@ export class StoreListingService {
       }
       return b.candidate.id > a.candidate.id ? 1 : -1;
     });
+    return scored;
+  }
+
+  /**
+   * 인기 매장 리스트. 랭킹 후 페이지를 잘라 대표 이미지·찜 여부를 채운다.
+   */
+  async popularStores(
+    input?: PopularStoresInput,
+    accountId?: bigint,
+  ): Promise<PopularStoreConnection> {
+    const offset = input?.offset ?? 0;
+    const limit = input?.limit ?? DEFAULT_POPULAR_STORES_LIMIT;
+    const regionIds = input?.regionIds?.map((id) => parseId(id));
+
+    const rankedAt = new Date();
+    const scored = await this.rankActiveStores(regionIds, rankedAt);
+    if (scored.length === 0) {
+      return { items: [], totalCount: 0, hasMore: false, rankedAt };
+    }
 
     const totalCount = scored.length;
     const page = scored.slice(offset, offset + limit);

--- a/src/features/store/services/store-mappers.helper.spec.ts
+++ b/src/features/store/services/store-mappers.helper.spec.ts
@@ -11,6 +11,8 @@ function row(overrides: Partial<StoreCandidateRow>): StoreCandidateRow {
     address_city: null,
     address_neighborhood: null,
     region: null,
+    pickup_slot_interval_minutes: 30,
+    min_lead_time_minutes: 30,
     ...overrides,
   };
 }

--- a/src/features/store/services/store-today-pickup.helper.spec.ts
+++ b/src/features/store/services/store-today-pickup.helper.spec.ts
@@ -1,0 +1,76 @@
+import {
+  buildTodaySlots,
+  timeColumnToMinutes,
+} from '@/features/store/services/store-today-pickup.helper';
+
+describe('store-today-pickup.helper', () => {
+  describe('buildTodaySlots', () => {
+    it('영업시간을 간격대로 잘라 슬롯을 만들고 리드타임 이전은 마감 처리한다', () => {
+      // 14:00~16:00, 30분 간격, 현재 14:20 + 리드 30분 → 14:50 이전 슬롯 마감
+      const slots = buildTodaySlots({
+        openMinutes: 14 * 60,
+        closeMinutes: 16 * 60,
+        intervalMinutes: 30,
+        leadTimeMinutes: 30,
+        nowMinutes: 14 * 60 + 20,
+      });
+
+      expect(slots).toEqual([
+        { time: '14:00', available: false },
+        { time: '14:30', available: false },
+        { time: '15:00', available: true },
+        { time: '15:30', available: true },
+      ]);
+    });
+
+    it('close 시각 자체는 슬롯에 포함하지 않는다(미포함 경계)', () => {
+      const slots = buildTodaySlots({
+        openMinutes: 10 * 60,
+        closeMinutes: 11 * 60,
+        intervalMinutes: 60,
+        leadTimeMinutes: 0,
+        nowMinutes: 0,
+      });
+
+      expect(slots).toEqual([{ time: '10:00', available: true }]);
+    });
+
+    it('간격이 0 이하거나 영업시간이 뒤집힌 경우 빈 배열을 반환한다', () => {
+      const base = {
+        openMinutes: 10 * 60,
+        closeMinutes: 12 * 60,
+        leadTimeMinutes: 0,
+        nowMinutes: 0,
+      };
+
+      expect(buildTodaySlots({ ...base, intervalMinutes: 0 })).toEqual([]);
+      expect(
+        buildTodaySlots({
+          ...base,
+          intervalMinutes: 30,
+          openMinutes: 12 * 60,
+          closeMinutes: 10 * 60,
+        }),
+      ).toEqual([]);
+    });
+
+    it('현재+리드타임이 영업 종료를 넘으면 전 슬롯이 마감된다', () => {
+      const slots = buildTodaySlots({
+        openMinutes: 10 * 60,
+        closeMinutes: 12 * 60,
+        intervalMinutes: 30,
+        leadTimeMinutes: 60,
+        nowMinutes: 11 * 60 + 30,
+      });
+
+      expect(slots.every((slot) => !slot.available)).toBe(true);
+    });
+  });
+
+  describe('timeColumnToMinutes', () => {
+    it('@db.Time 값(UTC 기반)을 자정 경과 분으로 변환한다', () => {
+      expect(timeColumnToMinutes(new Date('1970-01-01T10:30:00Z'))).toBe(630);
+      expect(timeColumnToMinutes(new Date('1970-01-01T00:00:00Z'))).toBe(0);
+    });
+  });
+});

--- a/src/features/store/services/store-today-pickup.helper.ts
+++ b/src/features/store/services/store-today-pickup.helper.ts
@@ -4,7 +4,11 @@ import type { TodayPickupSlot } from '@/features/store/types/store-today-pickup-
 export interface TodaySlotPolicy {
   /** 영업 시작(자정 경과 분). */
   openMinutes: number;
-  /** 영업 종료(자정 경과 분, 미포함 — 마지막 슬롯은 close-interval). */
+  /**
+   * 영업 종료(자정 경과 분, 미포함).
+   * 슬롯은 픽업 '시각' 포인트라 시작 시각이 close 이전이면 유효하다
+   * (전역 정책 pickup.constants의 close 미포함 규칙과 동일 해석).
+   */
   closeMinutes: number;
   /** 슬롯 간격(분). */
   intervalMinutes: number;

--- a/src/features/store/services/store-today-pickup.helper.ts
+++ b/src/features/store/services/store-today-pickup.helper.ts
@@ -1,0 +1,45 @@
+import { formatMinutesOfDay } from '@/common/utils/kst-time';
+import type { TodayPickupSlot } from '@/features/store/types/store-today-pickup-output.type';
+
+export interface TodaySlotPolicy {
+  /** 영업 시작(자정 경과 분). */
+  openMinutes: number;
+  /** 영업 종료(자정 경과 분, 미포함 — 마지막 슬롯은 close-interval). */
+  closeMinutes: number;
+  /** 슬롯 간격(분). */
+  intervalMinutes: number;
+  /** 최소 리드타임(분). now+lead 이전 슬롯은 마감. */
+  leadTimeMinutes: number;
+  /** 현재 시각(자정 경과 분). */
+  nowMinutes: number;
+}
+
+/**
+ * 오늘 영업시간 [open, close) 를 간격대로 잘라 슬롯을 만든다.
+ * 리드타임(now+lead) 이전 슬롯은 available=false로 표기한다(UI 회색 슬롯).
+ * 슬롯 단위 예약 점유는 capacity가 일(日) 단위 모델이라 표현하지 않는다 —
+ * capacity 소진은 호출부에서 매장 자체를 제외한다(figma 명세 외 정책 결정).
+ */
+export function buildTodaySlots(policy: TodaySlotPolicy): TodayPickupSlot[] {
+  if (
+    policy.intervalMinutes <= 0 ||
+    policy.closeMinutes <= policy.openMinutes
+  ) {
+    return [];
+  }
+  const cutoff = policy.nowMinutes + policy.leadTimeMinutes;
+  const slots: TodayPickupSlot[] = [];
+  for (
+    let t = policy.openMinutes;
+    t < policy.closeMinutes;
+    t += policy.intervalMinutes
+  ) {
+    slots.push({ time: formatMinutesOfDay(t), available: t >= cutoff });
+  }
+  return slots;
+}
+
+/** Prisma @db.Time(0) 값(1970-01-01 UTC 기반)을 자정 경과 분으로 변환. */
+export function timeColumnToMinutes(value: Date): number {
+  return value.getUTCHours() * 60 + value.getUTCMinutes();
+}

--- a/src/features/store/services/store-today-pickup.service.spec.ts
+++ b/src/features/store/services/store-today-pickup.service.spec.ts
@@ -73,8 +73,12 @@ describe('StoreTodayPickupService (real DB)', () => {
     });
   }
 
-  /** 오늘 픽업 유효 주문 n건 생성. */
-  async function bookToday(store: Store, count: number): Promise<void> {
+  /** 오늘 픽업 유효 주문 n건 생성(주문당 케이크 quantity개). */
+  async function bookToday(
+    store: Store,
+    count: number,
+    quantity = 1,
+  ): Promise<void> {
     for (let i = 0; i < count; i += 1) {
       const order = await createOrder(prisma, {
         status: 'CONFIRMED',
@@ -83,6 +87,7 @@ describe('StoreTodayPickupService (real DB)', () => {
       await createOrderItem(prisma, {
         order_id: order.id,
         store_id: store.id,
+        quantity,
       });
     }
   }
@@ -197,6 +202,24 @@ describe('StoreTodayPickupService (real DB)', () => {
       const result = await service.todayPickupStores();
 
       expect(result.items.map((i) => i.storeName)).toEqual(['여유매장']);
+    });
+
+    it('capacity는 주문 수가 아니라 제작 수량(quantity 합) 기준으로 소진된다', async () => {
+      // 주문 1건이라도 quantity=2면 capacity 2를 전부 소진한다
+      const store = await createStore(prisma, { store_name: '수량마감매장' });
+      await openToday(store, 10, 20);
+      await prisma.storeDailyCapacity.create({
+        data: {
+          store_id: store.id,
+          capacity_date: TODAY_DATE_ONLY,
+          capacity: 2,
+        },
+      });
+      await bookToday(store, 1, 2);
+
+      await expect(service.todayPickupStores()).resolves.toMatchObject({
+        items: [],
+      });
     });
 
     it('capacity 레코드가 없으면 무제한으로 간주한다', async () => {

--- a/src/features/store/services/store-today-pickup.service.spec.ts
+++ b/src/features/store/services/store-today-pickup.service.spec.ts
@@ -113,6 +113,24 @@ describe('StoreTodayPickupService (real DB)', () => {
       ]);
     });
 
+    it('초가 남은 시각은 다음 분으로 올려 리드타임을 보수적으로 적용한다', async () => {
+      // 16:00:30 KST + 리드 60분 → 17:00 슬롯은 59분 30초밖에 안 남아 마감
+      jest
+        .spyOn(clock, 'now')
+        .mockReturnValue(new Date('2026-08-19T07:00:30.000Z'));
+      const store = await createStore(prisma, { min_lead_time_minutes: 60 });
+      await openToday(store, 16, 18);
+
+      const [item] = (await service.todayPickupStores()).items;
+
+      expect(item.slots).toEqual([
+        { time: '16:00', available: false },
+        { time: '16:30', available: false },
+        { time: '17:00', available: false },
+        { time: '17:30', available: true },
+      ]);
+    });
+
     it('오늘 요일 휴무·영업시간 미설정·이미 영업 종료된 매장은 제외한다', async () => {
       const closedDay = await createStore(prisma, { store_name: '요일휴무' });
       await prisma.storeBusinessHour.create({

--- a/src/features/store/services/store-today-pickup.service.spec.ts
+++ b/src/features/store/services/store-today-pickup.service.spec.ts
@@ -1,0 +1,272 @@
+import type { PrismaClient, Store } from '@prisma/client';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
+import { StoreRepository } from '@/features/store/repositories/store.repository';
+import { StoreListingService } from '@/features/store/services/store-listing.service';
+import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createOrder,
+  createOrderItem,
+  createStore,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+// 2026-08-19(수) 16:00 KST 고정. 요일·자정 경계 계산이 모두 이 시각 기준.
+const NOW = new Date('2026-08-19T07:00:00.000Z');
+const TODAY_WEEKDAY = new Date(Date.UTC(2026, 7, 19)).getUTCDay();
+const TODAY_DATE_ONLY = new Date(Date.UTC(2026, 7, 19));
+/** 오늘 15:00 KST(UTC 06:00) — 픽업 예정 시각으로 사용. */
+const TODAY_PICKUP_AT = new Date('2026-08-19T06:00:00.000Z');
+
+describe('StoreTodayPickupService (real DB)', () => {
+  let service: StoreTodayPickupService;
+  let clock: ClockService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        StoreTodayPickupService,
+        StoreListingService,
+        StoreRepository,
+        StoreWishlistRepository,
+        ClockService,
+      ],
+    });
+    service = module.get(StoreTodayPickupService);
+    clock = module.get(ClockService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    jest.spyOn(clock, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** 오늘 요일 영업시간(HH 기준) 설정. */
+  async function openToday(
+    store: Store,
+    openHour: number,
+    closeHour: number,
+  ): Promise<void> {
+    await prisma.storeBusinessHour.create({
+      data: {
+        store_id: store.id,
+        day_of_week: TODAY_WEEKDAY,
+        is_closed: false,
+        open_time: new Date(Date.UTC(1970, 0, 1, openHour, 0, 0)),
+        close_time: new Date(Date.UTC(1970, 0, 1, closeHour, 0, 0)),
+      },
+    });
+  }
+
+  /** 오늘 픽업 유효 주문 n건 생성. */
+  async function bookToday(store: Store, count: number): Promise<void> {
+    for (let i = 0; i < count; i += 1) {
+      const order = await createOrder(prisma, {
+        status: 'CONFIRMED',
+        pickup_at: TODAY_PICKUP_AT,
+      });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        store_id: store.id,
+      });
+    }
+  }
+
+  describe('todayPickupStores', () => {
+    it('오늘 영업시간 슬롯을 만들고 리드타임 이전 슬롯은 available=false다', async () => {
+      const store = await createStore(prisma, {
+        store_name: '헤즈케이크',
+        min_lead_time_minutes: 60,
+      });
+      await openToday(store, 14, 18); // 14:00~18:00, 현재 16:00 + 60분 → 17:00부터 가용
+
+      const result = await service.todayPickupStores();
+
+      expect(result.totalCount).toBe(1);
+      expect(result.asOf).toEqual(NOW);
+      const [item] = result.items;
+      expect(item.storeName).toBe('헤즈케이크');
+      expect(item.slots).toEqual([
+        { time: '14:00', available: false },
+        { time: '14:30', available: false },
+        { time: '15:00', available: false },
+        { time: '15:30', available: false },
+        { time: '16:00', available: false },
+        { time: '16:30', available: false },
+        { time: '17:00', available: true },
+        { time: '17:30', available: true },
+      ]);
+    });
+
+    it('오늘 요일 휴무·영업시간 미설정·이미 영업 종료된 매장은 제외한다', async () => {
+      const closedDay = await createStore(prisma, { store_name: '요일휴무' });
+      await prisma.storeBusinessHour.create({
+        data: {
+          store_id: closedDay.id,
+          day_of_week: TODAY_WEEKDAY,
+          is_closed: true,
+        },
+      });
+      await createStore(prisma, { store_name: '시간미설정' });
+      const ended = await createStore(prisma, { store_name: '영업종료' });
+      await openToday(ended, 9, 12); // 현재 16:00 → 가용 슬롯 없음
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items).toEqual([]);
+      expect(result.totalCount).toBe(0);
+    });
+
+    it('오늘 특별휴무인 매장은 제외한다', async () => {
+      const store = await createStore(prisma, { store_name: '특별휴무' });
+      await openToday(store, 10, 20);
+      await prisma.storeSpecialClosure.create({
+        data: { store_id: store.id, closure_date: TODAY_DATE_ONLY },
+      });
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items).toEqual([]);
+    });
+
+    it('일일 capacity가 소진된 매장은 제외한다(CANCELED 주문 미집계)', async () => {
+      const full = await createStore(prisma, { store_name: '마감매장' });
+      await openToday(full, 10, 20);
+      await prisma.storeDailyCapacity.create({
+        data: {
+          store_id: full.id,
+          capacity_date: TODAY_DATE_ONLY,
+          capacity: 2,
+        },
+      });
+      await bookToday(full, 2);
+
+      const available = await createStore(prisma, { store_name: '여유매장' });
+      await openToday(available, 10, 20);
+      await prisma.storeDailyCapacity.create({
+        data: {
+          store_id: available.id,
+          capacity_date: TODAY_DATE_ONLY,
+          capacity: 2,
+        },
+      });
+      await bookToday(available, 1);
+      // CANCELED 주문은 capacity를 소모하지 않는다
+      const canceled = await createOrder(prisma, {
+        status: 'CANCELED',
+        pickup_at: TODAY_PICKUP_AT,
+      });
+      await createOrderItem(prisma, {
+        order_id: canceled.id,
+        store_id: available.id,
+      });
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items.map((i) => i.storeName)).toEqual(['여유매장']);
+    });
+
+    it('capacity 레코드가 없으면 무제한으로 간주한다', async () => {
+      const store = await createStore(prisma, { store_name: '무제한매장' });
+      await openToday(store, 10, 20);
+      await bookToday(store, 3);
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items.map((i) => i.storeName)).toEqual(['무제한매장']);
+    });
+
+    it('인기 매장 랭킹 순으로 정렬한다(찜 많은 매장 우선)', async () => {
+      const plain = await createStore(prisma, { store_name: '일반매장' });
+      await openToday(plain, 10, 20);
+      const popular = await createStore(prisma, { store_name: '인기매장' });
+      await openToday(popular, 10, 20);
+      for (let i = 0; i < 3; i += 1) {
+        const account = await createAccount(prisma, { account_type: 'USER' });
+        await prisma.storeWishlistItem.create({
+          data: { account_id: account.id, store_id: popular.id },
+        });
+      }
+
+      const result = await service.todayPickupStores();
+
+      expect(result.items.map((i) => i.storeName)).toEqual([
+        '인기매장',
+        '일반매장',
+      ]);
+    });
+
+    it('regionIds 필터와 offset 페이지네이션을 적용한다', async () => {
+      const region = await prisma.region.create({
+        data: { level: 2, name: '청라동', slug: 'test-cheongna' },
+      });
+      const inRegion = await createStore(prisma, {
+        store_name: '청라매장',
+        region_id: region.id,
+      });
+      await openToday(inRegion, 10, 20);
+      const outRegion = await createStore(prisma, { store_name: '타지역매장' });
+      await openToday(outRegion, 10, 20);
+
+      const filtered = await service.todayPickupStores({
+        regionIds: [region.id.toString()],
+      });
+      expect(filtered.items.map((i) => i.storeName)).toEqual(['청라매장']);
+
+      const paged = await service.todayPickupStores({ offset: 1, limit: 1 });
+      expect(paged.totalCount).toBe(2);
+      expect(paged.items).toHaveLength(1);
+      expect(paged.hasMore).toBe(false);
+    });
+
+    it('로그인 사용자의 찜 여부와 매장 카드 정보를 채운다', async () => {
+      const store = await createStore(prisma, {
+        store_name: '찜매장',
+        address_city: '인천',
+        address_neighborhood: '청라동',
+      });
+      await openToday(store, 10, 20);
+      const user = await createAccount(prisma, { account_type: 'USER' });
+      await prisma.storeWishlistItem.create({
+        data: { account_id: user.id, store_id: store.id },
+      });
+
+      const [asUser, asGuest] = [
+        await service.todayPickupStores(undefined, user.id),
+        await service.todayPickupStores(),
+      ];
+
+      expect(asUser.items[0]).toMatchObject({
+        storeName: '찜매장',
+        regionLabel: '인천 청라동',
+        isWishlisted: true,
+      });
+      expect(asGuest.items[0].isWishlisted).toBe(false);
+    });
+
+    it('매장이 없으면 빈 결과를 반환한다', async () => {
+      const result = await service.todayPickupStores();
+
+      expect(result).toMatchObject({
+        items: [],
+        totalCount: 0,
+        hasMore: false,
+      });
+    });
+  });
+});

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -67,7 +67,10 @@ export class StoreTodayPickupService {
     const hourByStore = new Map(
       businessHours.map((h) => [h.store_id.toString(), h]),
     );
-    const nowMinutes = kstMinutesOfDay(asOf);
+    // 분 단위 절삭은 리드타임을 최대 59초 짧게 만들므로, 초가 남으면 다음 분으로 올린다
+    const hasSubMinute =
+      asOf.getUTCSeconds() > 0 || asOf.getUTCMilliseconds() > 0;
+    const nowMinutes = kstMinutesOfDay(asOf) + (hasSubMinute ? 1 : 0);
 
     const open: { entry: ScoredStore; slots: TodayPickupSlot[] }[] = [];
     for (const entry of scored) {

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -1,0 +1,156 @@
+import { Injectable } from '@nestjs/common';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { parseId } from '@/common/utils/id-parser';
+import {
+  kstMidnightUtc,
+  kstMinutesOfDay,
+  toKstYmd,
+} from '@/common/utils/kst-time';
+import { DEFAULT_POPULAR_STORES_LIMIT } from '@/features/store/constants/store-ranking.constants';
+import type { TodayPickupStoresInput } from '@/features/store/dto/inputs/today-pickup-stores.input';
+import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
+import { StoreRepository } from '@/features/store/repositories/store.repository';
+import {
+  StoreListingService,
+  type ScoredStore,
+} from '@/features/store/services/store-listing.service';
+import { buildRegionLabel } from '@/features/store/services/store-mappers.helper';
+import {
+  buildTodaySlots,
+  timeColumnToMinutes,
+} from '@/features/store/services/store-today-pickup.helper';
+import type {
+  TodayPickupSlot,
+  TodayPickupStoreConnection,
+} from '@/features/store/types/store-today-pickup-output.type';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class StoreTodayPickupService {
+  constructor(
+    private readonly repo: StoreRepository,
+    private readonly wishlistRepo: StoreWishlistRepository,
+    private readonly listingService: StoreListingService,
+    private readonly clock: ClockService,
+  ) {}
+
+  /**
+   * 오늘(KST) 픽업 가능 매장 리스트. 인기 매장과 동일 랭킹으로 정렬하되,
+   * 매장별 정책(요일 영업시간·특별휴무·슬롯 간격·리드타임·일일 capacity)을
+   * 모두 반영해 오늘 예약 가능 슬롯이 1개 이상인 매장만 노출한다.
+   */
+  async todayPickupStores(
+    input?: TodayPickupStoresInput,
+    accountId?: bigint,
+  ): Promise<TodayPickupStoreConnection> {
+    const offset = input?.offset ?? 0;
+    const limit = input?.limit ?? DEFAULT_POPULAR_STORES_LIMIT;
+    const regionIds = input?.regionIds?.map((id) => parseId(id));
+
+    const asOf = this.clock.now();
+    const scored = await this.listingService.rankActiveStores(regionIds, asOf);
+    if (scored.length === 0) {
+      return { items: [], totalCount: 0, hasMore: false, asOf };
+    }
+
+    const storeIds = scored.map((s) => s.candidate.id);
+    const { weekday, dateOnlyUtc, dayStartUtc, dayEndUtc } = todayKst(asOf);
+    const [businessHours, closedStoreIds, capacities, bookedCounts] =
+      await Promise.all([
+        this.repo.findBusinessHoursByWeekday(storeIds, weekday),
+        this.repo.findSpecialClosureStoreIds(storeIds, dateOnlyUtc),
+        this.repo.findDailyCapacities(storeIds, dateOnlyUtc),
+        this.repo.countPickupOrdersInRange(storeIds, dayStartUtc, dayEndUtc),
+      ]);
+    const hourByStore = new Map(
+      businessHours.map((h) => [h.store_id.toString(), h]),
+    );
+    const nowMinutes = kstMinutesOfDay(asOf);
+
+    const open: { entry: ScoredStore; slots: TodayPickupSlot[] }[] = [];
+    for (const entry of scored) {
+      const storeId = entry.candidate.id;
+      if (closedStoreIds.has(storeId.toString())) continue;
+
+      const hour = hourByStore.get(storeId.toString());
+      // 영업시간 미설정·휴무 요일이면 오늘 픽업 불가
+      if (!hour || hour.is_closed || !hour.open_time || !hour.close_time) {
+        continue;
+      }
+
+      // capacity 레코드가 없으면 무제한으로 간주(figma 명세 외 정책 결정)
+      const capacity = capacities.get(storeId);
+      const booked = bookedCounts.get(storeId) ?? 0;
+      if (capacity !== undefined && booked >= capacity) continue;
+
+      const slots = buildTodaySlots({
+        openMinutes: timeColumnToMinutes(hour.open_time),
+        closeMinutes: timeColumnToMinutes(hour.close_time),
+        intervalMinutes: entry.candidate.pickup_slot_interval_minutes,
+        leadTimeMinutes: entry.candidate.min_lead_time_minutes,
+        nowMinutes,
+      });
+      if (!slots.some((slot) => slot.available)) continue;
+
+      open.push({ entry, slots });
+    }
+
+    const totalCount = open.length;
+    const page = open.slice(offset, offset + limit);
+    const pageStoreIds = page.map((p) => p.entry.candidate.id);
+    const [imagesByStore, wishlistedIds] = await Promise.all([
+      this.repo.findStoreCakeImages(pageStoreIds),
+      accountId
+        ? this.wishlistRepo.findWishlistedStoreIds({
+            accountId,
+            storeIds: pageStoreIds,
+          })
+        : Promise.resolve(new Set<string>()),
+    ]);
+
+    const items = page.map(({ entry, slots }) => ({
+      id: entry.candidate.id.toString(),
+      storeName: entry.candidate.store_name,
+      // 소수 첫째 자리까지(인기 매장 카드와 동일 표기)
+      ratingAverage: Math.round(entry.metrics.ratingAverage * 10) / 10,
+      reviewCount: entry.metrics.reviewCount,
+      regionLabel: buildRegionLabel(entry.candidate),
+      cakeImageUrls: imagesByStore.get(entry.candidate.id) ?? [],
+      isWishlisted: wishlistedIds.has(entry.candidate.id.toString()),
+      slots,
+    }));
+
+    return {
+      items,
+      totalCount,
+      hasMore: offset + limit < totalCount,
+      asOf,
+    };
+  }
+}
+
+/**
+ * asOf 기준 KST '오늘'의 요일과 날짜 경계.
+ * - dateOnlyUtc: @db.Date 컬럼 비교용(해당 KST 달력일의 UTC 자정 표현).
+ *   seller가 저장한 closure/capacity 날짜도 UTC date 부분으로 기록되는 전제.
+ * - dayStartUtc/dayEndUtc: pickup_at(DateTime) 범위 비교용(KST 자정 경계).
+ */
+function todayKst(asOf: Date): {
+  weekday: number;
+  dateOnlyUtc: Date;
+  dayStartUtc: Date;
+  dayEndUtc: Date;
+} {
+  const { year, month, day } = toKstYmd(asOf);
+  const dateOnlyUtc = new Date(Date.UTC(year, month - 1, day));
+  const dayStartUtc = kstMidnightUtc(year, month, day);
+  const dayEndUtc = new Date(dayStartUtc.getTime() + DAY_MS);
+  return {
+    weekday: dateOnlyUtc.getUTCDay(),
+    dateOnlyUtc,
+    dayStartUtc,
+    dayEndUtc,
+  };
+}

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -62,7 +62,7 @@ export class StoreTodayPickupService {
         this.repo.findBusinessHoursByWeekday(storeIds, weekday),
         this.repo.findSpecialClosureStoreIds(storeIds, dateOnlyUtc),
         this.repo.findDailyCapacities(storeIds, dateOnlyUtc),
-        this.repo.countPickupOrdersInRange(storeIds, dayStartUtc, dayEndUtc),
+        this.repo.sumPickupQuantitiesInRange(storeIds, dayStartUtc, dayEndUtc),
       ]);
     const hourByStore = new Map(
       businessHours.map((h) => [h.store_id.toString(), h]),

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -105,7 +105,8 @@ export class StoreTodayPickupService {
     const pageStoreIds = page.map((p) => p.entry.candidate.id);
     const [imagesByStore, wishlistedIds] = await Promise.all([
       this.repo.findStoreCakeImages(pageStoreIds),
-      accountId
+      // 0n도 유효한 계정 id — truthy 체크는 0n을 비로그인으로 떨궈 undefined로만 분기한다
+      accountId !== undefined
         ? this.wishlistRepo.findWishlistedStoreIds({
             accountId,
             storeIds: pageStoreIds,

--- a/src/features/store/store-today-pickup.graphql
+++ b/src/features/store/store-today-pickup.graphql
@@ -1,0 +1,43 @@
+extend type Query {
+  """오늘 픽업 가능 매장 리스트(인기순). 오늘 예약 가능 슬롯이 있는 매장만. 비로그인 접근 가능."""
+  todayPickupStores(input: TodayPickupStoresInput): TodayPickupStoreConnection!
+}
+
+input TodayPickupStoresInput {
+  """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
+  regionIds: [ID!]
+  offset: Int = 0
+  limit: Int = 20
+}
+
+type TodayPickupStoreConnection {
+  items: [TodayPickupStore!]!
+  """오늘 픽업 가능한 매장 총수."""
+  totalCount: Int!
+  hasMore: Boolean!
+  """슬롯 산출 기준 시각(서버 조회 시점). 화면의 'N시 기준' 표기에 사용."""
+  asOf: DateTime!
+}
+
+"""오늘 픽업 가능 매장 카드 + 슬롯 그리드."""
+type TodayPickupStore {
+  id: ID!
+  storeName: String!
+  """평균 평점(0.0~5.0, 소수 첫째 자리)."""
+  ratingAverage: Float!
+  reviewCount: Int!
+  """매장 위치 표기(예: 인천 청라동)."""
+  regionLabel: String
+  """대표 케이크 이미지(최대 4장)."""
+  cakeImageUrls: [String!]!
+  """로그인 사용자의 찜 여부(비로그인 시 false)."""
+  isWishlisted: Boolean!
+  """오늘 영업시간 내 슬롯 목록. 리드타임 마감 슬롯은 available=false."""
+  slots: [TodayPickupSlot!]!
+}
+
+"""픽업 슬롯("HH:MM")."""
+type TodayPickupSlot {
+  time: String!
+  available: Boolean!
+}

--- a/src/features/store/store.module.ts
+++ b/src/features/store/store.module.ts
@@ -6,10 +6,12 @@ import { StoreRepository } from '@/features/store/repositories/store.repository'
 import { StoreDetailQueryResolver } from '@/features/store/resolvers/store-detail-query.resolver';
 import { StoreQueryResolver } from '@/features/store/resolvers/store-query.resolver';
 import { StoreReviewQueryResolver } from '@/features/store/resolvers/store-review-query.resolver';
+import { StoreTodayPickupQueryResolver } from '@/features/store/resolvers/store-today-pickup-query.resolver';
 import { StoreWishlistMutationResolver } from '@/features/store/resolvers/store-wishlist-mutation.resolver';
 import { StoreDetailService } from '@/features/store/services/store-detail.service';
 import { StoreListingService } from '@/features/store/services/store-listing.service';
 import { StoreReviewService } from '@/features/store/services/store-review.service';
+import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
 import { StoreWishlistService } from '@/features/store/services/store-wishlist.service';
 
 @Module({
@@ -25,6 +27,8 @@ import { StoreWishlistService } from '@/features/store/services/store-wishlist.s
     StoreWishlistMutationResolver,
     StoreDetailQueryResolver,
     StoreReviewQueryResolver,
+    StoreTodayPickupService,
+    StoreTodayPickupQueryResolver,
   ],
   exports: [StoreRepository],
 })

--- a/src/features/store/types/store-today-pickup-output.type.ts
+++ b/src/features/store/types/store-today-pickup-output.type.ts
@@ -1,0 +1,27 @@
+/**
+ * store-today-pickup resolver 반환용 도메인 출력 타입.
+ * SDL(store-today-pickup.graphql)의 타입과 필드 일치.
+ */
+
+export interface TodayPickupSlot {
+  time: string;
+  available: boolean;
+}
+
+export interface TodayPickupStore {
+  id: string;
+  storeName: string;
+  ratingAverage: number;
+  reviewCount: number;
+  regionLabel: string | null;
+  cakeImageUrls: string[];
+  isWishlisted: boolean;
+  slots: TodayPickupSlot[];
+}
+
+export interface TodayPickupStoreConnection {
+  items: TodayPickupStore[];
+  totalCount: number;
+  hasMore: boolean;
+  asOf: Date;
+}

--- a/src/test/factories/category.factory.ts
+++ b/src/test/factories/category.factory.ts
@@ -1,0 +1,41 @@
+import type { Category, CategoryType, PrismaClient } from '@prisma/client';
+
+import { nextSeq } from '@/test/factories/sequence';
+
+export interface CategoryOverrides {
+  category_type?: CategoryType;
+  name?: string;
+  sort_order?: number;
+  is_active?: boolean;
+  deleted_at?: Date | null;
+}
+
+export async function createCategory(
+  prisma: PrismaClient,
+  overrides: CategoryOverrides = {},
+): Promise<Category> {
+  const seq = nextSeq();
+
+  return prisma.category.create({
+    data: {
+      category_type: overrides.category_type ?? 'EVENT',
+      name: overrides.name ?? `Category ${seq}`,
+      sort_order: overrides.sort_order ?? seq,
+      is_active: overrides.is_active ?? true,
+      deleted_at: overrides.deleted_at ?? null,
+    },
+  });
+}
+
+/** 상품 ↔ 카테고리 연결. */
+export async function linkProductCategory(
+  prisma: PrismaClient,
+  args: { productId: bigint; categoryId: bigint },
+): Promise<void> {
+  await prisma.productCategory.create({
+    data: {
+      product_id: args.productId,
+      category_id: args.categoryId,
+    },
+  });
+}

--- a/src/test/factories/index.ts
+++ b/src/test/factories/index.ts
@@ -1,5 +1,6 @@
 export * from './account.factory';
 export * from './auth.factory';
+export * from './category.factory';
 export * from './notification.factory';
 export * from './order.factory';
 export * from './product.factory';

--- a/src/test/factories/store.factory.ts
+++ b/src/test/factories/store.factory.ts
@@ -19,6 +19,8 @@ export interface StoreOverrides {
   business_hours_text?: string | null;
   access_guide_text?: string | null;
   regular_closure_text?: string | null;
+  pickup_slot_interval_minutes?: number;
+  min_lead_time_minutes?: number;
 }
 
 export async function createStore(
@@ -48,6 +50,9 @@ export async function createStore(
       business_hours_text: overrides.business_hours_text ?? null,
       access_guide_text: overrides.access_guide_text ?? null,
       regular_closure_text: overrides.regular_closure_text ?? null,
+      pickup_slot_interval_minutes:
+        overrides.pickup_slot_interval_minutes ?? 30,
+      min_lead_time_minutes: overrides.min_lead_time_minutes ?? 30,
     },
   });
 }


### PR DESCRIPTION
## 릴리즈 개요

figma 홈 화면(Main_Customer) 명세를 기반으로 개발한 **홈 화면 API 5건**을 릴리즈합니다. develop → main이며, 기능 PR 5건(#178~#182)과 릴리즈 리뷰 반영 PR 4건(#184~#187)이 포함됩니다. 스키마 변경(마이그레이션)은 없습니다.

## 배경

홈 화면은 상단 검색 폼(지역·픽업 날짜/시간), 퀵 진입 3종(카테고리별 둘러보기·오늘 픽업 가능·인기 있는 매장), 상황별 인기 케이크, 제작 후기(Before/After), 랜덤 케이크 그리드로 구성됩니다. 이 중 알림 뱃지(`viewerCounts`), 지역 바텀시트(`regionGroups`/`regions`/`searchRegions`), 픽업 날짜·시간(`pickupCalendar`/`pickupTimeSlots`), 인기 매장(`popularStores`), 후기 상세(`reviewDetail`), 케이크 상세(`productDetail`)는 **기존 API를 그대로 재사용**하는 것으로 확정했고, 나머지 5개 영역에 대응 API가 없어 신설했습니다.

## 포함된 기능 PR

| PR | API | 내용 |
| --- | --- | --- |
| #178 | `categories` | 전역 카테고리 목록 쿼리. 기존에는 매장 단위(`storeProductCategories`)만 있어 홈 칩·카테고리 진입 화면용 전역 목록이 없었음. figma Category_Entry 스펙을 정본으로 카테고리 마스터 시드(이벤트 16종 + 스타일 7종)도 함께 추가 — region과 동일한 영구 마스터 패턴(upsert 멱등, resetSeedScope 비대상). |
| #179 | `popularCakes` | 상황별 인기 케이크 섹션. 카테고리 대표 배너 1건 + 인기 케이크 카드 최대 3개 + 랭킹 산출 시각을 한 번의 호출로 반환. 지역 필터(`regionIds`) 옵션 지원. |
| #180 | `customCakeShowcase` | "다른 사람들은 이렇게 만들었어요" 제작 후기 카드. 요청 디자인(Before)과 완성 케이크(After)를 나란히 노출. |
| #181 | `randomCakes` | 랜덤 케이크 3열 그리드. 호출마다 무작위 재추출. 테스트 결정성을 위해 난수 추상화 `RandomService`(ClockService 동일 패턴)를 common에 신설. |
| #182 | `todayPickupStores` | 오늘 픽업 가능 매장 리스트 + 매장별 타임슬롯 그리드. 'N시 기준' 표기용 `asOf` 포함. |

## 주요 정책 결정

figma 명세에 없거나 해석이 필요했던 지점들은 아래와 같이 확정했습니다.

**카테고리**
- 홈 칩(인기 케이크·랜덤 케이크 섹션)은 **이벤트(EVENT) 카테고리 한정**. STYLE/OTHER id가 오면 에러가 아니라 빈 결과로 처리합니다.
- "전체" 칩은 서버 데이터가 아닌 **FE 가상 칩**이며, `categoryId` 생략으로 표현합니다(시드에도 없음).
- 홈 시안의 어버이날·어린이날 칩은 Category_Entry 스펙 목록에 없어 mock 텍스트로 간주했습니다.

**인기 케이크 랭킹**
- 인기 매장(`popularStores`)과 동일 산식(최근 30일 유효주문 + 찜 + 베이지안 평점 가중)을 **상품 단위**로 적용해 랭킹 정책을 단일화했습니다. store feature의 산식/상수를 배럴로 공개해 재사용합니다.

**배너**
- 배너 소스는 Banner 테이블만 사용하며, 등록분이 없으면 `null`을 반환합니다(1위 케이크 이미지 등 fallback 없음 — FE placeholder 처리).
- 카테고리 선택 시 `placement=CATEGORY` + 해당 카테고리 링크, "전체" 시 `HOME_MAIN`. 링크 대상(상품/매장/카테고리)이 비활성·삭제된 배너는 건너뛰고 차순위를 노출합니다.
- 현 데이터 모델에서 카테고리 지면 배너의 대상 식별 수단은 `link_category_id`뿐이므로, **카테고리 지면 배너는 `linkType=CATEGORY`로 등록하는 것을 운영 전제**로 합니다(대상 카테고리 컬럼 분리는 배너 운영 요구 발생 시 별도 설계).

**제작 후기 쇼케이스**
- Before(주문 커스텀 자유편집 크롭)와 After(리뷰 첫 IMAGE)가 **모두 있는 리뷰만** 후보로 삼습니다 — 대비 연출이 섹션의 본질이라는 판단.
- 전체기간 유효 좋아요순(soft-delete 좋아요 제외) 상위 5건, 탈퇴 작성자는 닉네임 익명화(null).

**랜덤 케이크**
- 호출마다 서버가 무작위 재추출하며 호출 간 중복을 허용합니다. "새로보기 1/3→2/3→3/3" 페이지 카운트는 서버가 관여하지 않는 FE 로컬 상태입니다.

**오늘 픽업 가능**
- 전역 픽업 정책이 아닌 **매장별 정책 완전 반영**: 요일별 영업시간 × 매장별 슬롯 간격 × 최소 리드타임 × 특별휴무 × 일일 생산 capacity.
- capacity 소진은 주문 건수가 아닌 **제작 수량(아이템 quantity 합)** 기준입니다(seller SDL의 "일별 생산 가능 수량" 정의 기준, CANCELED 제외). capacity 레코드가 없는 매장은 무제한으로 간주합니다.
- 슬롯은 구간이 아닌 **픽업 '시각' 포인트**로 해석해 시작 시각 < 마감이면 유효합니다(기존 전역 픽업 정책의 close 미포함 규칙과 동일). 리드타임 판정은 초 단위를 다음 분으로 올려 보수적으로 계산합니다.
- 슬롯 단위 점유 표시는 capacity가 일(日) 단위 모델이라 표현하지 않으며, capacity 소진 매장은 목록에서 제외합니다. 정렬은 인기 매장 랭킹을 재사용합니다(`rankActiveStores`로 추출해 공유).

## 릴리즈 리뷰 반영 (#184~#187)

릴리즈 리뷰에서 나온 지적은 main 직접 커밋 없이 develop 경유 fix PR로 반영했습니다.

- #184: 시드 매장에 구조화 영업시간(StoreBusinessHour) 추가 — 시드만으로 `todayPickupStores` 확인 가능하도록.
- #185: `randomCakes` SDL 오타('렌덤'→'랜덤') + `accountId` truthy 체크를 `!== undefined`로 교체(0n도 유효 id — "0" truthy 함정 회귀 사례와 동일 클래스, `popularStores` 동일 지점 포함).
- #186: 매장 B에도 평일 영업시간 시드(요일 커버리지) + 슬롯 계약 주석 명확화.
- #187: capacity 소진 판정을 주문 distinct 수 → 아이템 quantity 합으로 변경(위 정책 반영).

미반영으로 정리한 지적(근거는 각 코멘트 답글 참조): 카테고리 마스터의 프로덕션 부트스트랩(배포 비활성 상태·region 선례), 셀러 배너 큐레이션(admin 도메인 부재의 기존 설계 전제), 시드 트랜잭션화(멱등 재시드 구조), 실DB 테스트의 mock 전환(레포 테스트 아키텍처), 슬롯 마감 해석(픽업 시각 포인트), resolver 로그인 분기 테스트(service spec 담당 컨벤션).

## 이번 범위에서 제외 (후속 예정)

- 검색 결과 화면(상황별×스타일별×가격 필터 + 추천순) 상품 검색 API — 검색 화면 작업 시 별도 진행.
- 현재 위치 주변 검색 — Region 좌표 데이터 확보 후 진행(현재 좌표 데이터 전무).

## 검증

- 신규 real DB 회귀 테스트 약 60건(랭킹·필터·배너 선택·쇼케이스·랜덤·슬롯/휴무/capacity 경계) + 순수 단위 테스트.
- 각 PR에서 `yarn validate`(lint + tsc + dto:check + arch:check + 커버리지 포함 전체 테스트) 통과.