### PR TITLE
fix: 릴리즈 리뷰 반영 (시드 요일 커버리지·슬롯 계약 주석 명확화)

### DIFF
--- a/prisma/seed/stores.ts
+++ b/prisma/seed/stores.ts
@@ -111,6 +111,20 @@ export async function seedStores(
       is_active: true,
     },
   });
+  // 매장 B 구조화 영업시간: 평일 11~21시, 주말 휴무(텍스트 표기와 일치).
+  // A가 화요일 휴무라, B가 화요일을 커버해 요일과 무관하게 todayPickupStores 확인 가능.
+  await prisma.storeBusinessHour.createMany({
+    data: [0, 1, 2, 3, 4, 5, 6].map((dayOfWeek) => {
+      const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+      return {
+        store_id: storeB.id,
+        day_of_week: dayOfWeek,
+        is_closed: isWeekend,
+        open_time: isWeekend ? null : new Date(Date.UTC(1970, 0, 1, 11, 0)),
+        close_time: isWeekend ? null : new Date(Date.UTC(1970, 0, 1, 21, 0)),
+      };
+    }),
+  });
 
   // 상품
   const p1 = await prisma.product.create({

--- a/src/features/store/services/store-today-pickup.helper.ts
+++ b/src/features/store/services/store-today-pickup.helper.ts
@@ -4,7 +4,11 @@ import type { TodayPickupSlot } from '@/features/store/types/store-today-pickup-
 export interface TodaySlotPolicy {
   /** 영업 시작(자정 경과 분). */
   openMinutes: number;
-  /** 영업 종료(자정 경과 분, 미포함 — 마지막 슬롯은 close-interval). */
+  /**
+   * 영업 종료(자정 경과 분, 미포함).
+   * 슬롯은 픽업 '시각' 포인트라 시작 시각이 close 이전이면 유효하다
+   * (전역 정책 pickup.constants의 close 미포함 규칙과 동일 해석).
+   */
   closeMinutes: number;
   /** 슬롯 간격(분). */
   intervalMinutes: number;


### PR DESCRIPTION
릴리즈 PR #183 Codex 2차 지적 반영/판단.

- 반영: 매장 B 구조화 영업시간 시드(평일 11~21시, 주말 휴무). A(화요일 휴무)와 조합해 요일과 무관하게 `todayPickupStores`를 시드로 확인 가능.
- 부분 반영: 슬롯이 마감을 넘는다는 지적은 동작 미반영 — 슬롯은 픽업 '시각' 포인트라 시작 시각 < close면 유효(전역 정책 pickup.constants의 close 미포함 규칙과 동일 해석). 오해 소지가 있던 계약 주석("마지막 슬롯은 close-interval")만 명확화.