### PR TITLE
refactor(user): 활성 USER 판정·전화번호 정책 공용화 — user 배럴 신설

### DIFF
--- a/src/features/order/constants/order.constants.ts
+++ b/src/features/order/constants/order.constants.ts
@@ -1,6 +1,0 @@
-/**
- * 주문자 전화번호 형식. 프로필 전화번호 정책(user feature `PHONE_REGEX`,
- * 010-XXXX-XXXX 고정 13자)과 동일해야 한다 — user는 배럴 없는 feature라
- * cross-feature import 대신 정책을 복제하고 출처를 명시한다.
- */
-export const ORDER_BUYER_PHONE_REGEX = /^010-\d{4}-\d{4}$/;

--- a/src/features/order/dto/inputs/create-order.input.ts
+++ b/src/features/order/dto/inputs/create-order.input.ts
@@ -12,7 +12,7 @@ import {
   Min,
 } from 'class-validator';
 
-import { ORDER_BUYER_PHONE_REGEX } from '@/features/order/constants/order.constants';
+import { PHONE_REGEX } from '@/features/user';
 
 export class CreateOrderInput {
   // 정책: 8~64자, 공백 문자 불가(이슈 #212 사용자 확정 — 형식은 길이만 제한).
@@ -48,6 +48,6 @@ export class CreateOrderInput {
   @IsString()
   // 프로필 전화번호와 동일 정책(010-XXXX-XXXX 고정) — 임의 문자열이
   // 검증된 프로필 값을 덮어쓰지 못하게 형식을 강제한다
-  @Matches(ORDER_BUYER_PHONE_REGEX)
+  @Matches(PHONE_REGEX)
   buyerPhone?: string;
 }

--- a/src/features/order/services/order-checkout.service.ts
+++ b/src/features/order/services/order-checkout.service.ts
@@ -6,7 +6,7 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { AccountType, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
 import { RandomService } from '@/common/providers/random.service';
@@ -23,6 +23,7 @@ import { OrderRepository } from '@/features/order/repositories/order.repository'
 import type { CreateOrderOutput } from '@/features/order/types/create-order-output.type';
 import { ProductRepository, type ProductDetailRow } from '@/features/product';
 import { StorePickupScheduleService } from '@/features/store';
+import { evaluateActiveUserAccount } from '@/features/user';
 
 // 0/O·1/I 등 혼동 문자를 뺀 대문자 영숫자. 주문번호 무작위부에 사용.
 const ORDER_NUMBER_ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
@@ -263,8 +264,9 @@ export class OrderCheckoutService {
   }
 
   /**
-   * 활성 USER 계정 + 활성 프로필 강제(user feature requireActiveUser와
-   * 동일 의미론 — user는 배럴 없는 feature라 checkout 경로에 재구현).
+   * 활성 USER 계정 + 활성 프로필 강제. 판정 분기는 user feature의 공용 정책
+   * (evaluateActiveUserAccount) 단일 소스를 소비하고, 실패 사유 → 주문 도메인
+   * 에러 메시지 매핑만 여기서 한다.
    * SELLER/ADMIN이 구매자 mutation으로 주문을 만드는 것을 차단한다.
    */
   private async requireActiveBuyer(
@@ -272,15 +274,11 @@ export class OrderCheckoutService {
   ): Promise<{ nickname: string; phone_number: string | null }> {
     const account =
       await this.orderRepo.findAccountWithProfileForCheckout(accountId);
-    if (!account) {
-      throw new UnauthorizedException(
-        ORDER_CHECKOUT_ERRORS.BUYER_ACCOUNT_NOT_ACTIVE,
-      );
-    }
-    if (account.account_type !== AccountType.USER) {
+    const failure = evaluateActiveUserAccount(account);
+    if (failure === 'NOT_USER') {
       throw new ForbiddenException(ORDER_CHECKOUT_ERRORS.BUYER_NOT_USER);
     }
-    if (!account.user_profile || account.user_profile.deleted_at) {
+    if (failure !== null || !account?.user_profile) {
       throw new UnauthorizedException(
         ORDER_CHECKOUT_ERRORS.BUYER_ACCOUNT_NOT_ACTIVE,
       );

--- a/src/features/user/index.ts
+++ b/src/features/user/index.ts
@@ -1,0 +1,4 @@
+// cross-feature 공개 API. 전화번호 정책과 활성 USER 판정을 주문 생성(order feature)이
+// 공유한다 — 정책 복제 대신 단일 소스를 소비한다(이슈 #226).
+export { PHONE_REGEX } from '@/features/user/constants/user.constants';
+export { evaluateActiveUserAccount } from '@/features/user/services/user-account-policy.helper';

--- a/src/features/user/services/user-account-policy.helper.spec.ts
+++ b/src/features/user/services/user-account-policy.helper.spec.ts
@@ -1,0 +1,72 @@
+import { evaluateActiveUserAccount } from '@/features/user/services/user-account-policy.helper';
+
+describe('evaluateActiveUserAccount', () => {
+  const activeProfile = { deleted_at: null };
+
+  it('활성 USER 계정 + 활성 프로필은 통과한다', () => {
+    expect(
+      evaluateActiveUserAccount({
+        deleted_at: null,
+        account_type: 'USER',
+        user_profile: activeProfile,
+      }),
+    ).toBeNull();
+  });
+
+  it('계정 미존재는 ACCOUNT_NOT_FOUND', () => {
+    expect(evaluateActiveUserAccount(null)).toBe('ACCOUNT_NOT_FOUND');
+  });
+
+  it('soft-delete된 계정은 ACCOUNT_DELETED', () => {
+    expect(
+      evaluateActiveUserAccount({
+        deleted_at: new Date(),
+        account_type: 'USER',
+        user_profile: activeProfile,
+      }),
+    ).toBe('ACCOUNT_DELETED');
+  });
+
+  it('deleted_at 미선택 쿼리(soft-delete extension이 걸러준 경우)는 삭제 검사를 통과한다', () => {
+    expect(
+      evaluateActiveUserAccount({
+        account_type: 'USER',
+        user_profile: activeProfile,
+      }),
+    ).toBeNull();
+  });
+
+  it('SELLER/ADMIN 계정은 NOT_USER', () => {
+    expect(
+      evaluateActiveUserAccount({
+        deleted_at: null,
+        account_type: 'SELLER',
+        user_profile: activeProfile,
+      }),
+    ).toBe('NOT_USER');
+    expect(
+      evaluateActiveUserAccount({
+        deleted_at: null,
+        account_type: 'ADMIN',
+        user_profile: activeProfile,
+      }),
+    ).toBe('NOT_USER');
+  });
+
+  it('프로필 미존재·soft-delete는 PROFILE_INACTIVE', () => {
+    expect(
+      evaluateActiveUserAccount({
+        deleted_at: null,
+        account_type: 'USER',
+        user_profile: null,
+      }),
+    ).toBe('PROFILE_INACTIVE');
+    expect(
+      evaluateActiveUserAccount({
+        deleted_at: null,
+        account_type: 'USER',
+        user_profile: { deleted_at: new Date() },
+      }),
+    ).toBe('PROFILE_INACTIVE');
+  });
+});

--- a/src/features/user/services/user-account-policy.helper.ts
+++ b/src/features/user/services/user-account-policy.helper.ts
@@ -1,0 +1,39 @@
+import { AccountType } from '@prisma/client';
+
+/**
+ * 활성 USER 계정 판정 정책(단일 소스, 이슈 #226).
+ * user 마이페이지 계열(requireActiveUser)과 주문 생성(requireActiveBuyer)이
+ * 동일 의미론을 공유한다 — 판정 분기는 여기서만 두고, 실패 사유 → 에러 메시지
+ * 매핑은 호출부가 각자 유지한다(도메인별 메시지 정책 보존).
+ * DI-free 순수 함수만 둔다.
+ */
+
+/** 판정에 필요한 계정 row 부분집합. */
+export interface ActiveUserAccountCandidate {
+  /**
+   * soft-delete extension이 루트 READ에서 걸러주는 쿼리는 이 필드를
+   * select하지 않아도 된다(생략 시 삭제 검사 통과로 간주).
+   */
+  deleted_at?: Date | null;
+  account_type: AccountType;
+  user_profile: { deleted_at: Date | null } | null;
+}
+
+export type ActiveUserAccountFailure =
+  'ACCOUNT_NOT_FOUND' | 'ACCOUNT_DELETED' | 'NOT_USER' | 'PROFILE_INACTIVE';
+
+/**
+ * 판정 순서: 미존재 → 계정 삭제 → USER 아님 → 프로필 미존재/삭제.
+ * 통과하면 null.
+ */
+export function evaluateActiveUserAccount(
+  account: ActiveUserAccountCandidate | null,
+): ActiveUserAccountFailure | null {
+  if (!account) return 'ACCOUNT_NOT_FOUND';
+  if (account.deleted_at) return 'ACCOUNT_DELETED';
+  if (account.account_type !== AccountType.USER) return 'NOT_USER';
+  if (!account.user_profile || account.user_profile.deleted_at) {
+    return 'PROFILE_INACTIVE';
+  }
+  return null;
+}

--- a/src/features/user/services/user-base.service.ts
+++ b/src/features/user/services/user-base.service.ts
@@ -3,7 +3,6 @@ import {
   ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
-import { AccountType } from '@prisma/client';
 
 import {
   DEFAULT_PAGINATION_LIMIT,
@@ -16,6 +15,7 @@ import {
 } from '@/features/user/constants/user.constants';
 import type { UserAccountWithProfile } from '@/features/user/repositories/user.repository';
 import { UserRepository } from '@/features/user/repositories/user.repository';
+import { evaluateActiveUserAccount } from '@/features/user/services/user-account-policy.helper';
 import type { MePayload } from '@/features/user/types/user-output.type';
 
 export type ActiveUserAccount = UserAccountWithProfile & {
@@ -34,17 +34,19 @@ export abstract class UserBaseService {
     const account = await this.repo.findAccountWithProfile(accountId, {
       withDeleted: true,
     });
-    if (!account) throw new UnauthorizedException('Account not found.');
-    if (account.deleted_at) {
-      throw new UnauthorizedException('Account is deleted.');
+    // 판정 분기는 공용 정책(user-account-policy.helper) 단일 소스 — 메시지 매핑만 여기서
+    switch (evaluateActiveUserAccount(account)) {
+      case 'ACCOUNT_NOT_FOUND':
+        throw new UnauthorizedException('Account not found.');
+      case 'ACCOUNT_DELETED':
+        throw new UnauthorizedException('Account is deleted.');
+      case 'NOT_USER':
+        throw new ForbiddenException('Only USER account is allowed.');
+      case 'PROFILE_INACTIVE':
+        throw new UnauthorizedException('User profile not found.');
+      case null:
+        return account as ActiveUserAccount;
     }
-    if (account.account_type !== AccountType.USER) {
-      throw new ForbiddenException('Only USER account is allowed.');
-    }
-    if (!account.user_profile || account.user_profile.deleted_at) {
-      throw new UnauthorizedException('User profile not found.');
-    }
-    return account as ActiveUserAccount;
   }
 
   protected toMePayload(account: ActiveUserAccount): MePayload {


### PR DESCRIPTION
#226의 첫 번째 항목입니다. user feature에 배럴이 없어서 order feature가 정책을 복제해 쓰던 2건을, 배럴을 신설해 단일 소스 소비로 바꿨습니다.

## 배경

order-checkout에는 두 개의 복제가 있었습니다.

- `requireActiveBuyer` — 주석에 "user feature requireActiveUser와 동일 의미론… user는 배럴 없는 feature라 checkout 경로에 재구현"이라고 명시된 재구현
- `ORDER_BUYER_PHONE_REGEX` — user의 `PHONE_REGEX`(010-XXXX-XXXX 고정)를 복제하고 출처만 주석으로 남긴 상수

배럴 부재가 복제의 직접 원인이었으므로 `src/features/user/index.ts`를 신설했습니다. user feature는 타 feature import가 0이라 순환 의존 위험이 없음을 확인했습니다(boundaries·arch:check 통과).

## 통합 방식

두 재구현은 분기 의미론은 같지만 에러 메시지가 다릅니다(user는 영어 일반 메시지, order는 한국어 `ORDER_CHECKOUT_ERRORS`). 동작 변경 0을 지키기 위해 **판정 분기만 순수 함수로 공유**하고, 실패 사유 → 에러 메시지 매핑은 호출부가 각자 유지하는 구조를 택했습니다.

- `user-account-policy.helper.ts`(DI-free): `evaluateActiveUserAccount(account)` → `'ACCOUNT_NOT_FOUND' | 'ACCOUNT_DELETED' | 'NOT_USER' | 'PROFILE_INACTIVE' | null`
- order 쪽 조회는 soft-delete extension이 삭제 계정을 루트 READ에서 걸러 `deleted_at`을 select하지 않으므로, 해당 필드는 optional로 두고 생략 시 삭제 검사를 통과시킵니다
- `ORDER_BUYER_PHONE_REGEX`는 삭제하고 `PHONE_REGEX`를 배럴에서 import — 단일 상수만 남은 `order.constants.ts`는 파일째 제거했습니다

## 검증

- 정책 함수 단위 spec 6케이스 추가 (DB 불필요)
- 기존 spec 무변경 green — `yarn validate` 191 suites / 1665 tests

Refs #226