### PR TITLE
feat(product): 홈 카드 3종에 storeId 노출 (FE 상세 URL 대응)

### DIFF
--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -24,6 +24,8 @@ type RandomCakesResult {
 """랜덤 케이크 그리드 셀(클릭 시 케이크 상세 이동)."""
 type RandomCake {
   id: ID!
+  """소속 매장 ID(상세 URL 구성용: /store/{storeId}/products/{id})."""
+  storeId: ID!
   """대표 이미지(sort_order 최소)."""
   thumbnailUrl: String!
 }
@@ -79,6 +81,8 @@ input CustomCakeShowcaseInput {
 type CustomCakeShowcaseItem {
   """후기 보러가기(reviewDetail) 이동용."""
   reviewId: ID!
+  """후기 소속 매장 ID(상세 URL 구성용: /store/{storeId}/reviews/{reviewId})."""
+  storeId: ID!
   """좋아요순 순위(1부터)."""
   rank: Int!
   """작성자 닉네임. 탈퇴 작성자는 null(FE 익명 표기)."""
@@ -95,6 +99,8 @@ type CustomCakeShowcaseItem {
 """인기 케이크 카드(지역명·매장명·케이크명·가격·할인율)."""
 type PopularCake {
   id: ID!
+  """소속 매장 ID(상세 URL 구성용: /store/{storeId}/products/{id})."""
+  storeId: ID!
   rank: Int!
   name: String!
   """대표 이미지(sort_order 최소). 없으면 null."""

--- a/src/features/product/repositories/product-review.repository.ts
+++ b/src/features/product/repositories/product-review.repository.ts
@@ -201,6 +201,7 @@ export class ProductReviewRepository {
   async findShowcaseReviewRowsByIds(reviewIds: bigint[]): Promise<
     {
       id: bigint;
+      store_id: bigint;
       content: string | null;
       account: {
         user_profile: { nickname: string; deleted_at: Date | null } | null;
@@ -216,6 +217,7 @@ export class ProductReviewRepository {
       where: { id: { in: reviewIds }, deleted_at: null },
       select: {
         id: true,
+        store_id: true,
         content: true,
         account: {
           // soft-delete extension은 nested relation에 deleted_at을 주입하지 않으므로

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -28,6 +28,7 @@ export interface StoreProductCategoryRow {
 /** 인기 케이크 랭킹 후보 row. product-home 매퍼 입력. */
 export interface CakeCandidateRow {
   id: bigint;
+  store_id: bigint;
   name: string;
   regular_price: number;
   sale_price: number | null;
@@ -1000,6 +1001,7 @@ export class ProductRepository {
       },
       select: {
         id: true,
+        store_id: true,
         name: true,
         regular_price: true,
         sale_price: true,
@@ -1200,7 +1202,9 @@ export class ProductRepository {
   async findRandomCakeRows(args: {
     productIds: bigint[];
     categoryId?: bigint;
-  }): Promise<{ id: bigint; images: { image_url: string }[] }[]> {
+  }): Promise<
+    { id: bigint; store_id: bigint; images: { image_url: string }[] }[]
+  > {
     if (args.productIds.length === 0) return [];
     return this.prisma.product.findMany({
       where: {
@@ -1227,6 +1231,7 @@ export class ProductRepository {
       },
       select: {
         id: true,
+        store_id: true,
         images: {
           where: { deleted_at: null },
           orderBy: { sort_order: 'asc' },

--- a/src/features/product/resolvers/product-home-query.resolver.spec.ts
+++ b/src/features/product/resolvers/product-home-query.resolver.spec.ts
@@ -81,6 +81,7 @@ describe('ProductHome Query Resolver (real DB)', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
+      storeId: orderItem.store_id.toString(),
       reviewText: '제작 후기',
       beforeImageUrl: 'https://img/before.png',
       afterImageUrl: 'https://img/after.png',
@@ -97,7 +98,11 @@ describe('ProductHome Query Resolver (real DB)', () => {
     const result = await resolver.randomCakes();
 
     expect(result.items).toEqual([
-      { id: cake.id.toString(), thumbnailUrl: 'https://img/grid.png' },
+      {
+        id: cake.id.toString(),
+        storeId: store.id.toString(),
+        thumbnailUrl: 'https://img/grid.png',
+      },
     ]);
   });
 });

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -28,6 +28,7 @@ export function toPopularCake(
 ): PopularCake {
   return {
     id: row.id.toString(),
+    storeId: row.store_id.toString(),
     rank,
     name: row.name,
     thumbnailUrl: row.images[0]?.image_url ?? null,

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -219,6 +219,7 @@ describe('ProductHomeService (real DB)', () => {
 
       expect(item).toMatchObject({
         name: '레터링 케이크',
+        storeId: store.id.toString(),
         storeName: '청담 케이크샵',
         regionLabel: '서울 청담동',
         regularPrice: 40000,
@@ -619,6 +620,7 @@ describe('ProductHomeService (real DB)', () => {
       expect(new Set(result.items.map((i) => i.id)).size).toBe(9);
       for (const item of result.items) {
         expect(item.thumbnailUrl).toBe(`https://img/random-${item.id}.png`);
+        expect(item.storeId).toBe(store.id.toString());
       }
     });
 

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -133,6 +133,7 @@ export class ProductHomeService {
 
       items.push({
         reviewId: row.id.toString(),
+        storeId: row.store_id.toString(),
         rank: items.length + 1,
         // 탈퇴(soft-delete) 작성자는 닉네임을 노출하지 않는다(익명화 정책)
         authorNickname:
@@ -175,7 +176,9 @@ export class ProductHomeService {
       const thumbnailUrl = row?.images[0]?.image_url;
       // 후보 조회가 이미지 보유를 보장하지만, 조회 사이의 삭제 경합에 대비해 방어
       if (!thumbnailUrl) return [];
-      return [{ id: id.toString(), thumbnailUrl }];
+      return [
+        { id: id.toString(), storeId: row.store_id.toString(), thumbnailUrl },
+      ];
     });
 
     return { items };

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -16,6 +16,7 @@ export interface HomeBanner {
 
 export interface PopularCake {
   id: string;
+  storeId: string;
   rank: number;
   name: string;
   thumbnailUrl: string | null;
@@ -34,6 +35,7 @@ export interface PopularCakesResult {
 
 export interface RandomCake {
   id: string;
+  storeId: string;
   thumbnailUrl: string;
 }
 
@@ -43,6 +45,7 @@ export interface RandomCakesResult {
 
 export interface CustomCakeShowcaseItem {
   reviewId: string;
+  storeId: string;
   rank: number;
   authorNickname: string | null;
   reviewText: string | null;


### PR DESCRIPTION
## 배경

프론트의 상세 화면 URL 구조가 매장 id를 포함하는 형태입니다.

- 상품 상세: `/store/{storeId}/products/{productId}`
- 후기 상세: `/store/{storeId}/reviews/{reviewId}`

그런데 홈 신설 API의 카드 응답에는 상품/후기 id만 있어서, 카드를 탭했을 때 기존 상세 화면으로 바로 이동할 수 없습니다. 

프론트에서 카드 클릭 시마다 상세 조회를 한 번 더 해서 storeId를 알아내는 우회도 가능하지만, 클릭마다 불필요한 요청이 생기고 URL 구조와도 어긋나므로 홈 응답에 `storeId`를 함께 포함하기로 했습니다.

## 변경 내용

세 카드 타입에 `storeId: ID!` 필드를 추가했습니다. 모두 **additive 변경**이라 기존 필드·쿼리는 영향이 없습니다.

- `PopularCake.storeId` — 상황별 인기 케이크 카드
- `RandomCake.storeId` — 랜덤 케이크 그리드 셀
- `CustomCakeShowcaseItem.storeId` — 제작 후기 카드 (후기 상세 URL 구성용)

세 조회 모두 원본 데이터가 이미 매장 id를 갖고 있습니다 — 상품 카드 두 종은 `product.store_id`, 제작 후기는 `review.store_id`. 따라서 **추가 쿼리나 조인 없이** 기존 select에 컬럼 하나를 더하고 매핑에 노출하는 것으로 끝나며, 응답 비용 변화도 사실상 없습니다.

## 검증

- 기존 매핑 테스트 3곳(인기 케이크 카드 매핑, 랜덤 케이크 썸네일 매핑 루프, resolver 통합 2건)에 `storeId` 검증을 추가해 세 타입 모두 실제 매장 id가 매핑되는 것을 확인했습니다. 관련 스위트 33건 통과.
- `yarn validate`(lint + tsc + dto:check + arch:check + 커버리지 포함 전체 테스트) 통과.
- 프론트 가이드 문서(`docs/guide-to-frontend/guide-home-screen.md`, gitignore 경로)에도 세 쿼리 예시에 `storeId`를 반영해 두었습니다.