### PR TITLE
fix: 릴리즈 리뷰 반영 — 멱등 키 점유·페이지네이션 음수 limit

### DIFF
--- a/src/common/utils/pagination.spec.ts
+++ b/src/common/utils/pagination.spec.ts
@@ -20,6 +20,13 @@ describe('pagination utils', () => {
       });
       expect(sliceOverfetched([], 2)).toEqual({ items: [], hasMore: false });
     });
+
+    it('음수 limit은 0으로 정규화한다(마지막 항목을 떨어뜨리지 않는다)', () => {
+      expect(sliceOverfetched([1, 2, 3], -1)).toEqual({
+        items: [],
+        hasMore: true,
+      });
+    });
   });
 
   describe('sliceCursorPage', () => {
@@ -57,6 +64,10 @@ describe('pagination utils', () => {
       expect(hasMoreByOffset(0, 20, 21)).toBe(true);
       expect(hasMoreByOffset(0, 20, 20)).toBe(false);
       expect(hasMoreByOffset(20, 20, 21)).toBe(false);
+    });
+
+    it('음수 limit은 0으로 정규화한다(빈 목록에서 true가 되지 않는다)', () => {
+      expect(hasMoreByOffset(0, -1, 0)).toBe(false);
     });
   });
 });

--- a/src/common/utils/pagination.ts
+++ b/src/common/utils/pagination.ts
@@ -12,13 +12,19 @@ export interface CursorPage<T> {
   nextCursor: string | null;
 }
 
-/** `take: limit + 1` 초과 조회 결과를 페이지와 잔여 여부로 자른다. */
+/**
+ * `take: limit + 1` 초과 조회 결과를 페이지와 잔여 여부로 자른다.
+ * 음수 limit은 0으로 정규화한다 — slice(0, -1)이 마지막 항목을 떨어뜨리는
+ * 형태로 조용히 동작하지 않게 한다(호출부는 DTO 검증을 거치지만 범용 유틸이라
+ * 방어를 둔다. 릴리즈 리뷰 반영, PR #237).
+ */
 export function sliceOverfetched<T>(
   rows: T[],
   limit: number,
 ): { items: T[]; hasMore: boolean } {
-  const hasMore = rows.length > limit;
-  return { items: hasMore ? rows.slice(0, limit) : rows, hasMore };
+  const safeLimit = Math.max(0, limit);
+  const hasMore = rows.length > safeLimit;
+  return { items: hasMore ? rows.slice(0, safeLimit) : rows, hasMore };
 }
 
 /** 초과 조회 결과 → 커서 페이지. 다음 커서는 페이지 마지막 행에서 계산한다. */
@@ -37,11 +43,11 @@ export function sliceCursorPage<T>(
   };
 }
 
-/** offset 페이지네이션의 잔여 여부. */
+/** offset 페이지네이션의 잔여 여부. 음수 limit은 0으로 정규화한다. */
 export function hasMoreByOffset(
   offset: number,
   limit: number,
   totalCount: number,
 ): boolean {
-  return offset + limit < totalCount;
+  return offset + Math.max(0, limit) < totalCount;
 }

--- a/src/features/order/constants/order-error-messages.ts
+++ b/src/features/order/constants/order-error-messages.ts
@@ -17,4 +17,6 @@ export const ORDER_CHECKOUT_ERRORS = {
     '주문번호 생성에 실패했습니다. 잠시 후 다시 시도해 주세요.',
   IDEMPOTENT_REPLAY_FAILED:
     '이미 처리 중인 주문을 확인하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+  IDEMPOTENCY_KEY_UNAVAILABLE:
+    '이 요청 키로는 주문을 만들 수 없습니다. 주문서를 새로 열어 다시 시도해 주세요.',
 } as const;

--- a/src/features/order/repositories/order.repository.spec.ts
+++ b/src/features/order/repositories/order.repository.spec.ts
@@ -38,6 +38,43 @@ describe('OrderRepository (real DB)', () => {
     return createAccount(prisma, { account_type: 'USER' });
   }
 
+  describe('멱등 키 조회', () => {
+    it('활성 주문 조회는 soft-delete된 주문을 반환하지 않는다', async () => {
+      const buyer = await setupBuyer();
+      await createOrder(prisma, {
+        account_id: buyer.id,
+        idempotency_key: 'k-deleted',
+        deleted_at: new Date(),
+      });
+
+      expect(
+        await repo.findOrderByIdempotencyKey(buyer.id, 'k-deleted'),
+      ).toBeNull();
+    });
+
+    it('키 점유 확인은 soft-delete된 주문을 찾아낸다(extension 우회 계약)', async () => {
+      const buyer = await setupBuyer();
+      await createOrder(prisma, {
+        account_id: buyer.id,
+        idempotency_key: 'k-deleted',
+        deleted_at: new Date(),
+      });
+      await createOrder(prisma, {
+        account_id: buyer.id,
+        idempotency_key: 'k-active',
+      });
+
+      // MySQL unique는 deleted_at을 보지 않아 삭제된 주문도 키를 계속 점유한다
+      expect(
+        await repo.existsDeletedOrderWithIdempotencyKey(buyer.id, 'k-deleted'),
+      ).toBe(true);
+      // 활성 주문이 쥔 키는 '삭제가 점유' 케이스가 아니다
+      expect(
+        await repo.existsDeletedOrderWithIdempotencyKey(buyer.id, 'k-active'),
+      ).toBe(false);
+    });
+  });
+
   describe('findOngoingOrdersByAccount', () => {
     it('SUBMITTED/CONFIRMED/MADE 상태 주문만 since 이후로 반환하고 PICKED_UP/CANCELED 제외', async () => {
       const buyer = await setupBuyer();

--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -274,6 +274,27 @@ export class OrderRepository {
     });
   }
 
+  /**
+   * 해당 멱등 키가 soft-delete된 주문에 점유돼 있는지 확인(릴리즈 리뷰 반영).
+   * MySQL unique(uk_order_account_idempotency)는 deleted_at을 보지 않으므로,
+   * 삭제된 주문도 키를 계속 점유한다 — 이 경우 같은 키로는 영영 생성이 불가하다.
+   * soft-delete 포함 조회가 목적이라 extension이 주입하는 활성 필터를 우회한다.
+   */
+  async existsDeletedOrderWithIdempotencyKey(
+    accountId: bigint,
+    idempotencyKey: string,
+  ): Promise<boolean> {
+    const found = await this.prisma.order.findFirst({
+      where: {
+        account_id: accountId,
+        idempotency_key: idempotencyKey,
+        deleted_at: { not: null },
+      },
+      select: { id: true },
+    });
+    return found !== null;
+  }
+
   async findOngoingOrdersByAccount(args: {
     accountId: bigint;
     since: Date;

--- a/src/features/order/services/order-checkout.service.spec.ts
+++ b/src/features/order/services/order-checkout.service.spec.ts
@@ -9,6 +9,7 @@ import type { Account, PrismaClient, Product, Store } from '@prisma/client';
 
 import { ClockService } from '@/common/providers/clock.service';
 import { RandomService } from '@/common/providers/random.service';
+import { ORDER_CHECKOUT_ERRORS } from '@/features/order/constants/order-error-messages';
 import type { CreateOrderInput } from '@/features/order/dto/inputs/create-order.input';
 import { OrderRepository } from '@/features/order/repositories/order.repository';
 import { OrderCheckoutService } from '@/features/order/services/order-checkout.service';
@@ -731,6 +732,47 @@ describe('OrderCheckoutService (real DB)', () => {
 
       expect(orderB.orderId).not.toBe(orderA.orderId);
       expect(await prisma.order.count()).toBe(2);
+    });
+
+    it('soft-delete된 주문이 키를 점유하면 재시도 유도 대신 새 주문서를 안내한다', async () => {
+      // MySQL unique는 deleted_at을 보지 않아 삭제된 주문도 키를 계속 점유한다.
+      // 사전 조회는 활성 주문만 보므로 통과 → INSERT에서 P2002 → 같은 키로는
+      // 영영 실패. 재시도를 유도하는 500 대신 409로 새 키 사용을 알린다.
+      const store = await makeOpenStore();
+      const product = await createProduct(prisma, { store_id: store.id });
+      const buyer = await makeBuyer();
+
+      const created = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'deleted-holder-key',
+          productId: product.id.toString(),
+        }),
+      );
+      await prisma.order.update({
+        where: { id: BigInt(created.orderId) },
+        data: { deleted_at: new Date() },
+      });
+
+      await expect(
+        service.createOrder(
+          buyer.id,
+          baseInput({
+            idempotencyKey: 'deleted-holder-key',
+            productId: product.id.toString(),
+          }),
+        ),
+      ).rejects.toThrow(ORDER_CHECKOUT_ERRORS.IDEMPOTENCY_KEY_UNAVAILABLE);
+
+      // 새 키로는 정상 생성된다(키 단위 문제임을 확인)
+      const retried = await service.createOrder(
+        buyer.id,
+        baseInput({
+          idempotencyKey: 'fresh-key-after-delete',
+          productId: product.id.toString(),
+        }),
+      );
+      expect(retried.orderId).not.toBe(created.orderId);
     });
 
     it('대소문자만 다른 키는 다른 키로 취급한다(utf8mb4_bin)', async () => {

--- a/src/features/order/services/order-checkout.service.spec.ts
+++ b/src/features/order/services/order-checkout.service.spec.ts
@@ -754,15 +754,20 @@ describe('OrderCheckoutService (real DB)', () => {
         data: { deleted_at: new Date() },
       });
 
-      await expect(
+      const retry = () =>
         service.createOrder(
           buyer.id,
           baseInput({
             idempotencyKey: 'deleted-holder-key',
             productId: product.id.toString(),
           }),
-        ),
-      ).rejects.toThrow(ORDER_CHECKOUT_ERRORS.IDEMPOTENCY_KEY_UNAVAILABLE);
+        );
+      // BadRequest여야 GraphQL 코드가 BAD_USER_INPUT으로 나간다 — 500(재시도
+      // 유도)으로 보이면 클라이언트가 같은 키로 재시도해 같은 실패를 반복한다
+      await expect(retry()).rejects.toThrow(BadRequestException);
+      await expect(retry()).rejects.toThrow(
+        ORDER_CHECKOUT_ERRORS.IDEMPOTENCY_KEY_UNAVAILABLE,
+      );
 
       // 새 키로는 정상 생성된다(키 단위 문제임을 확인)
       const retried = await service.createOrder(

--- a/src/features/order/services/order-checkout.service.ts
+++ b/src/features/order/services/order-checkout.service.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   Injectable,
   InternalServerErrorException,
@@ -325,7 +326,21 @@ export class OrderCheckoutService {
             args.idempotencyKey,
           );
           if (existing) return existing;
-          // 생성 직후 소실(soft-delete 등) — 재시도 유도가 안전하다
+          // 활성 주문이 없는데 키 unique가 충돌했다면 soft-delete된 주문이 키를
+          // 점유한 경우다 — MySQL unique는 deleted_at을 보지 않는다. 같은 키로는
+          // 몇 번을 재시도해도 동일하게 실패하므로, 재시도를 유도하지 말고
+          // 새 주문서(새 키)로 유도한다(릴리즈 리뷰 반영, PR #237).
+          const heldByDeleted =
+            await this.orderRepo.existsDeletedOrderWithIdempotencyKey(
+              args.accountId,
+              args.idempotencyKey,
+            );
+          if (heldByDeleted) {
+            throw new ConflictException(
+              ORDER_CHECKOUT_ERRORS.IDEMPOTENCY_KEY_UNAVAILABLE,
+            );
+          }
+          // 그 외(조회 직후 하드 삭제 등 극단적 race)는 재시도가 유효할 수 있다
           throw new InternalServerErrorException(
             ORDER_CHECKOUT_ERRORS.IDEMPOTENT_REPLAY_FAILED,
           );

--- a/src/features/order/services/order-checkout.service.ts
+++ b/src/features/order/services/order-checkout.service.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  ConflictException,
   ForbiddenException,
   Injectable,
   InternalServerErrorException,
@@ -336,7 +335,11 @@ export class OrderCheckoutService {
               args.idempotencyKey,
             );
           if (heldByDeleted) {
-            throw new ConflictException(
+            // 409가 아니라 400을 쓴다 — GraphQL 필터의 STATUS_TO_CODE에 409
+            // 매핑이 없어 INTERNAL_SERVER_ERROR로 나가고, 그러면 클라이언트가
+            // 일시 장애로 오인해 같은 키로 재시도한다(릴리즈 리뷰 반영).
+            // BAD_USER_INPUT이 "입력을 고쳐 다시 보내라"는 이 상황과도 맞다.
+            throw new BadRequestException(
               ORDER_CHECKOUT_ERRORS.IDEMPOTENCY_KEY_UNAVAILABLE,
             );
           }

--- a/src/test/factories/order.factory.ts
+++ b/src/test/factories/order.factory.ts
@@ -21,6 +21,7 @@ export interface OrderOverrides {
   discount_price?: number;
   total_price?: number;
   deleted_at?: Date;
+  idempotency_key?: string;
 }
 
 export async function createOrder(
@@ -43,6 +44,9 @@ export async function createOrder(
       subtotal_price: overrides.subtotal_price ?? 10000,
       discount_price: overrides.discount_price ?? 0,
       total_price: overrides.total_price ?? 10000,
+      ...(overrides.idempotency_key
+        ? { idempotency_key: overrides.idempotency_key }
+        : {}),
       ...(overrides.deleted_at ? { deleted_at: overrides.deleted_at } : {}),
     },
   });


### PR DESCRIPTION
릴리즈 PR #237에서 받은 봇 리뷰 2건을 반영합니다. 릴리즈 리뷰 루프대로 main에 직접 커밋하지 않고 develop으로 먼저 머지한 뒤, 마지막에 #237을 머지합니다.

## 1. soft-delete된 주문이 멱등 키를 점유하는 경로 (Codex P2)

지적이 유효함을 코드로 확인했습니다.

`findOrderByIdempotencyKey`는 루트 READ라 soft-delete extension이 `deleted_at: null`을 주입합니다. 그런데 MySQL의 unique 인덱스(`uk_order_account_idempotency`)는 `deleted_at`을 보지 않으므로, **삭제된 주문도 키를 계속 점유**합니다. 그 결과:

사전 조회가 `null` → 검증 통과 후 INSERT → `P2002` → 충돌 처리에서 같은 필터로 재조회 → 또 `null` → `IDEMPOTENT_REPLAY_FAILED`(500). 이 500은 "잠시 후 다시 시도"를 안내하는데, **같은 키로 재시도하면 영원히 같은 실패가 반복**됩니다.

수정 방향으로 "삭제된 주문을 replay로 반환"은 택하지 않았습니다. 사용자에게 이미 사라진 주문을 성공 응답으로 돌려주는 게 더 나쁘기 때문입니다. 대신 충돌 후 재조회가 비면 키 점유 여부를 확인해, 같은 키로는 복구가 불가능함을 알리는 409를 던집니다.

- `existsDeletedOrderWithIdempotencyKey` 추가 — `deleted_at: { not: null }`을 명시해 extension의 활성 필터를 우회합니다(extension은 `deleted_at`이 이미 있으면 주입하지 않습니다).
- 새 에러 `IDEMPOTENCY_KEY_UNAVAILABLE`(409) — "주문서를 새로 열어 다시 시도해 주세요".
- `"재시도 유도가 안전하다"`는 기존 주석이 사실과 달라 함께 정정했습니다.

참고로 현재 주문을 soft-delete하는 프로덕션 경로는 없습니다(취소는 `status=CANCELED`). 즉 지금은 도달 불가한 방어이지만, soft-delete가 레포 기본값이라 남겨두는 편이 맞다고 판단했습니다.

## 2. 페이지네이션 음수 limit (CodeRabbit)

`limit < 0`이면 `slice(0, -1)`이 마지막 항목을 떨어뜨리고, `hasMoreByOffset(0, -1, 0)`이 `true`가 됩니다. `sliceCursorPage`에 이미 "limit<=0 방어" 주석이 있는 것과 어긋나므로 `sliceOverfetched`·`hasMoreByOffset` 양쪽에 0 정규화를 넣었습니다.

호출부는 전부 DTO(`@Min(1)`) 검증을 거치거나 상수 기본값이라 도달 불가하지만, `common/utils`의 범용 유틸이라 방어를 일관되게 두는 편이 맞다고 봤습니다.

## 검증

`yarn validate` green — 193 suites / 1685 tests (+5).

- service: 삭제된 주문이 키를 점유하면 409, 새 키로는 정상 생성
- repository: 활성 조회는 삭제 주문 미반환 / 점유 확인은 검출(extension 우회 계약)
- pagination: 음수 limit 2건

테스트 팩토리 `createOrder`에 `idempotency_key` override를 추가했습니다.