### PR TITLE
fix: 릴리즈 리뷰 반영 (SDL 오타·0n accountId 가드)

### DIFF
--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -5,7 +5,7 @@ extend type Query {
   """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기(좋아요순). 없으면 빈 배열. 비로그인 접근 가능."""
   customCakeShowcase(input: CustomCakeShowcaseInput): [CustomCakeShowcaseItem!]!
 
-  """홈 '렌덤 케이크 둘러보기' 그리드(호출마다 무작위 재추출). 비로그인 접근 가능."""
+  """홈 '랜덤 케이크 둘러보기' 그리드(호출마다 무작위 재추출). 비로그인 접근 가능."""
   randomCakes(input: RandomCakesInput): RandomCakesResult!
 }
 

--- a/src/features/store/services/store-listing.service.ts
+++ b/src/features/store/services/store-listing.service.ts
@@ -106,7 +106,8 @@ export class StoreListingService {
     const pageStoreIds = page.map((s) => s.candidate.id);
     const [imagesByStore, wishlistedIds] = await Promise.all([
       this.repo.findStoreCakeImages(pageStoreIds),
-      accountId
+      // 0n도 유효한 계정 id — truthy 체크는 0n을 비로그인으로 떨궈 undefined로만 분기한다
+      accountId !== undefined
         ? this.wishlistRepo.findWishlistedStoreIds({
             accountId,
             storeIds: pageStoreIds,

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -105,7 +105,8 @@ export class StoreTodayPickupService {
     const pageStoreIds = page.map((p) => p.entry.candidate.id);
     const [imagesByStore, wishlistedIds] = await Promise.all([
       this.repo.findStoreCakeImages(pageStoreIds),
-      accountId
+      // 0n도 유효한 계정 id — truthy 체크는 0n을 비로그인으로 떨궈 undefined로만 분기한다
+      accountId !== undefined
         ? this.wishlistRepo.findWishlistedStoreIds({
             accountId,
             storeIds: pageStoreIds,


### PR DESCRIPTION
릴리즈 PR #183 CodeRabbit 지적 반영 2건.

- `randomCakes` SDL 설명 '렌덤' → '랜덤' (figma 화면 타이틀 원문은 '렌덤'이지만 스키마 문서는 표준 표기)
- `todayPickupStores`·`popularStores`의 `accountId` truthy 체크 → `!== undefined` (0n도 유효 id — "0" truthy 함정 회귀 사례와 동일 클래스)

나머지 4건은 근거와 함께 미반영 답글 처리(시드 원자성=멱등 재시드 구조·기존 컨벤션, mock 전환=실DB 통합 테스트 아키텍처, 슬롯=픽업 시각 포인트로 기존 전역 정책과 동일 규칙, resolver 로그인 분기=service.spec 담당+기존 컨벤션).