### PR TITLE
refactor: KST 날짜 경계·말일·UTC 자정 정규화 헬퍼 통합

### DIFF
--- a/src/common/utils/date-parser.spec.ts
+++ b/src/common/utils/date-parser.spec.ts
@@ -1,6 +1,10 @@
 import { BadRequestException } from '@nestjs/common';
 
-import { toDate, toDateRequired } from '@/common/utils/date-parser';
+import {
+  toDate,
+  toDateRequired,
+  utcDateOnly,
+} from '@/common/utils/date-parser';
 
 describe('date-parser', () => {
   describe('toDate', () => {
@@ -59,6 +63,14 @@ describe('date-parser', () => {
     it('유효한 날짜면 Date를 반환해야 한다', () => {
       const result = toDateRequired('2024-01-01', 'testField');
       expect(result).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('utcDateOnly', () => {
+    it('시간 부분을 버리고 UTC 자정으로 정규화한다', () => {
+      expect(
+        utcDateOnly(new Date('2026-08-30T13:45:12.345Z')).toISOString(),
+      ).toBe('2026-08-30T00:00:00.000Z');
     });
   });
 });

--- a/src/common/utils/date-parser.ts
+++ b/src/common/utils/date-parser.ts
@@ -9,6 +9,13 @@ export function toDate(raw?: Date | string | null): Date | undefined {
   return date;
 }
 
+/** 시간 부분을 버리고 UTC 자정으로 정규화(@db.Date 비교/저장용). */
+export function utcDateOnly(date: Date): Date {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+}
+
 export function toDateRequired(
   raw: Date | string | null | undefined,
   field: string,

--- a/src/common/utils/kst-time.spec.ts
+++ b/src/common/utils/kst-time.spec.ts
@@ -1,6 +1,8 @@
 import {
+  daysInMonth,
   formatKstDate,
   formatMinutesOfDay,
+  kstDayBoundaries,
   kstDayDiff,
   kstMidnightUtc,
   kstMinutesOfDay,
@@ -88,6 +90,26 @@ describe('kst-time', () => {
       expect(formatMinutesOfDay(630)).toBe('10:30');
       expect(formatMinutesOfDay(0)).toBe('00:00');
       expect(formatMinutesOfDay(1170)).toBe('19:30');
+    });
+  });
+
+  describe('kstDayBoundaries', () => {
+    it('KST 달력일의 요일·날짜 경계 3종을 산출한다', () => {
+      // 2026-09-10(KST, 목요일). UTC 20시는 KST 다음날 05시 — KST 달력일 기준 확인
+      const at = new Date('2026-09-09T20:00:00Z');
+      const b = kstDayBoundaries(at);
+      expect(b.weekday).toBe(4);
+      expect(b.dateOnlyUtc.toISOString()).toBe('2026-09-10T00:00:00.000Z');
+      expect(b.dayStartUtc.toISOString()).toBe('2026-09-09T15:00:00.000Z');
+      expect(b.dayEndUtc.toISOString()).toBe('2026-09-10T15:00:00.000Z');
+    });
+  });
+
+  describe('daysInMonth', () => {
+    it('말일을 계산한다(윤년 포함)', () => {
+      expect(daysInMonth(2026, 9)).toBe(30);
+      expect(daysInMonth(2026, 2)).toBe(28);
+      expect(daysInMonth(2028, 2)).toBe(29);
     });
   });
 });

--- a/src/common/utils/kst-time.ts
+++ b/src/common/utils/kst-time.ts
@@ -33,6 +33,36 @@ export function kstMidnightUtc(year: number, month: number, day: number): Date {
   return new Date(Date.UTC(year, month - 1, day) - KST_OFFSET_MS);
 }
 
+/** 해당 KST 달력일의 요일·날짜 경계 묶음(이슈 #226 — 산출 로직 단일 소스). */
+export interface KstDayBoundaries {
+  /** 요일 0(일)~6(토). */
+  weekday: number;
+  /** `@db.Date` 컬럼 비교용 — 해당 KST 달력일의 UTC 자정 표현. */
+  dateOnlyUtc: Date;
+  /** DateTime 범위 비교용 — 해당 KST 달력일 자정(UTC 시각). */
+  dayStartUtc: Date;
+  /** 다음날 KST 자정(미포함 상한). */
+  dayEndUtc: Date;
+}
+
+/** at이 속한 KST 달력일의 요일과 날짜 경계 3종을 산출한다. */
+export function kstDayBoundaries(at: Date): KstDayBoundaries {
+  const { year, month, day } = toKstYmd(at);
+  const dateOnlyUtc = new Date(Date.UTC(year, month - 1, day));
+  const dayStartUtc = kstMidnightUtc(year, month, day);
+  return {
+    weekday: dateOnlyUtc.getUTCDay(),
+    dateOnlyUtc,
+    dayStartUtc,
+    dayEndUtc: new Date(dayStartUtc.getTime() + DAY_MS),
+  };
+}
+
+/** 해당 연·월(1-12)의 말일. */
+export function daysInMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
 /** KST 기준 "YYYY-MM-DD" 문자열. */
 export function formatKstDate(date: Date): string {
   const { year, month, day } = toKstYmd(date);

--- a/src/features/order/services/order-checkout.service.ts
+++ b/src/features/order/services/order-checkout.service.ts
@@ -11,12 +11,7 @@ import { Prisma } from '@prisma/client';
 import { ClockService } from '@/common/providers/clock.service';
 import { RandomService } from '@/common/providers/random.service';
 import { parseId } from '@/common/utils/id-parser';
-import {
-  DAY_MS,
-  formatKstDate,
-  kstMidnightUtc,
-  toKstYmd,
-} from '@/common/utils/kst-time';
+import { formatKstDate, kstDayBoundaries } from '@/common/utils/kst-time';
 import { ORDER_CHECKOUT_ERRORS } from '@/features/order/constants/order-error-messages';
 import type { CreateOrderInput } from '@/features/order/dto/inputs/create-order.input';
 import { OrderRepository } from '@/features/order/repositories/order.repository';
@@ -182,14 +177,8 @@ export class OrderCheckoutService {
 
   /** capacity 원자 검사 조건(픽업 KST 달력일 기준). */
   private buildCapacityGuard(storeId: bigint, pickupAt: Date) {
-    const { year, month, day } = toKstYmd(pickupAt);
-    const dayStartUtc = kstMidnightUtc(year, month, day);
-    return {
-      storeId,
-      dateOnlyUtc: new Date(Date.UTC(year, month - 1, day)),
-      dayStartUtc,
-      dayEndUtc: new Date(dayStartUtc.getTime() + DAY_MS),
-    };
+    const { dateOnlyUtc, dayStartUtc, dayEndUtc } = kstDayBoundaries(pickupAt);
+    return { storeId, dateOnlyUtc, dayStartUtc, dayEndUtc };
   }
 
   /**

--- a/src/features/pickup/services/pickup-slot.service.ts
+++ b/src/features/pickup/services/pickup-slot.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 
 import {
   formatKstDate,
+  daysInMonth,
   formatMinutesOfDay,
   kstDayDiff,
   kstMidnightUtc,
@@ -39,7 +40,7 @@ export class PickupSlotService {
       throw new BadRequestException(PICKUP_ERRORS.INVALID_YEAR_MONTH);
     }
 
-    const daysInMonth = new Date(Date.UTC(ym.year, ym.month, 0)).getUTCDate();
+    const dayCount = daysInMonth(ym.year, ym.month);
 
     // 오늘은 현재시각+리드타임 이후 가용 슬롯이 하나라도 있어야 선택 가능
     // (없으면 pickupTimeSlots가 전부 마감 → 캘린더도 선택 불가로 일치시킨다)
@@ -47,7 +48,7 @@ export class PickupSlotService {
     const lastSlotMinutes = PICKUP_CLOSE_MINUTES - PICKUP_SLOT_INTERVAL_MINUTES;
     const todayHasSlot = cutoffMinutes <= lastSlotMinutes;
 
-    const days = Array.from({ length: daysInMonth }, (_, index) => {
+    const days = Array.from({ length: dayCount }, (_, index) => {
       const day = index + 1;
       const date = kstMidnightUtc(ym.year, ym.month, day);
       const diff = kstDayDiff(now, date);

--- a/src/features/store/services/store-pickup-schedule.service.ts
+++ b/src/features/store/services/store-pickup-schedule.service.ts
@@ -6,6 +6,7 @@ import {
 
 import { ClockService } from '@/common/providers/clock.service';
 import {
+  daysInMonth,
   kstMidnightUtc,
   kstMinutesOfDay,
   parseKstDate,
@@ -73,7 +74,7 @@ export class StorePickupScheduleService {
     }
 
     const now = this.clock.now();
-    const daysInMonth = new Date(Date.UTC(ym.year, ym.month, 0)).getUTCDate();
+    const dayCount = daysInMonth(ym.year, ym.month);
     // 조회는 월 범위 벌크 4회로 끝내고, 날짜 루프에서는 추가 쿼리를 내지 않는다
     const ctx = await this.loadScheduleContext(
       store.id,
@@ -84,7 +85,7 @@ export class StorePickupScheduleService {
     );
 
     const days: StorePickupDay[] = Array.from(
-      { length: daysInMonth },
+      { length: dayCount },
       (_, index) => {
         const day = index + 1;
         const { reason } = evaluatePickupDay(

--- a/src/features/store/services/store-today-pickup.service.ts
+++ b/src/features/store/services/store-today-pickup.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { ClockService } from '@/common/providers/clock.service';
 import { parseId } from '@/common/utils/id-parser';
-import { DAY_MS, kstMidnightUtc, toKstYmd } from '@/common/utils/kst-time';
+import { kstDayBoundaries } from '@/common/utils/kst-time';
 import { hasMoreByOffset } from '@/common/utils/pagination';
 import { roundRatingAverage } from '@/common/utils/rating';
 import { DEFAULT_POPULAR_STORES_LIMIT } from '@/features/store/constants/store-ranking.constants';
@@ -49,7 +49,9 @@ export class StoreTodayPickupService {
     }
 
     const storeIds = scored.map((s) => s.candidate.id);
-    const { weekday, dateOnlyUtc, dayStartUtc, dayEndUtc } = todayKst(asOf);
+    // seller가 저장한 closure/capacity 날짜는 UTC date 부분으로 기록되는 전제(dateOnlyUtc 비교)
+    const { weekday, dateOnlyUtc, dayStartUtc, dayEndUtc } =
+      kstDayBoundaries(asOf);
     const [businessHours, closedStoreIds, capacities, bookedCounts] =
       await Promise.all([
         this.repo.findBusinessHoursByWeekday(storeIds, weekday),
@@ -112,28 +114,4 @@ export class StoreTodayPickupService {
       asOf,
     };
   }
-}
-
-/**
- * asOf 기준 KST '오늘'의 요일과 날짜 경계.
- * - dateOnlyUtc: @db.Date 컬럼 비교용(해당 KST 달력일의 UTC 자정 표현).
- *   seller가 저장한 closure/capacity 날짜도 UTC date 부분으로 기록되는 전제.
- * - dayStartUtc/dayEndUtc: pickup_at(DateTime) 범위 비교용(KST 자정 경계).
- */
-function todayKst(asOf: Date): {
-  weekday: number;
-  dateOnlyUtc: Date;
-  dayStartUtc: Date;
-  dayEndUtc: Date;
-} {
-  const { year, month, day } = toKstYmd(asOf);
-  const dateOnlyUtc = new Date(Date.UTC(year, month - 1, day));
-  const dayStartUtc = kstMidnightUtc(year, month, day);
-  const dayEndUtc = new Date(dayStartUtc.getTime() + DAY_MS);
-  return {
-    weekday: dateOnlyUtc.getUTCDay(),
-    dateOnlyUtc,
-    dayStartUtc,
-    dayEndUtc,
-  };
 }

--- a/src/features/user/services/user-base.service.ts
+++ b/src/features/user/services/user-base.service.ts
@@ -4,6 +4,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 
+import { utcDateOnly } from '@/common/utils/date-parser';
 import {
   DEFAULT_PAGINATION_LIMIT,
   MAX_NICKNAME_LENGTH,
@@ -113,18 +114,13 @@ export abstract class UserBaseService {
     }
     // DB가 @db.Date(시간 무시) + GraphQL DateTime이 ISO string을 UTC로 해석하므로
     // timezone 독립적으로 UTC 자정 기준으로 정규화한다.
-    const normalized = new Date(
-      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
-    );
+    const normalized = utcDateOnly(date);
     if (normalized < MIN_BIRTH_DATE) {
       throw new BadRequestException(
         'birthDate is too old (before 1900-01-01).',
       );
     }
-    const now = new Date();
-    const todayUtc = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
-    );
+    const todayUtc = utcDateOnly(new Date());
     if (normalized > todayUtc) {
       throw new BadRequestException('birthDate cannot be in the future.');
     }


### PR DESCRIPTION
#226의 네 번째 항목입니다. 같은 날짜 산출 로직이 feature마다 사설 구현돼 있던 것을 공용 유틸로 모았습니다.

- **`kstDayBoundaries(at)`** (kst-time) — 해당 KST 달력일의 `{ weekday, dateOnlyUtc, dayStartUtc, dayEndUtc }` 산출 단일 소스. store-today-pickup의 로컬 `todayKst`와 order-checkout `buildCapacityGuard`의 사설 산출 2벌을 치환했습니다. `@db.Date` 비교용(dateOnlyUtc)과 DateTime 범위 비교용(dayStart/dayEnd)의 의미는 인터페이스 주석으로 옮겼습니다.
- **`daysInMonth(year, month)`** (kst-time) — pickup-slot·store-pickup-schedule의 말일 계산(`Date.UTC(y, m, 0)` 트릭) 2벌 치환.
- **`utcDateOnly(date)`** (date-parser) — user-base `normalizeBirthDate`의 UTC 자정 정규화 인라인 2벌 치환.

동작 변경 0 — 기존 spec 무변경 green, 신설 함수 단위 spec 추가(KST 경계·윤년 케이스 포함). `yarn validate` 193 suites / 1677 tests.

Refs #226