### PR TITLE
refactor(store): 인기 랭킹 점수화·정렬 블록 공용화

### DIFF
--- a/src/features/product/services/product-home.service.ts
+++ b/src/features/product/services/product-home.service.ts
@@ -26,9 +26,8 @@ import type {
 } from '@/features/product/types/product-home-output.type';
 import {
   DEFAULT_GLOBAL_RATING_PRIOR,
-  popularityScore,
   RANKING_RECENT_ORDER_DAYS,
-  type StoreMetrics,
+  scoreAndSortByPopularity,
 } from '@/features/store';
 
 @Injectable()
@@ -79,25 +78,12 @@ export class ProductHomeService {
       ]);
     const prior = globalAverage ?? DEFAULT_GLOBAL_RATING_PRIOR;
 
-    const scored = candidates.map((candidate) => {
-      const review = reviewStats.get(candidate.id);
-      const metrics: StoreMetrics = {
-        recentOrderCount: orderCounts.get(candidate.id) ?? 0,
-        wishlistCount: wishlistCounts.get(candidate.id) ?? 0,
-        ratingAverage: review?.average ?? 0,
-        reviewCount: review?.count ?? 0,
-      };
-      return { candidate, metrics, score: popularityScore(metrics, prior) };
-    });
-
-    // 점수 desc → 리뷰수 desc → id desc (인기 매장과 동일한 안정적 동점 처리)
-    scored.sort((a, b) => {
-      if (b.score !== a.score) return b.score - a.score;
-      if (b.metrics.reviewCount !== a.metrics.reviewCount) {
-        return b.metrics.reviewCount - a.metrics.reviewCount;
-      }
-      return b.candidate.id > a.candidate.id ? 1 : -1;
-    });
+    // 점수화·정렬은 인기 매장과 동일 정책(scoreAndSortByPopularity) 단일 소스
+    const scored = scoreAndSortByPopularity(
+      candidates,
+      { wishlistCounts, reviewStats, recentOrderCounts: orderCounts },
+      prior,
+    );
 
     const items = scored
       .slice(0, limit)

--- a/src/features/store/index.ts
+++ b/src/features/store/index.ts
@@ -10,7 +10,4 @@ export { buildRegionLabel } from '@/features/store/services/store-mappers.helper
 // 매장 픽업 가능 판정. 주문 생성(order feature)이 픽업 일시 재검증에 사용한다 —
 // 판정 규칙은 store feature에 유지한다(달력·슬롯 조회와 단일 소스).
 export { StorePickupScheduleService } from '@/features/store/services/store-pickup-schedule.service';
-export {
-  popularityScore,
-  type StoreMetrics,
-} from '@/features/store/services/store-ranking.helper';
+export { scoreAndSortByPopularity } from '@/features/store/services/store-ranking.helper';

--- a/src/features/store/services/store-listing.service.ts
+++ b/src/features/store/services/store-listing.service.ts
@@ -16,17 +16,13 @@ import {
 } from '@/features/store/repositories/store.repository';
 import { toPopularStore } from '@/features/store/services/store-mappers.helper';
 import {
-  popularityScore,
-  type StoreMetrics,
+  scoreAndSortByPopularity,
+  type ScoredCandidate,
 } from '@/features/store/services/store-ranking.helper';
 import type { PopularStoreConnection } from '@/features/store/types/store-output.type';
 
 /** 점수화·정렬이 끝난 랭킹 항목. */
-export interface ScoredStore {
-  candidate: StoreCandidateRow;
-  metrics: StoreMetrics;
-  score: number;
-}
+export type ScoredStore = ScoredCandidate<StoreCandidateRow>;
 
 @Injectable()
 export class StoreListingService {
@@ -62,26 +58,11 @@ export class StoreListingService {
       ]);
     const prior = globalAverage ?? DEFAULT_GLOBAL_RATING_PRIOR;
 
-    const scored = candidates.map((candidate) => {
-      const review = reviewStats.get(candidate.id);
-      const metrics: StoreMetrics = {
-        recentOrderCount: orderCounts.get(candidate.id) ?? 0,
-        wishlistCount: wishlistCounts.get(candidate.id) ?? 0,
-        ratingAverage: review?.average ?? 0,
-        reviewCount: review?.count ?? 0,
-      };
-      return { candidate, metrics, score: popularityScore(metrics, prior) };
-    });
-
-    // 점수 desc → 리뷰수 desc → id desc (안정적 동점 처리)
-    scored.sort((a, b) => {
-      if (b.score !== a.score) return b.score - a.score;
-      if (b.metrics.reviewCount !== a.metrics.reviewCount) {
-        return b.metrics.reviewCount - a.metrics.reviewCount;
-      }
-      return b.candidate.id > a.candidate.id ? 1 : -1;
-    });
-    return scored;
+    return scoreAndSortByPopularity(
+      candidates,
+      { wishlistCounts, reviewStats, recentOrderCounts: orderCounts },
+      prior,
+    );
   }
 
   /**

--- a/src/features/store/services/store-ranking.helper.spec.ts
+++ b/src/features/store/services/store-ranking.helper.spec.ts
@@ -2,6 +2,7 @@ import { RANKING_BAYESIAN_M } from '@/features/store/constants/store-ranking.con
 import {
   bayesianRating,
   popularityScore,
+  scoreAndSortByPopularity,
 } from '@/features/store/services/store-ranking.helper';
 
 describe('store-ranking.helper', () => {
@@ -54,6 +55,53 @@ describe('store-ranking.helper', () => {
       const at110 = popularityScore({ ...base, recentOrderCount: 110 }, 0);
       // 같은 +10 증가라도 낮은 구간(0→10)의 상승폭이 높은 구간(100→110)보다 크다
       expect(at10 - at0).toBeGreaterThan(at110 - at100);
+    });
+  });
+
+  describe('scoreAndSortByPopularity', () => {
+    const emptyAggregates = {
+      wishlistCounts: new Map<bigint, number>(),
+      reviewStats: new Map<bigint, { average: number; count: number }>(),
+      recentOrderCounts: new Map<bigint, number>(),
+    };
+
+    it('집계값을 조립해 점수 내림차순으로 정렬한다', () => {
+      const result = scoreAndSortByPopularity(
+        [{ id: 1n }, { id: 2n }],
+        {
+          ...emptyAggregates,
+          recentOrderCounts: new Map([
+            [1n, 1],
+            [2n, 100],
+          ]),
+        },
+        0,
+      );
+      expect(result.map((r) => r.candidate.id)).toEqual([2n, 1n]);
+      expect(result[0].metrics.recentOrderCount).toBe(100);
+    });
+
+    it('동점이면 리뷰수 desc → id desc로 안정 정렬한다', () => {
+      const result = scoreAndSortByPopularity(
+        [{ id: 1n }, { id: 3n }, { id: 2n }],
+        emptyAggregates,
+        0,
+      );
+      expect(result.map((r) => r.candidate.id)).toEqual([3n, 2n, 1n]);
+    });
+
+    it('집계 미존재 후보는 0으로 채운다', () => {
+      const [entry] = scoreAndSortByPopularity(
+        [{ id: 7n }],
+        emptyAggregates,
+        4.0,
+      );
+      expect(entry.metrics).toEqual({
+        recentOrderCount: 0,
+        wishlistCount: 0,
+        ratingAverage: 0,
+        reviewCount: 0,
+      });
     });
   });
 });

--- a/src/features/store/services/store-ranking.helper.ts
+++ b/src/features/store/services/store-ranking.helper.ts
@@ -42,3 +42,49 @@ export function popularityScore(
     RANKING_WEIGHTS.rating * bayes
   );
 }
+
+/** 후보별 집계값 묶음(후보 id 키 Map). */
+export interface PopularityAggregates {
+  wishlistCounts: Map<bigint, number>;
+  reviewStats: Map<bigint, { average: number; count: number }>;
+  recentOrderCounts: Map<bigint, number>;
+}
+
+export interface ScoredCandidate<T> {
+  candidate: T;
+  metrics: StoreMetrics;
+  score: number;
+}
+
+/**
+ * 후보 목록을 인기 점수화하고 점수 desc → 리뷰수 desc → id desc로 정렬한다
+ * (안정적 동점 처리). 인기 매장·인기 케이크가 동일 정책을 공유한다(이슈 #226).
+ */
+export function scoreAndSortByPopularity<T extends { id: bigint }>(
+  candidates: T[],
+  aggregates: PopularityAggregates,
+  globalAverage: number,
+): ScoredCandidate<T>[] {
+  const scored = candidates.map((candidate) => {
+    const review = aggregates.reviewStats.get(candidate.id);
+    const metrics: StoreMetrics = {
+      recentOrderCount: aggregates.recentOrderCounts.get(candidate.id) ?? 0,
+      wishlistCount: aggregates.wishlistCounts.get(candidate.id) ?? 0,
+      ratingAverage: review?.average ?? 0,
+      reviewCount: review?.count ?? 0,
+    };
+    return {
+      candidate,
+      metrics,
+      score: popularityScore(metrics, globalAverage),
+    };
+  });
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (b.metrics.reviewCount !== a.metrics.reviewCount) {
+      return b.metrics.reviewCount - a.metrics.reviewCount;
+    }
+    return b.candidate.id > a.candidate.id ? 1 : -1;
+  });
+  return scored;
+}


### PR DESCRIPTION
#226의 다섯 번째(마지막) 항목입니다. `StoreMetrics 조립 → popularityScore → 점수/리뷰수/id 정렬` 블록이 인기 매장(store-listing)과 인기 케이크(product-home)에 통째로 2벌 복붙돼 있던 것을 하나로 모았습니다. 두 랭킹이 "동일 산식·동일 동점 처리"를 공유한다는 게 기존 주석으로만 표현되던 정책이었는데, 이제 코드 구조가 그것을 강제합니다.

- `store-ranking.helper.ts`에 `scoreAndSortByPopularity(candidates, aggregates, prior)` 신설 — 집계 Map 3종(찜/리뷰/최근 주문)을 받아 점수화하고 점수 desc → 리뷰수 desc → id desc로 정렬합니다. 후보 타입은 제네릭(`T extends { id: bigint }`)이라 매장·상품 모두 수용합니다.
- 위치는 이미 랭킹 산식을 배럴로 공개하던 store feature에 뒀고, product-home이 배럴로 소비합니다.
- 배럴 정리: `popularityScore`·`StoreMetrics`의 유일한 외부 소비처가 product-home이었어서, 치환 후 dead export가 되지 않도록 `scoreAndSortByPopularity`로 교체했습니다. `ScoredStore`는 `ScoredCandidate<StoreCandidateRow>` 별칭으로 유지해 today-pickup 쪽 시그니처는 그대로입니다.

동작 변경 0 — 기존 spec 무변경 green, 단위 spec 3케이스 추가(정렬·동점·집계 미존재 기본값). `yarn validate` 193 suites / 1677 tests.

Refs #226