### PR TITLE
refactor: 리뷰 작성자 익명화 정책 공용화

### DIFF
--- a/src/common/utils/review-author.spec.ts
+++ b/src/common/utils/review-author.spec.ts
@@ -1,0 +1,37 @@
+import { anonymizeReviewAuthor } from '@/common/utils/review-author';
+
+describe('anonymizeReviewAuthor', () => {
+  it('활성 프로필은 닉네임/이미지를 그대로 노출한다', () => {
+    expect(
+      anonymizeReviewAuthor({
+        nickname: '단골손님',
+        profile_image_url: 'https://img/1.png',
+        deleted_at: null,
+      }),
+    ).toEqual({ nickname: '단골손님', profileImageUrl: 'https://img/1.png' });
+  });
+
+  it('이미지 미선택 쿼리(필드 생략)는 profileImageUrl=null로 정규화한다', () => {
+    expect(
+      anonymizeReviewAuthor({ nickname: '단골손님', deleted_at: null }),
+    ).toEqual({ nickname: '단골손님', profileImageUrl: null });
+  });
+
+  it('프로필 미존재·soft-delete는 모두 익명화한다', () => {
+    expect(anonymizeReviewAuthor(null)).toEqual({
+      nickname: null,
+      profileImageUrl: null,
+    });
+    expect(anonymizeReviewAuthor(undefined)).toEqual({
+      nickname: null,
+      profileImageUrl: null,
+    });
+    expect(
+      anonymizeReviewAuthor({
+        nickname: 'deleted_123',
+        profile_image_url: 'https://img/1.png',
+        deleted_at: new Date(),
+      }),
+    ).toEqual({ nickname: null, profileImageUrl: null });
+  });
+});

--- a/src/common/utils/review-author.ts
+++ b/src/common/utils/review-author.ts
@@ -1,0 +1,25 @@
+/**
+ * 리뷰 작성자 노출 정책(단일 소스, 이슈 #226).
+ * 탈퇴(soft-delete)했거나 프로필이 없는 작성자는 닉네임/프로필 이미지를
+ * 노출하지 않는다(null) — 탈퇴 시 nickname이 deleted_<id>로 치환되는 값이
+ * 그대로 노출되는 것도 이 정책이 가린다.
+ */
+
+/** 판정에 필요한 프로필 row 부분집합. 이미지 미선택 쿼리는 필드 생략 가능. */
+export interface ReviewAuthorProfile {
+  nickname: string;
+  profile_image_url?: string | null;
+  deleted_at: Date | null;
+}
+
+export function anonymizeReviewAuthor(
+  profile: ReviewAuthorProfile | null | undefined,
+): { nickname: string | null; profileImageUrl: string | null } {
+  if (!profile || profile.deleted_at !== null) {
+    return { nickname: null, profileImageUrl: null };
+  }
+  return {
+    nickname: profile.nickname,
+    profileImageUrl: profile.profile_image_url ?? null,
+  };
+}

--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { RandomService } from '@/common/providers/random.service';
 import { parseId } from '@/common/utils/id-parser';
 import { DAY_MS } from '@/common/utils/kst-time';
+import { anonymizeReviewAuthor } from '@/common/utils/review-author';
 import {
   DEFAULT_POPULAR_CAKES_LIMIT,
   DEFAULT_RANDOM_CAKES_LIMIT,
@@ -134,12 +135,8 @@ export class ProductHomeService {
         reviewId: row.id.toString(),
         storeId: row.store_id.toString(),
         rank: items.length + 1,
-        // 탈퇴(soft-delete) 작성자는 닉네임을 노출하지 않는다(익명화 정책)
-        authorNickname:
-          row.account.user_profile &&
-          row.account.user_profile.deleted_at === null
-            ? row.account.user_profile.nickname
-            : null,
+        authorNickname: anonymizeReviewAuthor(row.account.user_profile)
+          .nickname,
         reviewText: row.content,
         likeCount: entry.likeCount,
         beforeImageUrl,

--- a/src/features/product/services/product-review-mappers.helper.ts
+++ b/src/features/product/services/product-review-mappers.helper.ts
@@ -1,3 +1,4 @@
+import { anonymizeReviewAuthor } from '@/common/utils/review-author';
 import type {
   ProductReviewRow,
   ReviewAuthorRow,
@@ -24,14 +25,7 @@ function toAuthor(account: ReviewAuthorRow): {
   nickname: string | null;
   profileImageUrl: string | null;
 } {
-  const profile = account.user_profile;
-  if (!profile || profile.deleted_at !== null) {
-    return { nickname: null, profileImageUrl: null };
-  }
-  return {
-    nickname: profile.nickname,
-    profileImageUrl: profile.profile_image_url,
-  };
+  return anonymizeReviewAuthor(account.user_profile);
 }
 
 export function toProductReview(

--- a/src/features/store/services/store-review-mappers.helper.ts
+++ b/src/features/store/services/store-review-mappers.helper.ts
@@ -1,3 +1,4 @@
+import { anonymizeReviewAuthor } from '@/common/utils/review-author';
 import type { StoreReviewRow } from '@/features/store/repositories/store-review.repository';
 import type { StoreReview } from '@/features/store/types/store-review-output.type';
 
@@ -18,11 +19,7 @@ export function toStoreReview(
     })),
     likeCount,
     isLiked,
-    // 탈퇴(soft-delete)한 작성자는 nickname이 deleted_<id>로 덮어써지므로 익명화한다
-    authorNickname:
-      row.account.user_profile && row.account.user_profile.deleted_at === null
-        ? row.account.user_profile.nickname
-        : null,
+    authorNickname: anonymizeReviewAuthor(row.account.user_profile).nickname,
     productName: row.order_item.product_name_snapshot,
     createdAt: row.created_at,
   };


### PR DESCRIPTION
#226의 세 번째 항목입니다. "탈퇴(soft-delete)했거나 프로필이 없는 리뷰 작성자는 닉네임/프로필 이미지를 노출하지 않는다"는 동일 정책이 세 곳에 손 복붙돼 있던 것을 공용 함수로 모았습니다.

- `common/utils/review-author.ts` 신설 — `anonymizeReviewAuthor(profile)` → `{ nickname, profileImageUrl }`. 탈퇴 시 nickname이 `deleted_<id>`로 치환된 값이 노출되는 것을 가리는 정책의 단일 소스입니다. 이미지를 select하지 않는 쿼리를 위해 `profile_image_url`은 생략 가능하게 뒀습니다.
- 치환 3곳: `product-review-mappers`의 `toAuthor`, `store-review-mappers` 인라인, `product-home.customCakeShowcase` 인라인(닉네임만 사용)

동작 변경 0 — 기존 spec 무변경 green, 신설 함수 단위 spec 추가. `yarn validate` 192 suites / 1668 tests.

Refs #226