### PR TITLE
fix: 릴리즈 리뷰 반영 (ReviewableOrderItemRow 명시 타입·매핑 테스트 보강)

### DIFF
--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -41,6 +41,21 @@ export interface OngoingOrderRow {
   }[];
 }
 
+/** 리뷰 작성 가능 주문 아이템 row. UserReviewService 매핑 입력. */
+export interface ReviewableOrderItemRow {
+  id: bigint;
+  product_id: bigint;
+  product_name_snapshot: string;
+  order: { picked_up_at: Date | null } | null;
+  product: { images: { image_url: string }[] } | null;
+  store: {
+    store_name: string;
+    address_city: string | null;
+    address_neighborhood: string | null;
+    region: { name: string } | null;
+  } | null;
+}
+
 @Injectable()
 export class OrderRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -183,7 +198,7 @@ export class OrderRepository {
     accountId: bigint;
     offset: number;
     limit: number;
-  }) {
+  }): Promise<{ items: ReviewableOrderItemRow[]; totalCount: number }> {
     const where = {
       deleted_at: null,
       order: {

--- a/src/features/user/services/user-review.service.spec.ts
+++ b/src/features/user/services/user-review.service.spec.ts
@@ -604,16 +604,26 @@ describe('UserReviewService (real DB)', () => {
         where: { id: setup.storeId },
         data: { address_city: '인천', address_neighborhood: '청라동' },
       });
+      const pickedUpAt = new Date('2026-08-15T05:00:00.000Z');
+      const orderItem = await prisma.orderItem.findUniqueOrThrow({
+        where: { id: setup.orderItemId },
+      });
+      await prisma.order.update({
+        where: { id: orderItem.order_id },
+        data: { picked_up_at: pickedUpAt },
+      });
 
       const [item] = (await service.myReviewableOrderItems(setup.accountId))
         .items;
 
       expect(item).toMatchObject({
         orderItemId: setup.orderItemId.toString(),
+        productId: setup.productId.toString(),
         productName: '상품R 스냅샷',
         productImageUrl: 'https://img/review-target.png',
         storeName: '매장R',
         regionLabel: '인천 청라동',
+        pickedUpAt,
       });
     });
 


### PR DESCRIPTION
## 배경

릴리즈 PR #189에서 CodeRabbit이 남긴 지적 2건을 반영합니다. 릴리즈 리뷰 절차에 따라 main 직접 커밋 없이 develop 경유로 처리합니다.

## 반영 내용

**1. `listReviewableOrderItems` 반환 타입 명시화** — 기존에는 Prisma `select` 결과의 타입 추론에 의존하고 있어서, 나중에 select 절이 바뀌면 `UserReviewService`의 매핑 계약이 소리 없이 약해질 수 있었습니다. 이 레포의 다른 repository들(`MyOrderRow`, `CakeCandidateRow` 등)처럼 명시적 row 인터페이스 `ReviewableOrderItemRow`를 정의하고 `Promise<{ items: ReviewableOrderItemRow[]; totalCount: number }>`로 선언했습니다. 동작 변경은 없습니다.

**2. 카드 매핑 테스트 보강** — 기존 매핑 테스트가 `productId`와 `pickedUpAt`을 검증하지 않아 두 필드의 매핑이 깨져도 테스트가 통과할 수 있었습니다. 고정 픽업 시각을 fixture에 넣고 두 필드를 함께 assert하도록 보강했습니다.

## 검증

- `user-review.service.spec.ts` 25건 통과 (매핑 테스트에 productId·pickedUpAt 검증 추가).
- tsc 통과. 로직 변경이 없는 타입 선언·테스트 보강이라 다른 스위트에는 영향 없습니다.