### PR TITLE
fix: soft-delete 가드 누락 지점 보강 (셀러 조회·리뷰 집계)

### DIFF
--- a/src/features/order/repositories/order.repository.spec.ts
+++ b/src/features/order/repositories/order.repository.spec.ts
@@ -180,6 +180,29 @@ describe('OrderRepository (real DB)', () => {
     });
   });
 
+  describe('findReviewableOrderIds', () => {
+    it('soft-delete된 주문의 아이템은 리뷰 가능 집계에서 제외한다', async () => {
+      const buyer = await setupBuyer();
+      const active = await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'PICKED_UP',
+      });
+      await createOrderItem(prisma, { order_id: active.id });
+      const deleted = await createOrder(prisma, {
+        account_id: buyer.id,
+        status: 'PICKED_UP',
+        deleted_at: new Date(),
+      });
+      await createOrderItem(prisma, { order_id: deleted.id });
+
+      const ids = await repo.findReviewableOrderIds({
+        accountId: buyer.id,
+        orderIds: [active.id, deleted.id],
+      });
+      expect(ids).toEqual(new Set([active.id.toString()]));
+    });
+  });
+
   describe('findOrderDetailByAccount', () => {
     it('본인 주문이면 상세 반환 (status_histories 포함)', async () => {
       const buyer = await setupBuyer();

--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -368,6 +368,9 @@ export class OrderRepository {
         order: {
           account_id: args.accountId,
           status: OrderStatus.PICKED_UP,
+          // 삭제된 주문의 아이템이 리뷰 가능으로 집계되지 않게 명시
+          // (listReviewableOrderItems와 동일 가드)
+          ...activeWhere,
         },
         OR: [
           { review: { is: null } },
@@ -557,6 +560,7 @@ export class OrderRepository {
         items: {
           some: {
             store_id: args.storeId,
+            ...activeWhere,
           },
         },
       },
@@ -572,11 +576,14 @@ export class OrderRepository {
         items: {
           some: {
             store_id: args.storeId,
+            ...activeWhere,
           },
         },
       },
+      // 유저측 상세(findOrderDetailByUser)와 동일하게 soft-delete 자식을 가드한다
       include: {
         status_histories: {
+          where: activeWhere,
           orderBy: {
             changed_at: 'desc',
           },
@@ -584,16 +591,20 @@ export class OrderRepository {
         items: {
           where: {
             store_id: args.storeId,
+            ...activeWhere,
           },
           include: {
-            option_items: true,
+            option_items: { where: activeWhere },
             custom_texts: {
+              where: activeWhere,
               orderBy: { sort_order: 'asc' },
             },
             free_edits: {
+              where: activeWhere,
               orderBy: { sort_order: 'asc' },
               include: {
                 attachments: {
+                  where: activeWhere,
                   orderBy: { sort_order: 'asc' },
                 },
               },

--- a/src/features/product/repositories/product.repository.spec.ts
+++ b/src/features/product/repositories/product.repository.spec.ts
@@ -64,6 +64,44 @@ describe('ProductRepository (real DB)', () => {
 
   // ─── Product list/fetch ──
   describe('listProductsByStore', () => {
+    it('삭제된 카테고리 연결·태그로는 목록 필터에 걸리지 않는다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, {
+        store_id: store.id,
+        name: '무관한 이름',
+      });
+      const category = await createCategory('생일');
+      await prisma.productCategory.create({
+        data: {
+          product_id: product.id,
+          category_id: category.id,
+          deleted_at: new Date(),
+        },
+      });
+      const tag = await createTag('레터링');
+      await prisma.productTag.create({
+        data: {
+          product_id: product.id,
+          tag_id: tag.id,
+          deleted_at: new Date(),
+        },
+      });
+
+      const byCategory = await repo.listProductsByStore({
+        storeId: store.id,
+        limit: 10,
+        categoryId: category.id,
+      });
+      expect(byCategory).toHaveLength(0);
+
+      const bySearch = await repo.listProductsByStore({
+        storeId: store.id,
+        limit: 10,
+        search: '레터링',
+      });
+      expect(bySearch).toHaveLength(0);
+    });
+
     it('store_id 필터 + cursor 페이지네이션', async () => {
       const storeA = await createStore(prisma);
       const storeB = await createStore(prisma);

--- a/src/features/product/repositories/product.repository.spec.ts
+++ b/src/features/product/repositories/product.repository.spec.ts
@@ -209,6 +209,50 @@ describe('ProductRepository (real DB)', () => {
       });
       expect(result).toBeNull();
     });
+
+    it('soft-delete된 카테고리·태그 연결과 삭제된 대상은 제외한다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const liveCategory = await createCategory('생일');
+      const linkDeletedCategory = await createCategory('링크 삭제');
+      const deletedCategory = await createCategory('대상 삭제');
+      await prisma.productCategory.createMany({
+        data: [
+          { product_id: product.id, category_id: liveCategory.id },
+          {
+            product_id: product.id,
+            category_id: linkDeletedCategory.id,
+            deleted_at: new Date(),
+          },
+          { product_id: product.id, category_id: deletedCategory.id },
+        ],
+      });
+      await prisma.category.update({
+        where: { id: deletedCategory.id },
+        data: { deleted_at: new Date() },
+      });
+      const liveTag = await createTag('레터링');
+      const linkDeletedTag = await createTag('링크 삭제 태그');
+      await prisma.productTag.createMany({
+        data: [
+          { product_id: product.id, tag_id: liveTag.id },
+          {
+            product_id: product.id,
+            tag_id: linkDeletedTag.id,
+            deleted_at: new Date(),
+          },
+        ],
+      });
+
+      const result = await repo.findProductById({
+        productId: product.id,
+        storeId: store.id,
+      });
+      expect(result?.product_categories.map((c) => c.category.name)).toEqual([
+        '생일',
+      ]);
+      expect(result?.product_tags.map((t) => t.tag.name)).toEqual(['레터링']);
+    });
   });
 
   describe('findProductByIdIncludingInactive', () => {
@@ -441,6 +485,26 @@ describe('ProductRepository (real DB)', () => {
       expect(result.option_items).toHaveLength(1);
     });
 
+    it('findOptionGroupById·listOptionGroupsByProduct는 soft-delete된 옵션 아이템을 제외한다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const group = await createOptionGroup(product.id);
+      const live = await createOptionItem(group.id);
+      await prisma.productOptionItem.create({
+        data: {
+          option_group_id: group.id,
+          title: '삭제된 항목',
+          deleted_at: new Date(),
+        },
+      });
+
+      const found = await repo.findOptionGroupById(group.id);
+      expect(found?.option_items.map((i) => i.id)).toEqual([live.id]);
+
+      const rows = await repo.listOptionGroupsByProduct(product.id);
+      expect(rows[0].option_items.map((i) => i.id)).toEqual([live.id]);
+    });
+
     it('softDeleteOptionGroup: deleted_at + is_active:false', async () => {
       const store = await createStore(prisma);
       const product = await createProduct(prisma, { store_id: store.id });
@@ -555,6 +619,26 @@ describe('ProductRepository (real DB)', () => {
       expect(second.id).toBe(first.id);
       expect(second.base_image_url).toBe('https://i.example/b.png');
       expect(second.is_active).toBe(false);
+    });
+
+    it('findCustomTemplateById는 soft-delete된 텍스트 토큰을 제외한다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      const tpl = await createTemplate(product.id);
+      const live = await prisma.productCustomTextToken.create({
+        data: { template_id: tpl.id, token_key: 'live', default_text: '문구' },
+      });
+      await prisma.productCustomTextToken.create({
+        data: {
+          template_id: tpl.id,
+          token_key: 'deleted',
+          default_text: '삭제',
+          deleted_at: new Date(),
+        },
+      });
+
+      const found = await repo.findCustomTemplateById(tpl.id);
+      expect(found?.text_tokens.map((t) => t.id)).toEqual([live.id]);
     });
 
     it('findCustomTemplateById + setCustomTemplateActive', async () => {

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -143,11 +143,15 @@ export class ProductRepository {
           orderBy: { sort_order: 'asc' },
         },
         product_categories: {
+          // 링크·대상 카테고리의 soft-delete 가드. is_active는 셀러 화면에서
+          // 기존 지정을 계속 보여줘야 하므로 걸지 않는다.
+          where: { ...activeWhere, category: activeWhere },
           include: {
             category: true,
           },
         },
         product_tags: {
+          where: { ...activeWhere, tag: activeWhere },
           include: {
             tag: true,
           },
@@ -206,11 +210,15 @@ export class ProductRepository {
           orderBy: { sort_order: 'asc' },
         },
         product_categories: {
+          // 링크·대상 카테고리의 soft-delete 가드. is_active는 셀러 화면에서
+          // 기존 지정을 계속 보여줘야 하므로 걸지 않는다.
+          where: { ...activeWhere, category: activeWhere },
           include: {
             category: true,
           },
         },
         product_tags: {
+          where: { ...activeWhere, tag: activeWhere },
           include: {
             tag: true,
           },
@@ -253,11 +261,15 @@ export class ProductRepository {
           orderBy: { sort_order: 'asc' },
         },
         product_categories: {
+          // 링크·대상 카테고리의 soft-delete 가드. is_active는 셀러 화면에서
+          // 기존 지정을 계속 보여줘야 하므로 걸지 않는다.
+          where: { ...activeWhere, category: activeWhere },
           include: {
             category: true,
           },
         },
         product_tags: {
+          where: { ...activeWhere, tag: activeWhere },
           include: {
             tag: true,
           },
@@ -478,6 +490,7 @@ export class ProductRepository {
           },
         },
         option_items: {
+          where: activeWhere,
           orderBy: { sort_order: 'asc' },
         },
       },
@@ -515,6 +528,7 @@ export class ProductRepository {
       orderBy: { sort_order: 'asc' },
       include: {
         option_items: {
+          where: activeWhere,
           orderBy: { sort_order: 'asc' },
         },
       },
@@ -662,6 +676,7 @@ export class ProductRepository {
           },
         },
         text_tokens: {
+          where: activeWhere,
           orderBy: { sort_order: 'asc' },
         },
       },

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -112,9 +112,12 @@ export class ProductRepository {
         ...(args.isActive !== undefined ? { is_active: args.isActive } : {}),
         ...(args.categoryId
           ? {
+              // include의 링크·대상 가드와 동일 — 삭제된 연결이 필터에 걸리지 않게 한다
               product_categories: {
                 some: {
                   category_id: args.categoryId,
+                  ...activeWhere,
+                  category: activeWhere,
                 },
               },
             }
@@ -126,8 +129,10 @@ export class ProductRepository {
                 {
                   product_tags: {
                     some: {
+                      ...activeWhere,
                       tag: {
                         name: { contains: args.search },
+                        ...activeWhere,
                       },
                     },
                   },

--- a/src/features/seller/services/seller-order.service.spec.ts
+++ b/src/features/seller/services/seller-order.service.spec.ts
@@ -158,6 +158,44 @@ describe('SellerOrderService (real DB)', () => {
       expect(result.statusHistories).toHaveLength(1);
       expect(result.statusHistories[0].toStatus).toBe('CONFIRMED');
     });
+
+    it('soft-delete된 아이템·상태 이력은 상세에서 제외한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const order = await createStoreOrder(store.id, { status: 'CONFIRMED' });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        store_id: store.id,
+        deleted_at: new Date(),
+      });
+      await prisma.orderStatusHistory.create({
+        data: {
+          order_id: order.id,
+          from_status: 'SUBMITTED',
+          to_status: 'CONFIRMED',
+          changed_at: new Date('2026-04-15T10:00:00Z'),
+          deleted_at: new Date(),
+        },
+      });
+
+      const result = await service.sellerOrder(account.id, order.id);
+      expect(result.items).toHaveLength(1);
+      expect(result.statusHistories).toHaveLength(0);
+    });
+
+    it('soft-delete된 아이템만 있는 주문은 상세·목록 모두에서 제외한다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      const order = await createStoreOrder(store.id);
+      await prisma.orderItem.updateMany({
+        where: { order_id: order.id },
+        data: { deleted_at: new Date() },
+      });
+
+      await expect(service.sellerOrder(account.id, order.id)).rejects.toThrow(
+        NotFoundException,
+      );
+      const list = await service.sellerOrderList(account.id);
+      expect(list.items).toHaveLength(0);
+    });
   });
 
   describe('sellerUpdateOrderStatus', () => {

--- a/src/test/factories/order.factory.ts
+++ b/src/test/factories/order.factory.ts
@@ -19,6 +19,7 @@ export interface OrderOverrides {
   subtotal_price?: number;
   discount_price?: number;
   total_price?: number;
+  deleted_at?: Date;
 }
 
 export async function createOrder(
@@ -42,6 +43,7 @@ export async function createOrder(
       subtotal_price: overrides.subtotal_price ?? 10000,
       discount_price: overrides.discount_price ?? 0,
       total_price: overrides.total_price ?? 10000,
+      ...(overrides.deleted_at ? { deleted_at: overrides.deleted_at } : {}),
     },
   });
 }
@@ -55,6 +57,7 @@ export interface OrderItemOverrides {
   sale_price_snapshot?: number | null;
   quantity?: number;
   item_subtotal_price?: number;
+  deleted_at?: Date;
 }
 
 export async function createOrderItem(
@@ -92,6 +95,7 @@ export async function createOrderItem(
       sale_price_snapshot: overrides.sale_price_snapshot ?? null,
       quantity: overrides.quantity ?? 1,
       item_subtotal_price: overrides.item_subtotal_price ?? 10000,
+      ...(overrides.deleted_at ? { deleted_at: overrides.deleted_at } : {}),
     },
   });
 }


### PR DESCRIPTION
## 무엇을 왜

#221의 전수 조사에서 soft-delete 가드가 빠진 지점들이 나왔습니다. 이 PR은 그중 "같은 파일에서 형제 필드는 가드하는데 이것만 안 한다"가 명백한 곳만 고칩니다. 예컨대 상품 상세 include에서 images와 option_groups는 걸러주면서 product_categories는 안 거르는 식인데, 이건 정책이 아니라 누락입니다. 반면 유저 본인 리뷰 목록에 삭제된 매장/상품이 보이는 건(to-one 무필터) 이력 표시라는 의도일 수 있어 정책 판단으로 넘겼고, mutation 결과 include는 방금 쓴 행이라 실피해가 낮아 함께 보류했습니다. 둘 다 #207에 기록해 뒀습니다.

## 고친 곳

- **상품 조회 3경로** (셀러 목록 · 상세 · 비활성 포함 상세) — `product_categories`/`product_tags`에 링크와 대상 양쪽의 가드를 추가했습니다. 삭제된 카테고리에 연결돼 있다는 이유로 상품 화면에 유령 카테고리가 뜨던 경로입니다.
- **셀러 옵션 그룹 · 커스텀 템플릿 read 3곳** — `option_items`/`text_tokens` 가드. 같은 파일의 구매자 노출용 include에는 전부 가드가 있었습니다.
- **셀러 주문 상세** — 유저측 상세는 상태 이력부터 첨부까지 5단 relation을 전부 거르는데 셀러측은 하나도 안 걸렀습니다. 동일하게 맞추고, 목록·상세의 `items.some`에도 가드를 얹어 soft-delete 아이템만 남은 주문이 목록에 뜨거나 상세가 열리는 일이 없게 했습니다.
- **리뷰 가능 집계**(findReviewableOrderIds) — 형제 메서드는 "삭제된 주문의 아이템 노출 방지" 주석과 함께 order 필터를 거는데 이쪽만 빠져 있어 맞췄습니다.

카테고리/태그에서 한 가지 판단이 있었습니다. 가드는 `deleted_at`만 걸고 `is_active`는 걸지 않았는데, 셀러 화면은 관리자가 카테고리를 비활성화해도 자기 상품의 기존 지정을 계속 볼 수 있어야 하기 때문입니다. 명세에 없는 결정이라 코드 주석에도 남겼습니다.

## 리뷰에서 하나 더

Codex가 유효한 빈틈을 짚었습니다. include만 가드하면 셀러 목록에서 "삭제된 연결로 필터에는 걸리는데 정작 그 연결은 화면에서 숨겨지는" 반쪽 상태가 된다는 것. `listProductsByStore`의 categoryId 필터와 태그 검색 predicate에도 같은 가드를 적용해 마무리했습니다.

## 검증

각 수정에 회귀 테스트를 붙여 총 7건입니다 — 카테고리·태그 링크/대상 제외와 삭제된 연결의 필터 미매칭(repository), 옵션 아이템·텍스트 토큰 제외(repository), 셀러 주문 상세의 아이템·이력 제외와 soft-delete 아이템만 남은 주문의 상세 NotFound·목록 제외(service), soft-delete 주문의 리뷰 가능 집계 제외(repository). 테스트를 위해 주문 팩토리에 `deleted_at` override를 추가했습니다. `yarn validate` 전체 green입니다(192 suites / 1,656 tests).

Refs #207
