### PR TITLE
feat(order): createOrder 멱등 키 도입 (재시도 중복 생성 방지)

### DIFF
--- a/prisma/migrations/20260829083035_add_order_idempotency_key/migration.sql
+++ b/prisma/migrations/20260829083035_add_order_idempotency_key/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE `order` ADD COLUMN `idempotency_key` VARCHAR(64) NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `uk_order_account_idempotency` ON `order`(`account_id`, `idempotency_key`);
+

--- a/prisma/migrations/20260829083035_add_order_idempotency_key/migration.sql
+++ b/prisma/migrations/20260829083035_add_order_idempotency_key/migration.sql
@@ -1,6 +1,7 @@
 -- AlterTable
-ALTER TABLE `order` ADD COLUMN `idempotency_key` VARCHAR(64) NULL;
+-- utf8mb4_bin: 대소문자만 다른 키('abc' vs 'ABC')가 같은 키로 취급되지 않게
+-- 이진 콜레이션으로 비교·unique를 건다 (릴리즈 리뷰 반영)
+ALTER TABLE `order` ADD COLUMN `idempotency_key` VARCHAR(64) COLLATE utf8mb4_bin NULL;
 
 -- CreateIndex
 CREATE UNIQUE INDEX `uk_order_account_idempotency` ON `order`(`account_id`, `idempotency_key`);
-

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -905,6 +905,10 @@ model Order {
   picked_up_at DateTime? @db.DateTime(3)
   canceled_at  DateTime? @db.DateTime(3)
 
+  // 클라이언트 재시도 중복 생성 방지 키(이슈 #212). 기존 row 호환을 위해 nullable
+  // (MySQL unique는 NULL 중복 허용) — 신규 주문은 항상 저장한다.
+  idempotency_key String? @db.VarChar(64)
+
   created_at DateTime  @default(now()) @db.DateTime(3)
   updated_at DateTime  @updatedAt @db.DateTime(3)
   deleted_at DateTime? @db.DateTime(3)
@@ -915,6 +919,7 @@ model Order {
   items            OrderItem[]
   notifications    Notification[]
 
+  @@unique([account_id, idempotency_key], map: "uk_order_account_idempotency")
   @@index([account_id], map: "idx_order_account")
   @@index([status, created_at], map: "idx_order_status")
   @@index([pickup_at], map: "idx_order_pickup_at")

--- a/src/features/order/constants/order-error-messages.ts
+++ b/src/features/order/constants/order-error-messages.ts
@@ -15,4 +15,6 @@ export const ORDER_CHECKOUT_ERRORS = {
     '주문자 연락처가 필요합니다. 프로필에 전화번호를 등록하거나 입력해 주세요.',
   ORDER_NUMBER_GENERATION_FAILED:
     '주문번호 생성에 실패했습니다. 잠시 후 다시 시도해 주세요.',
+  IDEMPOTENT_REPLAY_FAILED:
+    '이미 처리 중인 주문을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.',
 } as const;

--- a/src/features/order/dto/inputs/create-order.input.spec.ts
+++ b/src/features/order/dto/inputs/create-order.input.spec.ts
@@ -10,6 +10,7 @@ function build(plain: object): CreateOrderInput {
 }
 
 const VALID = {
+  idempotencyKey: 'a1b2c3d4-e5f6',
   productId: '1',
   optionItemIds: ['10', '11'],
   pickupAt: new Date('2026-09-18T05:00:00.000Z'),
@@ -30,6 +31,21 @@ describe('CreateOrderInput', () => {
       }),
     );
     expect(errors).toHaveLength(0);
+  });
+
+  it('idempotencyKey는 8자 미만·64자 초과·공백 포함을 거절한다', async () => {
+    for (const idempotencyKey of ['short7k', 'k'.repeat(65), 'has space-key']) {
+      const errors = await validate(build({ ...VALID, idempotencyKey }));
+      expect(errors.map((e) => e.property)).toContain('idempotencyKey');
+    }
+  });
+
+  it('idempotencyKey 경계 길이(8자·64자)는 통과한다', async () => {
+    for (const idempotencyKey of ['k'.repeat(8), 'k'.repeat(64)]) {
+      expect(await validate(build({ ...VALID, idempotencyKey }))).toHaveLength(
+        0,
+      );
+    }
   });
 
   it('optionItemIds가 배열이 아니면 거절한다', async () => {

--- a/src/features/order/dto/inputs/create-order.input.ts
+++ b/src/features/order/dto/inputs/create-order.input.ts
@@ -5,6 +5,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  Length,
   Matches,
   Max,
   MaxLength,
@@ -14,6 +15,12 @@ import {
 import { ORDER_BUYER_PHONE_REGEX } from '@/features/order/constants/order.constants';
 
 export class CreateOrderInput {
+  // 정책: 8~64자, 공백 문자 불가(이슈 #212 사용자 확정 — 형식은 길이만 제한).
+  @IsString()
+  @Length(8, 64)
+  @Matches(/^\S+$/)
+  idempotencyKey!: string;
+
   @IsString()
   @IsNotEmpty()
   productId!: string;

--- a/src/features/order/order-checkout.graphql
+++ b/src/features/order/order-checkout.graphql
@@ -5,6 +5,11 @@ extend type Mutation {
 
 """주문 생성 입력. 커스텀 필드는 커스텀 스펙 확정 후 optional로 확장 예정."""
 input CreateOrderInput {
+  """
+  클라이언트 생성 멱등 키(8~64자). 체크아웃 진입 시 새로 만들고 재시도에는
+  같은 키를 재사용한다. 같은 키의 재요청은 새 주문을 만들지 않고 기존 주문을 반환한다.
+  """
+  idempotencyKey: String!
   productId: ID!
   """선택한 옵션 아이템 ID 목록. 그룹 규칙(필수/min/max)을 서버가 검증한다."""
   optionItemIds: [ID!]!

--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -59,6 +59,7 @@ export interface DailyCapacityGuard {
 export interface CreateSubmittedOrderArgs {
   accountId: bigint;
   orderNumber: string;
+  idempotencyKey: string;
   pickupAt: Date;
   buyerName: string;
   buyerPhone: string;
@@ -206,6 +207,7 @@ export class OrderRepository {
       data: {
         account_id: args.accountId,
         order_number: args.orderNumber,
+        idempotency_key: args.idempotencyKey,
         status: OrderStatus.SUBMITTED,
         pickup_at: args.pickupAt,
         buyer_name: args.buyerName,
@@ -242,6 +244,26 @@ export class OrderRepository {
           },
         },
       },
+      select: {
+        id: true,
+        order_number: true,
+        status: true,
+        pickup_at: true,
+        total_price: true,
+      },
+    });
+  }
+
+  /**
+   * 멱등 키로 기존 주문 조회(replay 응답 재구성용, 이슈 #212).
+   * 상태가 이후 변경됐어도 현재 row를 그대로 반환한다.
+   */
+  async findOrderByIdempotencyKey(
+    accountId: bigint,
+    idempotencyKey: string,
+  ): Promise<CreatedOrderRow | null> {
+    return this.prisma.order.findFirst({
+      where: { account_id: accountId, idempotency_key: idempotencyKey },
       select: {
         id: true,
         order_number: true,

--- a/src/features/order/resolvers/order-checkout-mutation.resolver.spec.ts
+++ b/src/features/order/resolvers/order-checkout-mutation.resolver.spec.ts
@@ -88,6 +88,7 @@ describe('OrderCheckout Mutation Resolver (real DB)', () => {
     const user = { accountId: account.id.toString() } as JwtUser;
 
     const result = await resolver.createOrder(user, {
+      idempotencyKey: 'resolver-idem-key-1',
       productId: product.id.toString(),
       optionItemIds: [],
       pickupAt: new Date('2026-09-18T05:00:00.000Z'), // 9/18(금) 14:00 KST

--- a/src/features/order/services/order-checkout.service.spec.ts
+++ b/src/features/order/services/order-checkout.service.spec.ts
@@ -158,8 +158,13 @@ describe('OrderCheckoutService (real DB)', () => {
     return account;
   }
 
+  // 호출마다 새 키 — 한 케이스에서 createOrder를 여러 번 부를 때 의도치 않은
+  // 멱등 replay로 두 번째 생성이 생략되는 것을 막는다
+  let idemSeq = 0;
   function baseInput(overrides: Partial<CreateOrderInput>): CreateOrderInput {
+    idemSeq += 1;
     return {
+      idempotencyKey: `idem-key-${idemSeq}`,
       productId: '0',
       optionItemIds: [],
       pickupAt: VALID_PICKUP_AT,
@@ -655,6 +660,103 @@ describe('OrderCheckoutService (real DB)', () => {
           baseInput({ productId: product.id.toString() }),
         ),
       ).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('같은 키 재요청은 새 주문 없이 기존 주문을 반환한다', async () => {
+      const store = await makeOpenStore();
+      const product = await createProduct(prisma, { store_id: store.id });
+      const buyer = await makeBuyer();
+      const input = baseInput({
+        idempotencyKey: 'fixed-idem-key-01',
+        productId: product.id.toString(),
+      });
+
+      const first = await service.createOrder(buyer.id, input);
+      const replayed = await service.createOrder(buyer.id, input);
+
+      expect(replayed).toEqual(first);
+      expect(await prisma.order.count()).toBe(1);
+    });
+
+    it('같은 키면 입력이 달라도 기존 주문을 반환한다(입력 비교 없음)', async () => {
+      const store = await makeOpenStore();
+      const product = await createProduct(prisma, { store_id: store.id });
+      const buyer = await makeBuyer();
+
+      const first = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'fixed-idem-key-02',
+          productId: product.id.toString(),
+          quantity: 1,
+        }),
+      );
+      const replayed = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'fixed-idem-key-02',
+          productId: product.id.toString(),
+          quantity: 3,
+        }),
+      );
+
+      // 수량 3의 새 주문이 아니라 수량 1로 만든 기존 주문의 결과가 그대로 온다
+      expect(replayed.orderId).toBe(first.orderId);
+      expect(replayed.totalPrice).toBe(first.totalPrice);
+      expect(await prisma.order.count()).toBe(1);
+    });
+
+    it('다른 계정의 같은 키는 서로 간섭하지 않는다', async () => {
+      const store = await makeOpenStore();
+      const product = await createProduct(prisma, { store_id: store.id });
+      const buyerA = await makeBuyer();
+      const buyerB = await makeBuyer();
+
+      const orderA = await service.createOrder(
+        buyerA.id,
+        baseInput({
+          idempotencyKey: 'shared-idem-key',
+          productId: product.id.toString(),
+        }),
+      );
+      const orderB = await service.createOrder(
+        buyerB.id,
+        baseInput({
+          idempotencyKey: 'shared-idem-key',
+          productId: product.id.toString(),
+        }),
+      );
+
+      expect(orderB.orderId).not.toBe(orderA.orderId);
+      expect(await prisma.order.count()).toBe(2);
+    });
+
+    it('검증 실패 요청은 키를 소모하지 않아 같은 키로 재시도해 성공한다', async () => {
+      const store = await makeOpenStore();
+      const product = await createProduct(prisma, { store_id: store.id });
+      const buyer = await makeBuyer();
+
+      // 과거 픽업 일시로 실패 — 주문 row가 안 생기므로 키도 저장되지 않는다
+      await expect(
+        service.createOrder(
+          buyer.id,
+          baseInput({
+            idempotencyKey: 'retry-after-fail-key',
+            productId: product.id.toString(),
+            pickupAt: new Date('2026-09-01T05:00:00.000Z'),
+          }),
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      const retried = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'retry-after-fail-key',
+          productId: product.id.toString(),
+        }),
+      );
+      expect(retried.status).toBe('SUBMITTED');
+      expect(await prisma.order.count()).toBe(1);
     });
   });
 });

--- a/src/features/order/services/order-checkout.service.spec.ts
+++ b/src/features/order/services/order-checkout.service.spec.ts
@@ -34,6 +34,7 @@ const VALID_PICKUP_AT = new Date('2026-09-18T05:00:00.000Z');
 
 describe('OrderCheckoutService (real DB)', () => {
   let service: OrderCheckoutService;
+  let orderRepo: OrderRepository;
   let clock: ClockService;
   let random: RandomService;
   let prisma: PrismaClient;
@@ -51,6 +52,7 @@ describe('OrderCheckoutService (real DB)', () => {
       ],
     });
     service = module.get(OrderCheckoutService);
+    orderRepo = module.get(OrderRepository);
     clock = module.get(ClockService);
     random = module.get(RandomService);
     prisma = p;
@@ -729,6 +731,67 @@ describe('OrderCheckoutService (real DB)', () => {
 
       expect(orderB.orderId).not.toBe(orderA.orderId);
       expect(await prisma.order.count()).toBe(2);
+    });
+
+    it('대소문자만 다른 키는 다른 키로 취급한다(utf8mb4_bin)', async () => {
+      const store = await makeOpenStore();
+      const product = await createProduct(prisma, { store_id: store.id });
+      const buyer = await makeBuyer();
+
+      const lower = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'checkout-a',
+          productId: product.id.toString(),
+        }),
+      );
+      const upper = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'CHECKOUT-A',
+          productId: product.id.toString(),
+        }),
+      );
+
+      expect(upper.orderId).not.toBe(lower.orderId);
+      expect(await prisma.order.count()).toBe(2);
+    });
+
+    it('같은 키의 동시 재시도가 capacity를 채웠으면 픽업 불가 대신 replay로 응답한다', async () => {
+      const store = await makeOpenStore();
+      const product = await createProduct(prisma, { store_id: store.id });
+      const buyer = await makeBuyer();
+      await prisma.storeDailyCapacity.create({
+        data: {
+          store_id: store.id,
+          capacity_date: new Date(Date.UTC(2026, 8, 18)),
+          capacity: 1,
+        },
+      });
+
+      const first = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'race-idem-key',
+          productId: product.id.toString(),
+        }),
+      );
+
+      // 사전 조회를 통과한 뒤 첫 요청이 커밋되는 race 재현 — 첫 조회만 miss 처리
+      jest
+        .spyOn(orderRepo, 'findOrderByIdempotencyKey')
+        .mockResolvedValueOnce(null);
+      const raced = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'race-idem-key',
+          productId: product.id.toString(),
+        }),
+      );
+
+      // capacity가 가득 찼지만 채운 것이 내 주문 — 실패 대신 기존 주문 반환
+      expect(raced).toEqual(first);
+      expect(await prisma.order.count()).toBe(1);
     });
 
     it('검증 실패 요청은 키를 소모하지 않아 같은 키로 재시도해 성공한다', async () => {

--- a/src/features/order/services/order-checkout.service.ts
+++ b/src/features/order/services/order-checkout.service.ts
@@ -65,6 +65,16 @@ export class OrderCheckoutService {
     const optionItemIds = input.optionItemIds.map((id) => parseId(id));
     const quantity = input.quantity ?? 1;
 
+    // 멱등 replay: 같은 (계정, 키)의 주문이 있으면 검증·생성 없이 그 결과를
+    // 반환한다 — 원 요청 시점의 검증을 이미 통과한 주문이다(이슈 #212).
+    const replayed = await this.orderRepo.findOrderByIdempotencyKey(
+      accountId,
+      input.idempotencyKey,
+    );
+    if (replayed) {
+      return this.toCreateOrderOutput(replayed);
+    }
+
     const buyerProfile = await this.requireActiveBuyer(accountId);
 
     const product = await this.productRepo.findProductDetailById(productId);
@@ -122,6 +132,7 @@ export class OrderCheckoutService {
     const submittedAt = now;
     const created = await this.createWithOrderNumberRetry({
       accountId,
+      idempotencyKey: input.idempotencyKey,
       pickupAt: input.pickupAt,
       buyerName: buyer.name,
       buyerPhone: buyer.phone,
@@ -142,12 +153,22 @@ export class OrderCheckoutService {
       },
     });
 
+    return this.toCreateOrderOutput(created);
+  }
+
+  private toCreateOrderOutput(row: {
+    id: bigint;
+    order_number: string;
+    status: CreateOrderOutput['status'];
+    pickup_at: Date;
+    total_price: number;
+  }): CreateOrderOutput {
     return {
-      orderId: created.id.toString(),
-      orderNumber: created.order_number,
-      status: created.status,
-      pickupAt: created.pickup_at,
-      totalPrice: created.total_price,
+      orderId: row.id.toString(),
+      orderNumber: row.order_number,
+      status: row.status,
+      pickupAt: row.pickup_at,
+      totalPrice: row.total_price,
     };
   }
 
@@ -300,6 +321,19 @@ export class OrderCheckoutService {
         const isUniqueViolation =
           error instanceof Prisma.PrismaClientKnownRequestError &&
           error.code === 'P2002';
+        // 멱등 키 unique 충돌 = 같은 키의 동시 중복 제출. 사전 조회를 둘 다
+        // 통과한 race라, 먼저 생성된 주문을 조회해 replay로 반환한다(이슈 #212).
+        if (isUniqueViolation && this.isIdempotencyConflict(error)) {
+          const existing = await this.orderRepo.findOrderByIdempotencyKey(
+            args.accountId,
+            args.idempotencyKey,
+          );
+          if (existing) return existing;
+          // 생성 직후 소실(soft-delete 등) — 재시도 유도가 안전하다
+          throw new InternalServerErrorException(
+            ORDER_CHECKOUT_ERRORS.IDEMPOTENT_REPLAY_FAILED,
+          );
+        }
         if (!isUniqueViolation || attempt === ORDER_NUMBER_MAX_ATTEMPTS - 1) {
           if (isUniqueViolation) {
             throw new InternalServerErrorException(
@@ -314,6 +348,17 @@ export class OrderCheckoutService {
     throw new InternalServerErrorException(
       ORDER_CHECKOUT_ERRORS.ORDER_NUMBER_GENERATION_FAILED,
     );
+  }
+
+  /**
+   * P2002 충돌이 멱등 키 unique(uk_order_account_idempotency)에서 난 것인지 판별.
+   * MySQL은 meta.target에 제약 이름을 담는다 — 그 외(주문번호 등)는 재시도 대상.
+   */
+  private isIdempotencyConflict(
+    error: Prisma.PrismaClientKnownRequestError,
+  ): boolean {
+    const target = error.meta?.target;
+    return typeof target === 'string' && target.includes('idempotency');
   }
 
   /** 주문번호: ORD-YYYYMMDD-XXXXXX (KST 날짜 + 혼동 문자 제외 랜덤 6자리). */

--- a/src/features/order/services/order-checkout.service.ts
+++ b/src/features/order/services/order-checkout.service.ts
@@ -102,7 +102,14 @@ export class OrderCheckoutService {
         additionalQuantity: quantity,
       }));
     if (!pickupAvailable) {
-      throw new BadRequestException(ORDER_CHECKOUT_ERRORS.PICKUP_NOT_AVAILABLE);
+      // 같은 키의 동시 재시도가 방금 capacity를 채운 것일 수 있다 — 거절 전에
+      // 키를 재조회해, 내 주문이 이미 생성돼 있으면 실패 대신 replay로 응답한다
+      // (릴리즈 리뷰 반영: 응답 유실 재시도가 '가득 참' 실패를 받는 race 차단).
+      const raced = await this.replayAfterCapacityReject(
+        accountId,
+        input.idempotencyKey,
+      );
+      return this.toCreateOrderOutput(raced);
     }
 
     // 가격 스냅샷: FE 제출 금액은 신뢰하지 않고 서버가 재계산한다.
@@ -311,9 +318,11 @@ export class OrderCheckoutService {
           orderNumber: this.generateOrderNumber(args.submittedAt),
         });
         if (created === null) {
-          // 트랜잭션 내 capacity 재검사에서 잔여 부족 판정(동시 주문 race 차단)
-          throw new BadRequestException(
-            ORDER_CHECKOUT_ERRORS.PICKUP_NOT_AVAILABLE,
+          // 트랜잭션 내 capacity 재검사에서 잔여 부족 판정(동시 주문 race 차단).
+          // 잔여를 채운 것이 같은 키의 내 주문일 수 있어 거절 전에 replay를 확인한다.
+          return this.replayAfterCapacityReject(
+            args.accountId,
+            args.idempotencyKey,
           );
         }
         return created;
@@ -348,6 +357,22 @@ export class OrderCheckoutService {
     throw new InternalServerErrorException(
       ORDER_CHECKOUT_ERRORS.ORDER_NUMBER_GENERATION_FAILED,
     );
+  }
+
+  /**
+   * capacity 계열 거절 직전의 멱등 replay 확인. 같은 키의 주문이 있으면
+   * 그 주문을 반환하고, 없으면(진짜 잔여 부족) 픽업 불가로 거절한다.
+   */
+  private async replayAfterCapacityReject(
+    accountId: bigint,
+    idempotencyKey: string,
+  ) {
+    const existing = await this.orderRepo.findOrderByIdempotencyKey(
+      accountId,
+      idempotencyKey,
+    );
+    if (existing) return existing;
+    throw new BadRequestException(ORDER_CHECKOUT_ERRORS.PICKUP_NOT_AVAILABLE);
   }
 
   /**


### PR DESCRIPTION
## 무엇을 왜

주문 생성 요청의 응답이 유실되면(네트워크 끊김 등) 클라이언트 재시도가 같은 주문을 한 번 더 만듭니다. SUBMITTED 주문이 중복 생성되고 매장 capacity도 중복 점유되는 문제로, createOrder 릴리즈 리뷰(#209)에서 Codex가 P1으로 지적해 #212로 이관해 뒀던 항목입니다. 결제가 붙기 전에 처리하는 게 안전해 지금 도입합니다. #212의 나머지 항목(커스텀 입력 확장·가드 해제·통화 스냅샷)은 기획 확정 대기라 이번 범위가 아닙니다.

## 동작 방식

클라이언트가 체크아웃 진입 시 키를 하나 만들어 `idempotencyKey`로 보내고, 재시도에는 같은 키를 재사용합니다. 서버는 같은 (계정, 키)의 주문이 이미 있으면 새로 만들지 않고 그 주문의 결과를 그대로 돌려줍니다(replay). 검증·가격 계산보다 먼저 조회하는데, replay 대상은 원 요청 시점의 검증을 이미 통과한 주문이기 때문입니다.

사전 조회를 동시에 통과하는 race는 DB unique 제약이 막습니다. 이때 P2002를 기존 주문번호 충돌 재시도와 구분해야 해서, `meta.target`의 제약 이름으로 분기합니다 — 주문번호 충돌이면 지금처럼 번호를 다시 만들어 재시도하고, 멱등 키 충돌이면 먼저 생성된 주문을 조회해 replay로 응답합니다. 트랜잭션이 실패하면(검증 거절, capacity 초과) 키도 저장되지 않으므로 진짜 실패 후의 재시도는 정상적으로 새 주문을 만듭니다.

## 정책 결정 (사용자 확정)

- **키는 필수** — 멱등성이 옵션이면 보장이 아니라서 운영 전인 지금 스펙을 굳혔습니다. **FE 브레이킹: createOrder 호출 시 `idempotencyKey` 전송이 필수가 됩니다** (체크아웃 진입 시 UUID 하나 생성해 재시도에 재사용하면 됩니다).
- **replay는 입력 비교 없음** — 같은 키면 입력이 달라도 기존 주문을 반환합니다. 키를 체크아웃 세션당 새로 만드는 전제라 요청 해시 비교(Stripe식)는 과설계로 판단했습니다.
- **키 형식은 길이만 제한** — 8~64자, 공백 불가.

## 스키마

`Order.idempotency_key VARCHAR(64) NULL` + `uk_order_account_idempotency(account_id, idempotency_key)` unique. nullable인 이유는 기존 row 호환입니다(MySQL unique는 NULL 중복을 허용하므로 과거 주문은 그대로 두고 신규만 키를 갖습니다). 마이그레이션 1건, backfill 불필요.

## 검증

테스트 6건을 추가했습니다 — 같은 키 재요청은 row 1건 유지하며 기존 주문 반환, 같은 키 + 다른 입력도 기존 반환, 다른 계정의 같은 키는 비간섭, 검증 실패 후 같은 키 재시도는 정상 생성(service, real DB), 키 길이 경계·공백 검증(input). 기존 createOrder spec 19건은 필수 필드 추가만 반영해 전부 통과합니다 — 이 과정에서 테스트 픽스처가 실수로 같은 키를 재사용하자 두 번째 생성이 replay로 바뀌며 기존 케이스가 깨졌는데, 의도치 않게 replay 동작의 실증이 됐습니다. `yarn validate` 전체 green입니다(192 suites / 1,666 tests).

Refs #212
