### PR TITLE
refactor: 페이지네이션 조립 공용화 — 커서 절단·offset 잔여 계산 유틸

### DIFF
--- a/src/common/utils/pagination.spec.ts
+++ b/src/common/utils/pagination.spec.ts
@@ -1,0 +1,62 @@
+import {
+  hasMoreByOffset,
+  sliceCursorPage,
+  sliceOverfetched,
+} from '@/common/utils/pagination';
+
+describe('pagination utils', () => {
+  describe('sliceOverfetched', () => {
+    it('limit 초과분이 있으면 잘라내고 hasMore=true', () => {
+      expect(sliceOverfetched([1, 2, 3], 2)).toEqual({
+        items: [1, 2],
+        hasMore: true,
+      });
+    });
+
+    it('limit 이하면 그대로 반환하고 hasMore=false', () => {
+      expect(sliceOverfetched([1, 2], 2)).toEqual({
+        items: [1, 2],
+        hasMore: false,
+      });
+      expect(sliceOverfetched([], 2)).toEqual({ items: [], hasMore: false });
+    });
+  });
+
+  describe('sliceCursorPage', () => {
+    const toCursor = (last: { id: bigint }) => last.id.toString();
+
+    it('잔여가 있으면 페이지 마지막 행으로 다음 커서를 만든다', () => {
+      const rows = [{ id: 1n }, { id: 2n }, { id: 3n }];
+      expect(sliceCursorPage(rows, 2, toCursor)).toEqual({
+        items: [{ id: 1n }, { id: 2n }],
+        hasMore: true,
+        nextCursor: '2',
+      });
+    });
+
+    it('마지막 페이지면 nextCursor=null', () => {
+      const rows = [{ id: 1n }];
+      expect(sliceCursorPage(rows, 2, toCursor)).toEqual({
+        items: [{ id: 1n }],
+        hasMore: false,
+        nextCursor: null,
+      });
+    });
+
+    it('limit이 0 이하라 페이지가 비면 커서를 만들지 않는다(방어)', () => {
+      expect(sliceCursorPage([{ id: 1n }], 0, toCursor)).toEqual({
+        items: [],
+        hasMore: true,
+        nextCursor: null,
+      });
+    });
+  });
+
+  describe('hasMoreByOffset', () => {
+    it('offset+limit이 totalCount 미만일 때만 true', () => {
+      expect(hasMoreByOffset(0, 20, 21)).toBe(true);
+      expect(hasMoreByOffset(0, 20, 20)).toBe(false);
+      expect(hasMoreByOffset(20, 20, 21)).toBe(false);
+    });
+  });
+});

--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -1,0 +1,47 @@
+/**
+ * 페이지네이션 조립 공용 유틸(이슈 #226).
+ * - 커서형: `take: limit + 1` 초과 조회 → 페이지 절단 → 다음 커서 계산
+ * - offset형: 잔여 여부 계산
+ * 커서 토큰의 형식/파싱은 정렬 정책과 결합돼 있어 호출부 책임으로 남긴다.
+ */
+
+/** 키셋 커서 페이지네이션 결과 조각. */
+export interface CursorPage<T> {
+  items: T[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+/** `take: limit + 1` 초과 조회 결과를 페이지와 잔여 여부로 자른다. */
+export function sliceOverfetched<T>(
+  rows: T[],
+  limit: number,
+): { items: T[]; hasMore: boolean } {
+  const hasMore = rows.length > limit;
+  return { items: hasMore ? rows.slice(0, limit) : rows, hasMore };
+}
+
+/** 초과 조회 결과 → 커서 페이지. 다음 커서는 페이지 마지막 행에서 계산한다. */
+export function sliceCursorPage<T>(
+  rows: T[],
+  limit: number,
+  toCursor: (last: T) => string,
+): CursorPage<T> {
+  const { items, hasMore } = sliceOverfetched(rows, limit);
+  const last = items[items.length - 1];
+  return {
+    items,
+    hasMore,
+    // limit<=0 방어: 잔여가 있어도 페이지가 비면 커서를 만들 수 없다
+    nextCursor: hasMore && last !== undefined ? toCursor(last) : null,
+  };
+}
+
+/** offset 페이지네이션의 잔여 여부. */
+export function hasMoreByOffset(
+  offset: number,
+  limit: number,
+  totalCount: number,
+): boolean {
+  return offset + limit < totalCount;
+}

--- a/src/features/product/services/product-review.service.ts
+++ b/src/features/product/services/product-review.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
+import { sliceCursorPage } from '@/common/utils/pagination';
 import { PRODUCT_REVIEW_ERRORS } from '@/features/product/constants/product-review-error-messages';
 import {
   DEFAULT_PRODUCT_REVIEWS_LIMIT,
@@ -115,14 +116,13 @@ export class ProductReviewService {
       this.repo.countReviewComments(reviewId),
     ]);
 
-    const hasMore = rows.length > limit;
-    const page = hasMore ? rows.slice(0, limit) : rows;
+    const page = sliceCursorPage(rows, limit, (last) => last.id.toString());
 
     return {
-      items: page.map((row) => toReviewCommentItem(row, accountId)),
+      items: page.items.map((row) => toReviewCommentItem(row, accountId)),
       totalCount,
-      hasMore,
-      nextCursor: hasMore ? page[page.length - 1].id.toString() : null,
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
     };
   }
 
@@ -153,13 +153,15 @@ export class ProductReviewService {
           ? this.parseLikesCursor(args.cursorRaw)
           : undefined,
       });
-      const hasMore = rows.length > args.limit;
-      const page = hasMore ? rows.slice(0, args.limit) : rows;
-      const last = page[page.length - 1];
+      const page = sliceCursorPage(
+        rows,
+        args.limit,
+        (last) => `${last.likeCount}:${last.id.toString()}`,
+      );
       return {
-        pageIds: page.map((row) => row.id),
-        hasMore,
-        nextCursor: hasMore ? `${last.likeCount}:${last.id.toString()}` : null,
+        pageIds: page.items.map((row) => row.id),
+        hasMore: page.hasMore,
+        nextCursor: page.nextCursor,
       };
     }
 
@@ -169,12 +171,11 @@ export class ProductReviewService {
       limit: args.limit,
       cursor: args.cursorRaw ? parseId(args.cursorRaw) : undefined,
     });
-    const hasMore = ids.length > args.limit;
-    const pageIds = hasMore ? ids.slice(0, args.limit) : ids;
+    const page = sliceCursorPage(ids, args.limit, (last) => last.toString());
     return {
-      pageIds,
-      hasMore,
-      nextCursor: hasMore ? pageIds[pageIds.length - 1].toString() : null,
+      pageIds: page.items,
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
     };
   }
 

--- a/src/features/product/services/product-storefront.service.ts
+++ b/src/features/product/services/product-storefront.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
+import { sliceCursorPage } from '@/common/utils/pagination';
 import { DEFAULT_STORE_PRODUCTS_LIMIT } from '@/features/product/constants/product-storefront.constants';
 import type { StoreProductsInput } from '@/features/product/dto/inputs/store-products.input';
 import { ProductRepository } from '@/features/product/repositories/product.repository';
@@ -31,13 +32,12 @@ export class ProductStorefrontService {
       search: search ? search : undefined,
     });
 
-    const hasMore = rows.length > limit;
-    const page = hasMore ? rows.slice(0, limit) : rows;
+    const page = sliceCursorPage(rows, limit, (last) => last.id.toString());
 
     return {
-      items: page.map(toStoreProduct),
-      hasMore,
-      nextCursor: hasMore ? page[page.length - 1].id.toString() : null,
+      items: page.items.map(toStoreProduct),
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
     };
   }
 

--- a/src/features/store/services/store-listing.service.ts
+++ b/src/features/store/services/store-listing.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
 import { DAY_MS } from '@/common/utils/kst-time';
+import { hasMoreByOffset } from '@/common/utils/pagination';
 import {
   DEFAULT_GLOBAL_RATING_PRIOR,
   DEFAULT_POPULAR_STORES_LIMIT,
@@ -127,7 +128,7 @@ export class StoreListingService {
     return {
       items,
       totalCount,
-      hasMore: offset + limit < totalCount,
+      hasMore: hasMoreByOffset(offset, limit, totalCount),
       rankedAt,
     };
   }

--- a/src/features/store/services/store-review.service.ts
+++ b/src/features/store/services/store-review.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
+import { sliceCursorPage } from '@/common/utils/pagination';
 import { STORE_REVIEW_ERRORS } from '@/features/store/constants/store-review-error-messages';
 import { DEFAULT_STORE_REVIEWS_LIMIT } from '@/features/store/constants/store-review.constants';
 import type { StoreReviewsInput } from '@/features/store/dto/inputs/store-reviews.input';
@@ -79,13 +80,15 @@ export class StoreReviewService {
           ? this.parseLikesCursor(args.cursorRaw)
           : undefined,
       });
-      const hasMore = rows.length > args.limit;
-      const page = hasMore ? rows.slice(0, args.limit) : rows;
-      const last = page[page.length - 1];
+      const page = sliceCursorPage(
+        rows,
+        args.limit,
+        (last) => `${last.likeCount}:${last.id.toString()}`,
+      );
       return {
-        pageIds: page.map((row) => row.id),
-        hasMore,
-        nextCursor: hasMore ? `${last.likeCount}:${last.id.toString()}` : null,
+        pageIds: page.items.map((row) => row.id),
+        hasMore: page.hasMore,
+        nextCursor: page.nextCursor,
       };
     }
 
@@ -95,12 +98,11 @@ export class StoreReviewService {
       limit: args.limit,
       cursor: args.cursorRaw ? parseId(args.cursorRaw) : undefined,
     });
-    const hasMore = ids.length > args.limit;
-    const pageIds = hasMore ? ids.slice(0, args.limit) : ids;
+    const page = sliceCursorPage(ids, args.limit, (last) => last.toString());
     return {
-      pageIds,
-      hasMore,
-      nextCursor: hasMore ? pageIds[pageIds.length - 1].toString() : null,
+      pageIds: page.items,
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
     };
   }
 

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { ClockService } from '@/common/providers/clock.service';
 import { parseId } from '@/common/utils/id-parser';
 import { DAY_MS, kstMidnightUtc, toKstYmd } from '@/common/utils/kst-time';
+import { hasMoreByOffset } from '@/common/utils/pagination';
 import { roundRatingAverage } from '@/common/utils/rating';
 import { DEFAULT_POPULAR_STORES_LIMIT } from '@/features/store/constants/store-ranking.constants';
 import type { TodayPickupStoresInput } from '@/features/store/dto/inputs/today-pickup-stores.input';
@@ -107,7 +108,7 @@ export class StoreTodayPickupService {
     return {
       items,
       totalCount,
-      hasMore: offset + limit < totalCount,
+      hasMore: hasMoreByOffset(offset, limit, totalCount),
       asOf,
     };
   }

--- a/src/features/store/services/store-wishlist.service.ts
+++ b/src/features/store/services/store-wishlist.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
+import { hasMoreByOffset } from '@/common/utils/pagination';
 import { roundRatingAverage } from '@/common/utils/rating';
 import { STORE_WISHLIST_ERRORS } from '@/features/store/constants/store-wishlist-error-messages';
 import {
@@ -90,7 +91,7 @@ export class StoreWishlistService {
         };
       }),
       totalCount,
-      hasMore: offset + limit < totalCount,
+      hasMore: hasMoreByOffset(offset, limit, totalCount),
     };
   }
 

--- a/src/features/user/services/user-notification.service.ts
+++ b/src/features/user/services/user-notification.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
+import { hasMoreByOffset } from '@/common/utils/pagination';
 import type { MyNotificationsInput } from '@/features/user/dto/inputs/my-notifications.input';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserBaseService } from '@/features/user/services/user-base.service';
@@ -43,7 +44,7 @@ export class UserNotificationService extends UserBaseService {
         createdAt: item.created_at,
       })),
       totalCount: result.totalCount,
-      hasMore: offset + limit < result.totalCount,
+      hasMore: hasMoreByOffset(offset, limit, result.totalCount),
     };
   }
 

--- a/src/features/user/services/user-order.service.ts
+++ b/src/features/user/services/user-order.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { OrderStatus } from '@prisma/client';
 
 import { formatBusinessHours } from '@/common/utils/business-hours-formatter';
+import { sliceOverfetched } from '@/common/utils/pagination';
 import { OrderRepository } from '@/features/order';
 import { USER_ORDER_ERRORS } from '@/features/user/constants/user-order-error-messages';
 import type { MyOrdersInput } from '@/features/user/dto/inputs/my-orders.input';
@@ -35,8 +36,7 @@ export class UserOrderService {
       }),
     ]);
 
-    const hasMore = orders.length > limit;
-    const sliced = hasMore ? orders.slice(0, limit) : orders;
+    const { items: sliced, hasMore } = sliceOverfetched(orders, limit);
 
     // N+1 회피: PICKED_UP + 미작성 리뷰가 있는 order id 집합을 단일 IN 쿼리로 조회
     const reviewableOrderIds =

--- a/src/features/user/services/user-recent-view.service.ts
+++ b/src/features/user/services/user-recent-view.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
+import { hasMoreByOffset } from '@/common/utils/pagination';
 import { ProductRepository } from '@/features/product';
 import type { MyRecentViewedProductsInput } from '@/features/user/dto/inputs/my-recent-viewed-products.input';
 import { RecentProductViewRepository } from '@/features/user/repositories/recent-product-view.repository';
@@ -54,7 +55,7 @@ export class UserRecentViewService {
         isWishlisted: wishlistedProductIds.has(view.product_id.toString()),
       })),
       totalCount,
-      hasMore: offset + limit < totalCount,
+      hasMore: hasMoreByOffset(offset, limit, totalCount),
     };
   }
 

--- a/src/features/user/services/user-review.service.ts
+++ b/src/features/user/services/user-review.service.ts
@@ -7,6 +7,7 @@ import {
 import { OrderStatus, ReviewMediaType } from '@prisma/client';
 
 import { parseId } from '@/common/utils/id-parser';
+import { hasMoreByOffset } from '@/common/utils/pagination';
 import { OrderRepository } from '@/features/order';
 import { buildRegionLabel } from '@/features/store';
 import { USER_REVIEW_ERRORS } from '@/features/user/constants/user-review-error-messages';
@@ -82,7 +83,7 @@ export class UserReviewService {
         pickedUpAt: item.order?.picked_up_at ?? null,
       })),
       totalCount,
-      hasMore: offset + limit < totalCount,
+      hasMore: hasMoreByOffset(offset, limit, totalCount),
     };
   }
 
@@ -155,7 +156,7 @@ export class UserReviewService {
     return {
       items: items.map((r) => this.mapReview(r)),
       totalCount,
-      hasMore: offset + limit < totalCount,
+      hasMore: hasMoreByOffset(offset, limit, totalCount),
     };
   }
 

--- a/src/features/user/services/user-search.service.ts
+++ b/src/features/user/services/user-search.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
+import { hasMoreByOffset } from '@/common/utils/pagination';
 import type { MySearchHistoriesInput } from '@/features/user/dto/inputs/my-search-histories.input';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserBaseService } from '@/features/user/services/user-base.service';
@@ -31,7 +32,7 @@ export class UserSearchService extends UserBaseService {
         lastUsedAt: item.last_used_at,
       })),
       totalCount: result.totalCount,
-      hasMore: offset + limit < result.totalCount,
+      hasMore: hasMoreByOffset(offset, limit, result.totalCount),
     };
   }
 

--- a/src/features/user/services/user-wishlist.service.ts
+++ b/src/features/user/services/user-wishlist.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { parseId } from '@/common/utils/id-parser';
+import { hasMoreByOffset } from '@/common/utils/pagination';
 import { roundRatingAverage } from '@/common/utils/rating';
 import { calcDiscountRate, ProductRepository } from '@/features/product';
 import { buildRegionLabel } from '@/features/store';
@@ -105,7 +106,7 @@ export class UserWishlistService extends UserBaseService {
         };
       }),
       totalCount,
-      hasMore: offset + limit < totalCount,
+      hasMore: hasMoreByOffset(offset, limit, totalCount),
     };
   }
 
@@ -170,7 +171,7 @@ export class UserWishlistService extends UserBaseService {
         wishlistedProductCount: group.count,
       })),
       totalCount,
-      hasMore: offset + limit < totalCount,
+      hasMore: hasMoreByOffset(offset, limit, totalCount),
     };
   }
 }


### PR DESCRIPTION
#226의 두 번째 항목입니다. 같은 페이지네이션 조립 코드가 손 복붙으로 퍼져 있던 것을 공용 유틸로 모았습니다.

## 무엇이 복붙돼 있었나

- **커서형**: `take: limit + 1`로 한 건 더 조회한 뒤 `hasMore = rows.length > limit` → `slice(0, limit)` → 마지막 행으로 `nextCursor` 계산하는 3줄 패턴이 7곳 — product-storefront, product-review(댓글·좋아요순·최신순), store-review(좋아요순·최신순), user-order
- **offset형**: `hasMore: offset + limit < totalCount` 계산이 10곳 — user 목록 6곳 + store 목록 4곳

## 변경

`common/utils/pagination.ts`를 신설했습니다(DI-free 순수 함수).

- `sliceOverfetched(rows, limit)` — 초과 조회 절단의 코어
- `sliceCursorPage(rows, limit, toCursor)` — 절단 + 다음 커서 계산. 커서 토큰을 만드는 `toCursor`만 호출부가 넘깁니다(최신순은 `last.id`, 좋아요순은 `"<likeCount>:<id>"` 식으로 정렬 정책마다 다르므로)
- `hasMoreByOffset(offset, limit, totalCount)`

커서 토큰의 **형식과 파싱**은 정렬 정책과 결합돼 있어 의도적으로 호출부에 남겼습니다. seller의 `normalizeCursorInput`/`nextCursorOf`도 고유 시그니처(기본값 정책 포함)가 있어 이번 범위에서는 유지했습니다 — 억지로 맞추면 diff만 커진다고 판단했습니다.

## 검증

- 동작 변경 0 — 기존 spec 무변경 green
- 신설 유틸 단위 spec 추가(limit 0 방어 케이스 포함)
- `yarn validate` 191 suites / 1665 tests

Refs #226