### PR TITLE
fix: 릴리즈 리뷰 반영 (특별휴무일 픽업 슬롯 빈 배열 반환)

### DIFF
--- a/src/features/store/services/store-pickup-schedule.service.spec.ts
+++ b/src/features/store/services/store-pickup-schedule.service.spec.ts
@@ -365,6 +365,25 @@ describe('StorePickupScheduleService (real DB)', () => {
       });
     });
 
+    it('특별휴무일도 빈 배열을 반환한다', async () => {
+      const store = await createStore(prisma);
+      await openAllWeek(store);
+      await prisma.storeSpecialClosure.create({
+        data: {
+          store_id: store.id,
+          closure_date: new Date(Date.UTC(2026, 8, 18)),
+        },
+      });
+
+      const result = await service.storePickupTimeSlots(store.id, '2026-09-18');
+
+      expect(result).toEqual({
+        date: '2026-09-18',
+        morning: [],
+        afternoon: [],
+      });
+    });
+
     it('capacity 소진 날짜는 전 슬롯 마감으로 표기한다', async () => {
       const store = await createStore(prisma);
       await openAllWeek(store, 10, 12);

--- a/src/features/store/services/store-pickup-schedule.service.ts
+++ b/src/features/store/services/store-pickup-schedule.service.ts
@@ -146,6 +146,14 @@ export class StorePickupScheduleService {
     if (!hour || hour.is_closed || !hour.open_time || !hour.close_time) {
       return { date, morning: [], afternoon: [] };
     }
+    // 특별휴무도 요일 휴무와 같은 "영업하지 않는 날" — SDL 주석대로 빈 배열로 통일한다.
+    // (PAST/OUT_OF_RANGE/CAPACITY_FULL/당일 마감은 영업일이므로 슬롯을 마감 표기로 유지)
+    const dateKey = new Date(Date.UTC(year, month - 1, day))
+      .toISOString()
+      .slice(0, 10);
+    if (ctx.closureDates.has(dateKey)) {
+      return { date, morning: [], afternoon: [] };
+    }
 
     const reason = this.evaluateDay(store, ctx, now, year, month, day);
     const isToday = kstDayDiff(now, parsed) === 0;


### PR DESCRIPTION
## 배경

릴리즈 PR #194의 CodeRabbit 지적 반영입니다.
SDL 주석은 "영업하지 않는 날은 빈 배열"인데, 특별휴무일은 요일 휴무와 달리 전체 슬롯을 `available: false`로 반환해 동작이 어긋났습니다.
특별휴무도 "매장이 그날 안 여는 날"이므로 요일 휴무와 동일하게 빈 배열로 통일합니다.

## 변경점

- `storePickupTimeSlots`: 특별휴무일이면 슬롯 생성 전에 빈 배열 반환.
- `PAST`/`OUT_OF_RANGE`/`CAPACITY_FULL`/당일 리드타임 마감은 영업일이므로 기존대로 슬롯 마감 표기 유지.

## 검증

- real DB 회귀 테스트 1건 추가(특별휴무일 빈 배열), 스위트 19건 전체 통과.