### PR TITLE
fix: 릴리즈 리뷰 반영 (capacity 소진을 제작 수량 기준으로 집계)

### DIFF
--- a/src/features/store/repositories/store.repository.ts
+++ b/src/features/store/repositories/store.repository.ts
@@ -133,19 +133,20 @@ export class StoreRepository {
   }
 
   /**
-   * 픽업 시각이 [rangeStart, rangeEnd)인 매장별 유효 주문 수(주문 단위 distinct).
-   * capacity 소진 판정용 — CANCELED·soft-delete 주문은 제외한다.
+   * 픽업 시각이 [rangeStart, rangeEnd)인 매장별 예약 제작 수량(아이템 quantity 합).
+   * capacity(일별 생산 가능 '수량') 소진 판정용 — CANCELED·soft-delete 주문은 제외한다.
    */
-  async countPickupOrdersInRange(
+  async sumPickupQuantitiesInRange(
     storeIds: bigint[],
     rangeStart: Date,
     rangeEnd: Date,
   ): Promise<Map<bigint, number>> {
     if (storeIds.length === 0) return new Map();
     const rows = await this.prisma.$queryRaw<
-      { store_id: bigint; order_count: bigint }[]
+      { store_id: bigint; booked_quantity: bigint }[]
     >(Prisma.sql`
-      SELECT oi.store_id AS store_id, COUNT(DISTINCT oi.order_id) AS order_count
+      SELECT oi.store_id AS store_id,
+             CAST(COALESCE(SUM(oi.quantity), 0) AS UNSIGNED) AS booked_quantity
       FROM order_item oi
       JOIN \`order\` o
         ON o.id = oi.order_id
@@ -157,7 +158,7 @@ export class StoreRepository {
         AND oi.deleted_at IS NULL
       GROUP BY oi.store_id
     `);
-    return new Map(rows.map((r) => [r.store_id, Number(r.order_count)]));
+    return new Map(rows.map((r) => [r.store_id, Number(r.booked_quantity)]));
   }
 
   /** 활성 매장 존재 검증(찜 등). */

--- a/src/features/store/services/store-today-pickup.service.spec.ts
+++ b/src/features/store/services/store-today-pickup.service.spec.ts
@@ -73,8 +73,12 @@ describe('StoreTodayPickupService (real DB)', () => {
     });
   }
 
-  /** 오늘 픽업 유효 주문 n건 생성. */
-  async function bookToday(store: Store, count: number): Promise<void> {
+  /** 오늘 픽업 유효 주문 n건 생성(주문당 케이크 quantity개). */
+  async function bookToday(
+    store: Store,
+    count: number,
+    quantity = 1,
+  ): Promise<void> {
     for (let i = 0; i < count; i += 1) {
       const order = await createOrder(prisma, {
         status: 'CONFIRMED',
@@ -83,6 +87,7 @@ describe('StoreTodayPickupService (real DB)', () => {
       await createOrderItem(prisma, {
         order_id: order.id,
         store_id: store.id,
+        quantity,
       });
     }
   }
@@ -197,6 +202,24 @@ describe('StoreTodayPickupService (real DB)', () => {
       const result = await service.todayPickupStores();
 
       expect(result.items.map((i) => i.storeName)).toEqual(['여유매장']);
+    });
+
+    it('capacity는 주문 수가 아니라 제작 수량(quantity 합) 기준으로 소진된다', async () => {
+      // 주문 1건이라도 quantity=2면 capacity 2를 전부 소진한다
+      const store = await createStore(prisma, { store_name: '수량마감매장' });
+      await openToday(store, 10, 20);
+      await prisma.storeDailyCapacity.create({
+        data: {
+          store_id: store.id,
+          capacity_date: TODAY_DATE_ONLY,
+          capacity: 2,
+        },
+      });
+      await bookToday(store, 1, 2);
+
+      await expect(service.todayPickupStores()).resolves.toMatchObject({
+        items: [],
+      });
     });
 
     it('capacity 레코드가 없으면 무제한으로 간주한다', async () => {

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -62,7 +62,7 @@ export class StoreTodayPickupService {
         this.repo.findBusinessHoursByWeekday(storeIds, weekday),
         this.repo.findSpecialClosureStoreIds(storeIds, dateOnlyUtc),
         this.repo.findDailyCapacities(storeIds, dateOnlyUtc),
-        this.repo.countPickupOrdersInRange(storeIds, dayStartUtc, dayEndUtc),
+        this.repo.sumPickupQuantitiesInRange(storeIds, dayStartUtc, dayEndUtc),
       ]);
     const hourByStore = new Map(
       businessHours.map((h) => [h.store_id.toString(), h]),


### PR DESCRIPTION
릴리즈 PR #183 Codex P1 반영 — `StoreDailyCapacity.capacity`는 seller SDL 정의상 "일별 생산 가능 **수량**"이므로, 소진 판정을 주문 distinct 카운트가 아닌 유효 아이템 `quantity` 합(`SUM`)으로 변경.

- `countPickupOrdersInRange` → `sumPickupQuantitiesInRange` (CANCELED·soft-delete 제외 동일, `CAST AS UNSIGNED`)
- 회귀 테스트: 주문 1건 quantity=2 → capacity 2 소진되어 매장 제외