### PR TITLE
feat(store): 매장별 픽업 달력·시간 슬롯 조회(storePickupCalendar/storePickupTimeSlots)

### DIFF
--- a/src/features/pickup/index.ts
+++ b/src/features/pickup/index.ts
@@ -1,1 +1,3 @@
+// 오전/오후 경계는 매장 무관 UI 규칙이라 매장별 픽업 달력(store feature)에서도 재사용한다.
+export { PICKUP_AFTERNOON_START_MINUTES } from '@/features/pickup/constants/pickup.constants';
 export { PickupModule } from '@/features/pickup/pickup.module';

--- a/src/features/store/constants/store-pickup-schedule-error-messages.ts
+++ b/src/features/store/constants/store-pickup-schedule-error-messages.ts
@@ -1,0 +1,5 @@
+export const STORE_PICKUP_SCHEDULE_ERRORS = {
+  INVALID_YEAR_MONTH: '유효하지 않은 연월 형식입니다. (YYYY-MM)',
+  INVALID_DATE: '유효하지 않은 날짜 형식입니다. (YYYY-MM-DD)',
+  STORE_NOT_FOUND: '매장을 찾을 수 없습니다.',
+} as const;

--- a/src/features/store/constants/store-pickup-schedule.constants.ts
+++ b/src/features/store/constants/store-pickup-schedule.constants.ts
@@ -1,0 +1,9 @@
+/** 매장 픽업 달력 선택 불가 사유 코드(SDL StorePickupDay.reason). */
+export const STORE_PICKUP_DAY_REASON = {
+  PAST: 'PAST',
+  OUT_OF_RANGE: 'OUT_OF_RANGE',
+  // 특별휴무·요일 휴무·영업시간 미설정·당일 잔여 가용 슬롯 없음을 묶는다.
+  // FE 표기가 동일("마감")하고, 세분화는 capacity 소진(CAPACITY_FULL)만 요구되기 때문.
+  CLOSED: 'CLOSED',
+  CAPACITY_FULL: 'CAPACITY_FULL',
+} as const;

--- a/src/features/store/repositories/store.repository.ts
+++ b/src/features/store/repositories/store.repository.ts
@@ -25,6 +25,22 @@ export interface StoreTodayBusinessHourRow {
   close_time: Date | null;
 }
 
+/** 매장 픽업 정책 row(달력·시간 슬롯 산출용). */
+export interface StorePickupPolicyRow {
+  id: bigint;
+  pickup_slot_interval_minutes: number;
+  min_lead_time_minutes: number;
+  max_days_ahead: number;
+}
+
+/** 요일별 영업시간 row(매장 픽업 달력용). */
+export interface StoreWeekdayBusinessHourRow {
+  day_of_week: number;
+  is_closed: boolean;
+  open_time: Date | null;
+  close_time: Date | null;
+}
+
 export interface StoreReviewStat {
   average: number;
   count: number;
@@ -159,6 +175,101 @@ export class StoreRepository {
       GROUP BY oi.store_id
     `);
     return new Map(rows.map((r) => [r.store_id, Number(r.booked_quantity)]));
+  }
+
+  /** 픽업 달력·슬롯 산출용 매장 정책. 활성·미삭제 매장만. */
+  async findStoreForPickupSchedule(
+    storeId: bigint,
+  ): Promise<StorePickupPolicyRow | null> {
+    return this.prisma.store.findFirst({
+      where: { id: storeId, is_active: true, deleted_at: null },
+      select: {
+        id: true,
+        pickup_slot_interval_minutes: true,
+        min_lead_time_minutes: true,
+        max_days_ahead: true,
+      },
+    });
+  }
+
+  /** 매장의 요일별 영업시간 전체(요일당 최대 1행). */
+  async findBusinessHoursForStore(
+    storeId: bigint,
+  ): Promise<StoreWeekdayBusinessHourRow[]> {
+    return this.prisma.storeBusinessHour.findMany({
+      where: { store_id: storeId, deleted_at: null },
+      select: {
+        day_of_week: true,
+        is_closed: true,
+        open_time: true,
+        close_time: true,
+      },
+    });
+  }
+
+  /** [from, to) 범위(@db.Date, UTC 자정 표현)의 특별휴무 날짜 집합("YYYY-MM-DD"). */
+  async findSpecialClosureDatesInRange(
+    storeId: bigint,
+    from: Date,
+    to: Date,
+  ): Promise<Set<string>> {
+    const rows = await this.prisma.storeSpecialClosure.findMany({
+      where: {
+        store_id: storeId,
+        closure_date: { gte: from, lt: to },
+        deleted_at: null,
+      },
+      select: { closure_date: true },
+    });
+    return new Set(rows.map((r) => r.closure_date.toISOString().slice(0, 10)));
+  }
+
+  /** [from, to) 범위의 일일 capacity 맵("YYYY-MM-DD" → capacity). 레코드 없으면 무제한 취급은 호출부 책임. */
+  async findDailyCapacitiesInRange(
+    storeId: bigint,
+    from: Date,
+    to: Date,
+  ): Promise<Map<string, number>> {
+    const rows = await this.prisma.storeDailyCapacity.findMany({
+      where: {
+        store_id: storeId,
+        capacity_date: { gte: from, lt: to },
+        deleted_at: null,
+      },
+      select: { capacity_date: true, capacity: true },
+    });
+    return new Map(
+      rows.map((r) => [r.capacity_date.toISOString().slice(0, 10), r.capacity]),
+    );
+  }
+
+  /**
+   * 픽업 시각이 [rangeStart, rangeEnd)인 KST 날짜별 예약 제작 수량(아이템 quantity 합).
+   * capacity 소진 판정용 — CANCELED·soft-delete 주문은 제외한다.
+   * KST는 DST 없는 고정 +9h라 INTERVAL 9 HOUR 변환으로 달력일을 묶는다.
+   */
+  async sumPickupQuantitiesByKstDate(
+    storeId: bigint,
+    rangeStart: Date,
+    rangeEnd: Date,
+  ): Promise<Map<string, number>> {
+    const rows = await this.prisma.$queryRaw<
+      { pickup_date: string; booked_quantity: bigint }[]
+    >(Prisma.sql`
+      SELECT DATE_FORMAT(DATE_ADD(o.pickup_at, INTERVAL 9 HOUR), '%Y-%m-%d') AS pickup_date,
+             CAST(COALESCE(SUM(oi.quantity), 0) AS UNSIGNED) AS booked_quantity
+      FROM order_item oi
+      JOIN \`order\` o
+        ON o.id = oi.order_id
+        AND o.deleted_at IS NULL
+        AND o.status <> 'CANCELED'
+        AND o.pickup_at >= ${rangeStart}
+        AND o.pickup_at < ${rangeEnd}
+      WHERE oi.store_id = ${storeId}
+        AND oi.deleted_at IS NULL
+      GROUP BY pickup_date
+    `);
+    return new Map(rows.map((r) => [r.pickup_date, Number(r.booked_quantity)]));
   }
 
   /** 활성 매장 존재 검증(찜 등). */

--- a/src/features/store/resolvers/store-pickup-schedule-query.resolver.spec.ts
+++ b/src/features/store/resolvers/store-pickup-schedule-query.resolver.spec.ts
@@ -1,0 +1,98 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { StoreRepository } from '@/features/store/repositories/store.repository';
+import { StorePickupScheduleQueryResolver } from '@/features/store/resolvers/store-pickup-schedule-query.resolver';
+import { StorePickupScheduleService } from '@/features/store/services/store-pickup-schedule.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+// 2026-09-16(수) 16:00 KST 고정
+const NOW = new Date('2026-09-16T07:00:00.000Z');
+
+/**
+ * Resolver ↔ Service ↔ Repository ↔ DB 통합 경로 검증.
+ * 달력 판정·슬롯 분기 세부 검증은 service.spec.ts에서 담당.
+ */
+describe('StorePickupSchedule Query Resolver (real DB)', () => {
+  let resolver: StorePickupScheduleQueryResolver;
+  let clock: ClockService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        StorePickupScheduleQueryResolver,
+        StorePickupScheduleService,
+        StoreRepository,
+        ClockService,
+      ],
+    });
+    resolver = module.get(StorePickupScheduleQueryResolver);
+    clock = module.get(ClockService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    jest.spyOn(clock, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function openAllWeek(storeId: bigint): Promise<void> {
+    for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek += 1) {
+      await prisma.storeBusinessHour.create({
+        data: {
+          store_id: storeId,
+          day_of_week: dayOfWeek,
+          is_closed: false,
+          open_time: new Date(Date.UTC(1970, 0, 1, 10, 0, 0)),
+          close_time: new Date(Date.UTC(1970, 0, 1, 20, 0, 0)),
+        },
+      });
+    }
+  }
+
+  it('storePickupCalendar: ID 문자열을 파싱해 월 달력을 반환한다', async () => {
+    const store = await createStore(prisma);
+    await openAllWeek(store.id);
+
+    const result = await resolver.storePickupCalendar(
+      store.id.toString(),
+      '2026-09',
+    );
+
+    expect(result.yearMonth).toBe('2026-09');
+    expect(result.days).toHaveLength(30);
+    expect(result.days.find((d) => d.date === '2026-09-18')).toEqual({
+      date: '2026-09-18',
+      selectable: true,
+      reason: null,
+    });
+  });
+
+  it('storePickupTimeSlots: 선택 날짜의 오전/오후 슬롯을 반환한다', async () => {
+    const store = await createStore(prisma);
+    await openAllWeek(store.id);
+
+    const result = await resolver.storePickupTimeSlots(
+      store.id.toString(),
+      '2026-09-18',
+    );
+
+    expect(result.date).toBe('2026-09-18');
+    expect(result.morning[0]).toEqual({ time: '10:00', available: true });
+    expect(result.afternoon[0]).toEqual({ time: '12:00', available: true });
+    expect(result.morning.length + result.afternoon.length).toBe(20);
+  });
+});

--- a/src/features/store/resolvers/store-pickup-schedule-query.resolver.ts
+++ b/src/features/store/resolvers/store-pickup-schedule-query.resolver.ts
@@ -1,0 +1,32 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { parseId } from '@/common/utils/id-parser';
+import { StorePickupScheduleService } from '@/features/store/services/store-pickup-schedule.service';
+import type {
+  StorePickupCalendar,
+  StorePickupTimeSlots,
+} from '@/features/store/types/store-pickup-schedule-output.type';
+
+/**
+ * 매장별 픽업 달력·시간 슬롯 resolver. 비로그인도 접근 가능한 public query.
+ */
+@Resolver('Query')
+export class StorePickupScheduleQueryResolver {
+  constructor(private readonly service: StorePickupScheduleService) {}
+
+  @Query('storePickupCalendar')
+  storePickupCalendar(
+    @Args('storeId') storeId: string,
+    @Args('yearMonth') yearMonth: string,
+  ): Promise<StorePickupCalendar> {
+    return this.service.storePickupCalendar(parseId(storeId), yearMonth);
+  }
+
+  @Query('storePickupTimeSlots')
+  storePickupTimeSlots(
+    @Args('storeId') storeId: string,
+    @Args('date') date: string,
+  ): Promise<StorePickupTimeSlots> {
+    return this.service.storePickupTimeSlots(parseId(storeId), date);
+  }
+}

--- a/src/features/store/services/store-pickup-schedule.service.spec.ts
+++ b/src/features/store/services/store-pickup-schedule.service.spec.ts
@@ -288,6 +288,10 @@ describe('StorePickupScheduleService (real DB)', () => {
       await expect(
         service.storePickupCalendar(store.id, '0999-01'),
       ).rejects.toThrow(BadRequestException);
+      // 1000-01은 KST 월 시작 경계(-9h)가 0999-12-31T15:00Z로 DATETIME 하한을 밑돈다
+      await expect(
+        service.storePickupCalendar(store.id, '1000-01'),
+      ).rejects.toThrow(BadRequestException);
       // 9999-12는 익월 상한 계산이 DATE 상한(9999-12-31)을 넘는다
       await expect(
         service.storePickupCalendar(store.id, '9999-12'),
@@ -407,6 +411,10 @@ describe('StorePickupScheduleService (real DB)', () => {
       // 9999-12-31은 익일 상한 계산이 DATE 상한(9999-12-31)을 넘는다
       await expect(
         service.storePickupTimeSlots(store.id, '9999-12-31'),
+      ).rejects.toThrow(BadRequestException);
+      // 1000-01-01은 KST 자정 경계(-9h)가 DATETIME 하한을 밑돈다
+      await expect(
+        service.storePickupTimeSlots(store.id, '1000-01-01'),
       ).rejects.toThrow(BadRequestException);
     });
 

--- a/src/features/store/services/store-pickup-schedule.service.spec.ts
+++ b/src/features/store/services/store-pickup-schedule.service.spec.ts
@@ -277,6 +277,23 @@ describe('StorePickupScheduleService (real DB)', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
+    it('DB date 표현 범위 밖 연도는 거절한다', async () => {
+      const store = await createStore(prisma);
+
+      // 0~99년은 Date.UTC가 1900년대로 매핑해 엉뚱한 세기를 반환하므로 차단
+      await expect(
+        service.storePickupCalendar(store.id, '0000-01'),
+      ).rejects.toThrow(BadRequestException);
+      // MySQL DATE 하한(1000-01-01) 미만
+      await expect(
+        service.storePickupCalendar(store.id, '0999-01'),
+      ).rejects.toThrow(BadRequestException);
+      // 9999-12는 익월 상한 계산이 DATE 상한(9999-12-31)을 넘는다
+      await expect(
+        service.storePickupCalendar(store.id, '9999-12'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it('없거나 비활성 매장은 NOT_FOUND다', async () => {
       const inactive = await createStore(prisma, { is_active: false });
 
@@ -381,6 +398,15 @@ describe('StorePickupScheduleService (real DB)', () => {
       ).rejects.toThrow(BadRequestException);
       await expect(
         service.storePickupTimeSlots(store.id, '20260918'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('DB date 표현 범위 밖 연도는 거절한다', async () => {
+      const store = await createStore(prisma);
+
+      // 9999-12-31은 익일 상한 계산이 DATE 상한(9999-12-31)을 넘는다
+      await expect(
+        service.storePickupTimeSlots(store.id, '9999-12-31'),
       ).rejects.toThrow(BadRequestException);
     });
 

--- a/src/features/store/services/store-pickup-schedule.service.spec.ts
+++ b/src/features/store/services/store-pickup-schedule.service.spec.ts
@@ -1,0 +1,398 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import type { OrderStatus, PrismaClient, Store } from '@prisma/client';
+
+import { ClockService } from '@/common/providers/clock.service';
+import { StoreRepository } from '@/features/store/repositories/store.repository';
+import { StorePickupScheduleService } from '@/features/store/services/store-pickup-schedule.service';
+import type { StorePickupCalendar } from '@/features/store/types/store-pickup-schedule-output.type';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import { createOrder, createOrderItem, createStore } from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+// 2026-09-16(수) 16:00 KST 고정. 요일·자정 경계 계산이 모두 이 시각 기준.
+const NOW = new Date('2026-09-16T07:00:00.000Z');
+
+describe('StorePickupScheduleService (real DB)', () => {
+  let service: StorePickupScheduleService;
+  let clock: ClockService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [StorePickupScheduleService, StoreRepository, ClockService],
+    });
+    service = module.get(StorePickupScheduleService);
+    clock = module.get(ClockService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    jest.spyOn(clock, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** 특정 요일(0=일~6=토) 영업시간 설정. */
+  async function setBusinessHour(
+    store: Store,
+    dayOfWeek: number,
+    openHour: number,
+    closeHour: number,
+    isClosed = false,
+  ): Promise<void> {
+    await prisma.storeBusinessHour.create({
+      data: {
+        store_id: store.id,
+        day_of_week: dayOfWeek,
+        is_closed: isClosed,
+        open_time: isClosed ? null : new Date(Date.UTC(1970, 0, 1, openHour)),
+        close_time: isClosed ? null : new Date(Date.UTC(1970, 0, 1, closeHour)),
+      },
+    });
+  }
+
+  /** 전 요일 동일 영업시간 설정. */
+  async function openAllWeek(
+    store: Store,
+    openHour = 10,
+    closeHour = 20,
+  ): Promise<void> {
+    for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek += 1) {
+      await setBusinessHour(store, dayOfWeek, openHour, closeHour);
+    }
+  }
+
+  /** 특정 날짜(@db.Date, UTC 자정 표현) 일일 capacity 설정. */
+  async function setCapacity(
+    store: Store,
+    dateOnlyUtc: Date,
+    capacity: number,
+  ): Promise<void> {
+    await prisma.storeDailyCapacity.create({
+      data: { store_id: store.id, capacity_date: dateOnlyUtc, capacity },
+    });
+  }
+
+  /** 픽업 주문 1건 생성(케이크 quantity개). */
+  async function book(
+    store: Store,
+    pickupAt: Date,
+    quantity = 1,
+    status: OrderStatus = 'CONFIRMED',
+  ): Promise<bigint> {
+    const order = await createOrder(prisma, { status, pickup_at: pickupAt });
+    await createOrderItem(prisma, {
+      order_id: order.id,
+      store_id: store.id,
+      quantity,
+    });
+    return order.id;
+  }
+
+  /** 달력에서 특정 날짜 row 조회. */
+  function dayOf(calendar: StorePickupCalendar, date: string) {
+    const found = calendar.days.find((d) => d.date === date);
+    if (!found) throw new Error(`달력에 ${date}가 없음`);
+    return found;
+  }
+
+  describe('storePickupCalendar', () => {
+    it('과거는 PAST, max_days_ahead 초과는 OUT_OF_RANGE, 그 사이 영업일은 선택 가능하다', async () => {
+      const store = await createStore(prisma, { max_days_ahead: 7 });
+      await openAllWeek(store);
+
+      const calendar = await service.storePickupCalendar(store.id, '2026-09');
+
+      expect(calendar.yearMonth).toBe('2026-09');
+      expect(calendar.days).toHaveLength(30);
+      expect(dayOf(calendar, '2026-09-01')).toMatchObject({
+        selectable: false,
+        reason: 'PAST',
+      });
+      expect(dayOf(calendar, '2026-09-15')).toMatchObject({
+        selectable: false,
+        reason: 'PAST',
+      });
+      expect(dayOf(calendar, '2026-09-17')).toMatchObject({
+        selectable: true,
+        reason: null,
+      });
+      expect(dayOf(calendar, '2026-09-23')).toMatchObject({
+        selectable: true,
+        reason: null,
+      });
+      expect(dayOf(calendar, '2026-09-24')).toMatchObject({
+        selectable: false,
+        reason: 'OUT_OF_RANGE',
+      });
+      expect(dayOf(calendar, '2026-09-30')).toMatchObject({
+        selectable: false,
+        reason: 'OUT_OF_RANGE',
+      });
+    });
+
+    it('특별휴무일은 CLOSED다', async () => {
+      const store = await createStore(prisma);
+      await openAllWeek(store);
+      await prisma.storeSpecialClosure.create({
+        data: {
+          store_id: store.id,
+          closure_date: new Date(Date.UTC(2026, 8, 18)),
+        },
+      });
+
+      const calendar = await service.storePickupCalendar(store.id, '2026-09');
+
+      expect(dayOf(calendar, '2026-09-18')).toMatchObject({
+        selectable: false,
+        reason: 'CLOSED',
+      });
+      expect(dayOf(calendar, '2026-09-17').selectable).toBe(true);
+    });
+
+    it('요일 휴무(is_closed)·영업시간 미설정 요일은 CLOSED다', async () => {
+      const store = await createStore(prisma);
+      await setBusinessHour(store, 4, 10, 20); // 목요일만 영업
+      await setBusinessHour(store, 5, 0, 0, true); // 금요일 휴무 지정
+
+      const calendar = await service.storePickupCalendar(store.id, '2026-09');
+
+      expect(dayOf(calendar, '2026-09-17')).toMatchObject({
+        selectable: true,
+        reason: null,
+      }); // 목
+      expect(dayOf(calendar, '2026-09-18')).toMatchObject({
+        selectable: false,
+        reason: 'CLOSED',
+      }); // 금(is_closed)
+      expect(dayOf(calendar, '2026-09-19')).toMatchObject({
+        selectable: false,
+        reason: 'CLOSED',
+      }); // 토(미설정)
+    });
+
+    it('capacity 소진 날짜는 CAPACITY_FULL이고 레코드 없는 날짜는 무제한이다', async () => {
+      const store = await createStore(prisma);
+      await openAllWeek(store);
+      await setCapacity(store, new Date(Date.UTC(2026, 8, 17)), 2);
+      // 9/17 14:00 KST 픽업 2건 → capacity 2 소진
+      await book(store, new Date('2026-09-17T05:00:00.000Z'));
+      await book(store, new Date('2026-09-17T05:00:00.000Z'));
+      // 9/18은 capacity 레코드 없음 → 예약이 많아도 무제한
+      await book(store, new Date('2026-09-18T05:00:00.000Z'), 5);
+
+      const calendar = await service.storePickupCalendar(store.id, '2026-09');
+
+      expect(dayOf(calendar, '2026-09-17')).toMatchObject({
+        selectable: false,
+        reason: 'CAPACITY_FULL',
+      });
+      expect(dayOf(calendar, '2026-09-18').selectable).toBe(true);
+    });
+
+    it('취소·soft-delete 주문은 capacity 점유에서 제외한다', async () => {
+      const store = await createStore(prisma);
+      await openAllWeek(store);
+      await setCapacity(store, new Date(Date.UTC(2026, 8, 17)), 1);
+      await book(store, new Date('2026-09-17T05:00:00.000Z'), 1, 'CANCELED');
+      const deletedOrderId = await book(
+        store,
+        new Date('2026-09-17T05:00:00.000Z'),
+      );
+      await prisma.order.update({
+        where: { id: deletedOrderId },
+        data: { deleted_at: new Date() },
+      });
+
+      const calendar = await service.storePickupCalendar(store.id, '2026-09');
+
+      expect(dayOf(calendar, '2026-09-17')).toMatchObject({
+        selectable: true,
+        reason: null,
+      });
+    });
+
+    it('당일은 리드타임 반영 잔여 슬롯이 없으면 CLOSED다', async () => {
+      // 현재 16:00 + 리드 60분 → 마지막 슬롯 15:30이 이미 지나 잔여 없음
+      const soldOutToday = await createStore(prisma, {
+        min_lead_time_minutes: 60,
+      });
+      await openAllWeek(soldOutToday, 10, 16);
+      const openToday = await createStore(prisma, {
+        min_lead_time_minutes: 60,
+      });
+      await openAllWeek(openToday, 10, 20);
+
+      const closedCal = await service.storePickupCalendar(
+        soldOutToday.id,
+        '2026-09',
+      );
+      const openCal = await service.storePickupCalendar(
+        openToday.id,
+        '2026-09',
+      );
+
+      expect(dayOf(closedCal, '2026-09-16')).toMatchObject({
+        selectable: false,
+        reason: 'CLOSED',
+      });
+      // 미래일은 리드타임 무관하게 선택 가능
+      expect(dayOf(closedCal, '2026-09-17').selectable).toBe(true);
+      expect(dayOf(openCal, '2026-09-16').selectable).toBe(true);
+    });
+
+    it('KST 자정 경계 픽업 주문은 KST 날짜 기준으로 집계한다', async () => {
+      const store = await createStore(prisma);
+      await openAllWeek(store);
+      await setCapacity(store, new Date(Date.UTC(2026, 8, 21)), 1);
+      // UTC 9/20 15:30 = KST 9/21 00:30 → 9/21 점유
+      await book(store, new Date('2026-09-20T15:30:00.000Z'));
+
+      const calendar = await service.storePickupCalendar(store.id, '2026-09');
+
+      expect(dayOf(calendar, '2026-09-21')).toMatchObject({
+        selectable: false,
+        reason: 'CAPACITY_FULL',
+      });
+      expect(dayOf(calendar, '2026-09-20').selectable).toBe(true);
+    });
+
+    it('연월 형식 오류는 거절한다', async () => {
+      const store = await createStore(prisma);
+
+      await expect(
+        service.storePickupCalendar(store.id, '2026-13'),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.storePickupCalendar(store.id, '202609'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('없거나 비활성 매장은 NOT_FOUND다', async () => {
+      const inactive = await createStore(prisma, { is_active: false });
+
+      await expect(
+        service.storePickupCalendar(999999n, '2026-09'),
+      ).rejects.toThrow(NotFoundException);
+      await expect(
+        service.storePickupCalendar(inactive.id, '2026-09'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('storePickupTimeSlots', () => {
+    it('매장 간격·영업시간으로 슬롯을 만들고 당일 리드타임 이전 슬롯은 마감한다', async () => {
+      const store = await createStore(prisma, {
+        pickup_slot_interval_minutes: 60,
+        min_lead_time_minutes: 60,
+      });
+      await openAllWeek(store, 10, 18);
+
+      const result = await service.storePickupTimeSlots(store.id, '2026-09-16');
+
+      // 현재 16:00 + 리드 60분 → 17:00부터 가용
+      expect(result.date).toBe('2026-09-16');
+      expect(result.morning).toEqual([
+        { time: '10:00', available: false },
+        { time: '11:00', available: false },
+      ]);
+      expect(result.afternoon).toEqual([
+        { time: '12:00', available: false },
+        { time: '13:00', available: false },
+        { time: '14:00', available: false },
+        { time: '15:00', available: false },
+        { time: '16:00', available: false },
+        { time: '17:00', available: true },
+      ]);
+    });
+
+    it('미래 날짜는 전 슬롯 가용이고 12:00 기준으로 오전/오후를 나눈다', async () => {
+      const store = await createStore(prisma);
+      await openAllWeek(store, 11, 13);
+
+      const result = await service.storePickupTimeSlots(store.id, '2026-09-18');
+
+      expect(result.morning).toEqual([
+        { time: '11:00', available: true },
+        { time: '11:30', available: true },
+      ]);
+      expect(result.afternoon).toEqual([
+        { time: '12:00', available: true },
+        { time: '12:30', available: true },
+      ]);
+    });
+
+    it('영업하지 않는 날은 빈 배열을 반환한다', async () => {
+      const store = await createStore(prisma);
+      await setBusinessHour(store, 4, 10, 20); // 목요일만 영업
+
+      const result = await service.storePickupTimeSlots(store.id, '2026-09-19');
+
+      expect(result).toEqual({
+        date: '2026-09-19',
+        morning: [],
+        afternoon: [],
+      });
+    });
+
+    it('capacity 소진 날짜는 전 슬롯 마감으로 표기한다', async () => {
+      const store = await createStore(prisma);
+      await openAllWeek(store, 10, 12);
+      await setCapacity(store, new Date(Date.UTC(2026, 8, 18)), 1);
+      await book(store, new Date('2026-09-18T02:00:00.000Z'));
+
+      const result = await service.storePickupTimeSlots(store.id, '2026-09-18');
+
+      expect(result.morning).toEqual([
+        { time: '10:00', available: false },
+        { time: '10:30', available: false },
+        { time: '11:00', available: false },
+        { time: '11:30', available: false },
+      ]);
+      expect(result.afternoon).toEqual([]);
+    });
+
+    it('과거 날짜는 전 슬롯 마감이다', async () => {
+      const store = await createStore(prisma);
+      await openAllWeek(store, 10, 11);
+
+      const result = await service.storePickupTimeSlots(store.id, '2026-09-15');
+
+      expect(result.morning).toEqual([
+        { time: '10:00', available: false },
+        { time: '10:30', available: false },
+      ]);
+    });
+
+    it('날짜 형식 오류는 거절한다', async () => {
+      const store = await createStore(prisma);
+
+      await expect(
+        service.storePickupTimeSlots(store.id, '2026-09-32'),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.storePickupTimeSlots(store.id, '20260918'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('없거나 비활성 매장은 NOT_FOUND다', async () => {
+      const inactive = await createStore(prisma, { is_active: false });
+
+      await expect(
+        service.storePickupTimeSlots(999999n, '2026-09-18'),
+      ).rejects.toThrow(NotFoundException);
+      await expect(
+        service.storePickupTimeSlots(inactive.id, '2026-09-18'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/features/store/services/store-pickup-schedule.service.ts
+++ b/src/features/store/services/store-pickup-schedule.service.ts
@@ -32,9 +32,12 @@ import type {
   StorePickupTimeSlots,
 } from '@/features/store/types/store-pickup-schedule-output.type';
 
-// MySQL DATE 표현 범위(1000-01-01~9999-12-31) 안에서 익월/익일 상한 계산이 넘치지
-// 않도록 연도를 제한한다. Date.UTC의 0~99년 → 1900년대 매핑 오동작도 함께 차단.
-const MIN_SCHEDULE_YEAR = 1000;
+// MySQL DATE/DATETIME 표현 범위(1000-01-01~9999-12-31) 안에서 KST 자정(-9h) 경계와
+// 익월/익일 상한 계산이 넘치지 않도록 연도를 제한한다.
+// 하한 1001: 1000-01의 KST 월 시작 경계가 0999-12-31T15:00Z로 DATETIME 하한을 밑돈다.
+// 상한 9998: 9999-12의 익월 상한이 DATE 상한을 넘는다.
+// Date.UTC의 0~99년 → 1900년대 매핑 오동작도 함께 차단.
+const MIN_SCHEDULE_YEAR = 1001;
 const MAX_SCHEDULE_YEAR = 9998;
 
 /** 월/일 범위 벌크 조회 결과(달력 판정 컨텍스트). */

--- a/src/features/store/services/store-pickup-schedule.service.ts
+++ b/src/features/store/services/store-pickup-schedule.service.ts
@@ -32,6 +32,11 @@ import type {
   StorePickupTimeSlots,
 } from '@/features/store/types/store-pickup-schedule-output.type';
 
+// MySQL DATE 표현 범위(1000-01-01~9999-12-31) 안에서 익월/익일 상한 계산이 넘치지
+// 않도록 연도를 제한한다. Date.UTC의 0~99년 → 1900년대 매핑 오동작도 함께 차단.
+const MIN_SCHEDULE_YEAR = 1000;
+const MAX_SCHEDULE_YEAR = 9998;
+
 /** 월/일 범위 벌크 조회 결과(달력 판정 컨텍스트). */
 interface ScheduleContext {
   hoursByWeekday: Map<number, StoreWeekdayBusinessHourRow>;
@@ -56,7 +61,7 @@ export class StorePickupScheduleService {
     yearMonth: string,
   ): Promise<StorePickupCalendar> {
     const ym = parseKstYearMonth(yearMonth);
-    if (!ym) {
+    if (!ym || ym.year < MIN_SCHEDULE_YEAR || ym.year > MAX_SCHEDULE_YEAR) {
       throw new BadRequestException(
         STORE_PICKUP_SCHEDULE_ERRORS.INVALID_YEAR_MONTH,
       );
@@ -114,13 +119,16 @@ export class StorePickupScheduleService {
     if (!parsed) {
       throw new BadRequestException(STORE_PICKUP_SCHEDULE_ERRORS.INVALID_DATE);
     }
+    const { year, month, day } = toKstYmd(parsed);
+    if (year < MIN_SCHEDULE_YEAR || year > MAX_SCHEDULE_YEAR) {
+      throw new BadRequestException(STORE_PICKUP_SCHEDULE_ERRORS.INVALID_DATE);
+    }
     const store = await this.repo.findStoreForPickupSchedule(storeId);
     if (!store) {
       throw new NotFoundException(STORE_PICKUP_SCHEDULE_ERRORS.STORE_NOT_FOUND);
     }
 
     const now = this.clock.now();
-    const { year, month, day } = toKstYmd(parsed);
     const ctx = await this.loadScheduleContext(
       store.id,
       new Date(Date.UTC(year, month - 1, day)),

--- a/src/features/store/services/store-pickup-schedule.service.ts
+++ b/src/features/store/services/store-pickup-schedule.service.ts
@@ -1,0 +1,273 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { ClockService } from '@/common/providers/clock.service';
+import {
+  kstDayDiff,
+  kstMidnightUtc,
+  kstMinutesOfDay,
+  parseKstDate,
+  parseKstYearMonth,
+  toKstYmd,
+} from '@/common/utils/kst-time';
+import { PICKUP_AFTERNOON_START_MINUTES } from '@/features/pickup';
+import { STORE_PICKUP_SCHEDULE_ERRORS } from '@/features/store/constants/store-pickup-schedule-error-messages';
+import { STORE_PICKUP_DAY_REASON } from '@/features/store/constants/store-pickup-schedule.constants';
+import {
+  StoreRepository,
+  type StorePickupPolicyRow,
+  type StoreWeekdayBusinessHourRow,
+} from '@/features/store/repositories/store.repository';
+import {
+  buildTodaySlots,
+  timeColumnToMinutes,
+} from '@/features/store/services/store-today-pickup.helper';
+import type {
+  StorePickupCalendar,
+  StorePickupDay,
+  StorePickupSlot,
+  StorePickupTimeSlots,
+} from '@/features/store/types/store-pickup-schedule-output.type';
+
+/** 월/일 범위 벌크 조회 결과(달력 판정 컨텍스트). */
+interface ScheduleContext {
+  hoursByWeekday: Map<number, StoreWeekdayBusinessHourRow>;
+  closureDates: Set<string>;
+  capacities: Map<string, number>;
+  bookedByDate: Map<string, number>;
+}
+
+@Injectable()
+export class StorePickupScheduleService {
+  constructor(
+    private readonly repo: StoreRepository,
+    private readonly clock: ClockService,
+  ) {}
+
+  /**
+   * 매장별 월 픽업 가능 날짜. todayPickupStores와 동일한 매장 정책
+   * (요일 영업시간·특별휴무·일일 capacity·리드타임)을 월 단위로 판정한다.
+   */
+  async storePickupCalendar(
+    storeId: bigint,
+    yearMonth: string,
+  ): Promise<StorePickupCalendar> {
+    const ym = parseKstYearMonth(yearMonth);
+    if (!ym) {
+      throw new BadRequestException(
+        STORE_PICKUP_SCHEDULE_ERRORS.INVALID_YEAR_MONTH,
+      );
+    }
+    const store = await this.repo.findStoreForPickupSchedule(storeId);
+    if (!store) {
+      throw new NotFoundException(STORE_PICKUP_SCHEDULE_ERRORS.STORE_NOT_FOUND);
+    }
+
+    const now = this.clock.now();
+    const daysInMonth = new Date(Date.UTC(ym.year, ym.month, 0)).getUTCDate();
+    // 조회는 월 범위 벌크 4회로 끝내고, 날짜 루프에서는 추가 쿼리를 내지 않는다
+    const ctx = await this.loadScheduleContext(
+      store.id,
+      new Date(Date.UTC(ym.year, ym.month - 1, 1)),
+      new Date(Date.UTC(ym.year, ym.month, 1)),
+      kstMidnightUtc(ym.year, ym.month, 1),
+      kstMidnightUtc(ym.year, ym.month + 1, 1),
+    );
+
+    const days: StorePickupDay[] = Array.from(
+      { length: daysInMonth },
+      (_, index) => {
+        const day = index + 1;
+        const reason = this.evaluateDay(
+          store,
+          ctx,
+          now,
+          ym.year,
+          ym.month,
+          day,
+        );
+        return {
+          date: new Date(Date.UTC(ym.year, ym.month - 1, day))
+            .toISOString()
+            .slice(0, 10),
+          selectable: reason === null,
+          reason,
+        };
+      },
+    );
+
+    return { yearMonth, days };
+  }
+
+  /**
+   * 매장별 특정 날짜의 시간 슬롯(오전/오후). 영업하지 않는 날은 빈 배열,
+   * 선택 불가 날짜(과거·범위 초과·휴무·capacity 소진)는 전 슬롯 마감 표기.
+   */
+  async storePickupTimeSlots(
+    storeId: bigint,
+    date: string,
+  ): Promise<StorePickupTimeSlots> {
+    const parsed = parseKstDate(date);
+    if (!parsed) {
+      throw new BadRequestException(STORE_PICKUP_SCHEDULE_ERRORS.INVALID_DATE);
+    }
+    const store = await this.repo.findStoreForPickupSchedule(storeId);
+    if (!store) {
+      throw new NotFoundException(STORE_PICKUP_SCHEDULE_ERRORS.STORE_NOT_FOUND);
+    }
+
+    const now = this.clock.now();
+    const { year, month, day } = toKstYmd(parsed);
+    const ctx = await this.loadScheduleContext(
+      store.id,
+      new Date(Date.UTC(year, month - 1, day)),
+      new Date(Date.UTC(year, month - 1, day + 1)),
+      parsed,
+      kstMidnightUtc(year, month, day + 1),
+    );
+
+    const hour = ctx.hoursByWeekday.get(
+      new Date(Date.UTC(year, month - 1, day)).getUTCDay(),
+    );
+    if (!hour || hour.is_closed || !hour.open_time || !hour.close_time) {
+      return { date, morning: [], afternoon: [] };
+    }
+
+    const reason = this.evaluateDay(store, ctx, now, year, month, day);
+    const isToday = kstDayDiff(now, parsed) === 0;
+    let slots = this.buildDaySlots(
+      store,
+      hour.open_time,
+      hour.close_time,
+      isToday,
+      now,
+    );
+    if (reason !== null) {
+      slots = slots.map((slot) => ({ ...slot, available: false }));
+    }
+
+    return {
+      date,
+      morning: slots.filter(
+        (slot) => slotMinutes(slot) < PICKUP_AFTERNOON_START_MINUTES,
+      ),
+      afternoon: slots.filter(
+        (slot) => slotMinutes(slot) >= PICKUP_AFTERNOON_START_MINUTES,
+      ),
+    };
+  }
+
+  private async loadScheduleContext(
+    storeId: bigint,
+    fromDateOnly: Date,
+    toDateOnly: Date,
+    rangeStartUtc: Date,
+    rangeEndUtc: Date,
+  ): Promise<ScheduleContext> {
+    const [hours, closureDates, capacities, bookedByDate] = await Promise.all([
+      this.repo.findBusinessHoursForStore(storeId),
+      this.repo.findSpecialClosureDatesInRange(
+        storeId,
+        fromDateOnly,
+        toDateOnly,
+      ),
+      this.repo.findDailyCapacitiesInRange(storeId, fromDateOnly, toDateOnly),
+      this.repo.sumPickupQuantitiesByKstDate(
+        storeId,
+        rangeStartUtc,
+        rangeEndUtc,
+      ),
+    ]);
+    return {
+      hoursByWeekday: new Map(hours.map((h) => [h.day_of_week, h])),
+      closureDates,
+      capacities,
+      bookedByDate,
+    };
+  }
+
+  /**
+   * 해당 KST 달력일의 선택 불가 사유(null이면 선택 가능).
+   * 판정 순서: 과거 → 범위 초과 → 특별휴무 → 요일 휴무/영업시간 미설정
+   * → capacity 소진 → 당일 잔여 가용 슬롯 없음.
+   */
+  private evaluateDay(
+    store: StorePickupPolicyRow,
+    ctx: ScheduleContext,
+    now: Date,
+    year: number,
+    month: number,
+    day: number,
+  ): string | null {
+    const dateOnlyUtc = new Date(Date.UTC(year, month - 1, day));
+    const dateKey = dateOnlyUtc.toISOString().slice(0, 10);
+    const diff = kstDayDiff(now, kstMidnightUtc(year, month, day));
+
+    if (diff < 0) return STORE_PICKUP_DAY_REASON.PAST;
+    if (diff > store.max_days_ahead) {
+      return STORE_PICKUP_DAY_REASON.OUT_OF_RANGE;
+    }
+    if (ctx.closureDates.has(dateKey)) return STORE_PICKUP_DAY_REASON.CLOSED;
+
+    const hour = ctx.hoursByWeekday.get(dateOnlyUtc.getUTCDay());
+    if (!hour || hour.is_closed || !hour.open_time || !hour.close_time) {
+      return STORE_PICKUP_DAY_REASON.CLOSED;
+    }
+
+    // capacity 레코드가 없으면 무제한으로 간주(todayPickupStores와 동일 해석)
+    const capacity = ctx.capacities.get(dateKey);
+    const booked = ctx.bookedByDate.get(dateKey) ?? 0;
+    if (capacity !== undefined && booked >= capacity) {
+      return STORE_PICKUP_DAY_REASON.CAPACITY_FULL;
+    }
+
+    // 당일은 리드타임 반영 잔여 슬롯이 있어야 선택 가능(전역 pickupCalendar 선례와 일치)
+    if (diff === 0) {
+      const slots = this.buildDaySlots(
+        store,
+        hour.open_time,
+        hour.close_time,
+        true,
+        now,
+      );
+      if (!slots.some((slot) => slot.available)) {
+        return STORE_PICKUP_DAY_REASON.CLOSED;
+      }
+    }
+    return null;
+  }
+
+  /** 영업시간·매장 슬롯 간격으로 슬롯 생성. 당일만 리드타임 컷오프를 적용한다. */
+  private buildDaySlots(
+    store: StorePickupPolicyRow,
+    openTime: Date,
+    closeTime: Date,
+    isToday: boolean,
+    now: Date,
+  ): StorePickupSlot[] {
+    // 분 단위 절삭은 리드타임을 최대 59초 짧게 만들므로, 초가 남으면 다음 분으로 올린다
+    const hasSubMinute =
+      now.getUTCSeconds() > 0 || now.getUTCMilliseconds() > 0;
+    // 미래일은 컷오프 무력화(-Infinity + 리드타임 = -Infinity → 전 슬롯 가용)
+    const nowMinutes = isToday
+      ? kstMinutesOfDay(now) + (hasSubMinute ? 1 : 0)
+      : Number.NEGATIVE_INFINITY;
+    return buildTodaySlots({
+      openMinutes: timeColumnToMinutes(openTime),
+      closeMinutes: timeColumnToMinutes(closeTime),
+      intervalMinutes: store.pickup_slot_interval_minutes,
+      leadTimeMinutes: store.min_lead_time_minutes,
+      nowMinutes,
+    });
+  }
+}
+
+/** "HH:MM" 슬롯 시각을 자정 경과 분으로 변환(오전/오후 분리용). */
+function slotMinutes(slot: StorePickupSlot): number {
+  const hours = Number(slot.time.slice(0, 2));
+  const minutes = Number(slot.time.slice(3, 5));
+  return hours * 60 + minutes;
+}

--- a/src/features/store/store-pickup-schedule.graphql
+++ b/src/features/store/store-pickup-schedule.graphql
@@ -1,0 +1,31 @@
+extend type Query {
+  """매장별 월 픽업 가능 날짜. 없거나 비활성/삭제 매장이면 NOT_FOUND. 비로그인 접근 가능. yearMonth: "YYYY-MM" """
+  storePickupCalendar(storeId: ID!, yearMonth: String!): StorePickupCalendar!
+  """매장별 선택 날짜의 픽업 시간 슬롯. date: "YYYY-MM-DD" """
+  storePickupTimeSlots(storeId: ID!, date: String!): StorePickupTimeSlots!
+}
+
+"""매장별 월 픽업 달력(상품 상세 픽업 일정 선택용)."""
+type StorePickupCalendar {
+  yearMonth: String!
+  days: [StorePickupDay!]!
+}
+
+type StorePickupDay {
+  date: String!
+  selectable: Boolean!
+  """선택 불가 사유. PAST | OUT_OF_RANGE | CLOSED(휴무·영업요일 아님·당일 잔여 슬롯 없음) | CAPACITY_FULL. 선택 가능 시 null."""
+  reason: String
+}
+
+"""매장별 특정 날짜의 픽업 시간 슬롯. 영업하지 않는 날은 빈 배열."""
+type StorePickupTimeSlots {
+  date: String!
+  morning: [StorePickupSlot!]!
+  afternoon: [StorePickupSlot!]!
+}
+
+type StorePickupSlot {
+  time: String!
+  available: Boolean!
+}

--- a/src/features/store/store.module.ts
+++ b/src/features/store/store.module.ts
@@ -4,12 +4,14 @@ import { StoreReviewRepository } from '@/features/store/repositories/store-revie
 import { StoreWishlistRepository } from '@/features/store/repositories/store-wishlist.repository';
 import { StoreRepository } from '@/features/store/repositories/store.repository';
 import { StoreDetailQueryResolver } from '@/features/store/resolvers/store-detail-query.resolver';
+import { StorePickupScheduleQueryResolver } from '@/features/store/resolvers/store-pickup-schedule-query.resolver';
 import { StoreQueryResolver } from '@/features/store/resolvers/store-query.resolver';
 import { StoreReviewQueryResolver } from '@/features/store/resolvers/store-review-query.resolver';
 import { StoreTodayPickupQueryResolver } from '@/features/store/resolvers/store-today-pickup-query.resolver';
 import { StoreWishlistMutationResolver } from '@/features/store/resolvers/store-wishlist-mutation.resolver';
 import { StoreDetailService } from '@/features/store/services/store-detail.service';
 import { StoreListingService } from '@/features/store/services/store-listing.service';
+import { StorePickupScheduleService } from '@/features/store/services/store-pickup-schedule.service';
 import { StoreReviewService } from '@/features/store/services/store-review.service';
 import { StoreTodayPickupService } from '@/features/store/services/store-today-pickup.service';
 import { StoreWishlistService } from '@/features/store/services/store-wishlist.service';
@@ -29,6 +31,8 @@ import { StoreWishlistService } from '@/features/store/services/store-wishlist.s
     StoreReviewQueryResolver,
     StoreTodayPickupService,
     StoreTodayPickupQueryResolver,
+    StorePickupScheduleService,
+    StorePickupScheduleQueryResolver,
   ],
   exports: [StoreRepository],
 })

--- a/src/features/store/types/store-pickup-schedule-output.type.ts
+++ b/src/features/store/types/store-pickup-schedule-output.type.ts
@@ -1,0 +1,26 @@
+/**
+ * store-pickup-schedule resolver 반환용 도메인 출력 타입.
+ * SDL(store-pickup-schedule.graphql)의 타입과 필드 일치.
+ */
+
+export interface StorePickupDay {
+  date: string;
+  selectable: boolean;
+  reason: string | null;
+}
+
+export interface StorePickupCalendar {
+  yearMonth: string;
+  days: StorePickupDay[];
+}
+
+export interface StorePickupSlot {
+  time: string;
+  available: boolean;
+}
+
+export interface StorePickupTimeSlots {
+  date: string;
+  morning: StorePickupSlot[];
+  afternoon: StorePickupSlot[];
+}

--- a/src/test/factories/store.factory.ts
+++ b/src/test/factories/store.factory.ts
@@ -21,6 +21,7 @@ export interface StoreOverrides {
   regular_closure_text?: string | null;
   pickup_slot_interval_minutes?: number;
   min_lead_time_minutes?: number;
+  max_days_ahead?: number;
 }
 
 export async function createStore(
@@ -53,6 +54,7 @@ export async function createStore(
       pickup_slot_interval_minutes:
         overrides.pickup_slot_interval_minutes ?? 30,
       min_lead_time_minutes: overrides.min_lead_time_minutes ?? 30,
+      max_days_ahead: overrides.max_days_ahead ?? 30,
     },
   });
 }


### PR DESCRIPTION
## 배경

상품 상세의 주문 전(커스텀 진입 전) 픽업 일정 선택 화면은 달력의 날짜별 "마감" 표기와 시간 슬롯 비활성 표시를 요구합니다.
기존 `pickupCalendar`/`pickupTimeSlots`는 홈 화면용 전역 고정 정책이라 매장별 휴무·영업시간·일일 capacity를 표현할 수 없었습니다.
그래서 매장별 조회 쿼리 `storePickupCalendar(storeId, yearMonth)` / `storePickupTimeSlots(storeId, date)` 2건을 신설했습니다.
전역 쿼리는 변경하지 않았습니다.

## 주요 결정 사항

- **판정 규칙을 새로 만들지 않고 `todayPickupStores` 선례를 월 단위로 확장**: 특별휴무·요일 휴무·영업시간 미설정은 `CLOSED`로 처리합니다.
  capacity는 레코드가 없으면 무제한이고, 취소·soft-delete 제외 주문 수량 합이 capacity 이상이면 `CAPACITY_FULL`입니다.
  슬롯은 매장 `pickup_slot_interval_minutes` 간격과 `[open, close)` 규칙으로 만들고, 당일만 `min_lead_time_minutes` 컷오프를 적용합니다(초 잔여 시 다음 분 올림).
- **달력 범위는 매장 `max_days_ahead` 컬럼 사용**: 과거는 `PAST`, 초과는 `OUT_OF_RANGE`이며, 당일에 잔여 가용 슬롯이 없으면 날짜 자체를 `CLOSED` 처리합니다(전역 달력 선례와 동일).
- **위치는 store feature**: 판정에 필요한 데이터(영업시간·휴무·capacity·주문 점유)와 슬롯 헬퍼가 모두 store feature에 있어 그대로 재사용했습니다.
  오전/오후 경계(12:00)는 매장 무관 UI 규칙으로 판단해 pickup feature 전역 상수를 배럴 export로 가져왔습니다(명세 외 정책 결정).
- **연도를 1001~9998로 제한**(Codex 리뷰 반영): KST -9h 경계와 익월/익일 상한 계산이 MySQL DATE/DATETIME 표현 범위를 벗어나지 않도록 방어합니다.
  0~99년을 1900년대로 매핑하는 `Date.UTC` 오동작도 함께 차단합니다.
- 조회는 월 범위 벌크 4회로 고정해 날짜 루프에서 추가 쿼리를 내지 않습니다.
  비로그인 접근 가능하며, 비활성/삭제 매장은 NOT_FOUND입니다.
  스키마 변경(마이그레이션) 없음.

## 검증

- real DB 회귀 테스트 20건(달력 판정 전 분기, KST 자정 경계 집계, 슬롯 간격·리드타임·오전오후 분리, 연도 범위·형식 오류·NOT_FOUND, resolver 통합 2건) 추가.
- `yarn validate` 전체 통과.