### PR TITLE
fix(common): 쿼리 키의 프로토타입 오염 위험 속성 쓰기 차단

### DIFF
--- a/src/common/utils/url-query.spec.ts
+++ b/src/common/utils/url-query.spec.ts
@@ -50,5 +50,16 @@ describe('url-query', () => {
       const result = toQueryParams({ nested: { x: 1 } as never });
       expect(result.nested).toBe('{"x":1}');
     });
+
+    it('프로토타입 오염 위험 키는 제외한다', () => {
+      const result = toQueryParams({
+        ['__proto__']: 'x',
+        constructor: 'y',
+        prototype: 'z',
+        safe: 'ok',
+      } as never);
+      expect(result).toEqual({ safe: 'ok' });
+      expect(Object.keys(result)).toEqual(['safe']);
+    });
   });
 });

--- a/src/common/utils/url-query.ts
+++ b/src/common/utils/url-query.ts
@@ -38,6 +38,12 @@ export function toQueryParams(qs: ParsedQs | undefined): QueryParams {
   if (!qs) return out;
 
   for (const [key, raw] of Object.entries(qs)) {
+    // 쿼리 키는 사용자 입력이라 프로토타입 오염 위험 키를 속성으로 쓰지 않는다
+    // (CodeQL js/remote-property-injection). Set 대신 직접 비교를 쓰는 이유:
+    // CodeQL이 sanitizer로 인식하는 패턴이 명시적 키 비교이기 때문.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
     if (raw === undefined || raw === null) continue;
 
     if (Array.isArray(raw)) {


### PR DESCRIPTION
## 배경

CodeQL code scanning의 `js/remote-property-injection`(high) 3건 반영입니다.
`toQueryParams`가 사용자 쿼리 문자열의 키를 그대로 객체 속성으로 써서(`out[key] = ...`) `__proto__` 같은 위험 키가 속성 이름으로 유입될 수 있었습니다.
사용처가 HTTP 요청 메타 로깅(`request-context.ts`) 1곳의 로컬 객체라 실질 위험은 낮지만, 지적은 정당하고 수정 비용이 작아 차단합니다.

## 변경점

- `__proto__`/`constructor`/`prototype` 키는 변환에서 제외.
- CodeQL이 sanitizer로 인식하는 패턴을 따르기 위해 Set 조회가 아닌 명시적 키 비교 사용.

## 검증

- 순수 단위 테스트 1건 추가(위험 키 제외), 스위트 12건 통과.
- 알림 3건은 이 수정이 main에 반영된 뒤 CodeQL 재분석 시 자동 종료 예상.