### PR TITLE
test(product): 대상(tag) soft-delete 분기 검증 추가

### DIFF
--- a/src/features/product/repositories/product.repository.spec.ts
+++ b/src/features/product/repositories/product.repository.spec.ts
@@ -271,6 +271,9 @@ describe('ProductRepository (real DB)', () => {
       });
       const liveTag = await createTag('레터링');
       const linkDeletedTag = await createTag('링크 삭제 태그');
+      // 대상(tag) 자체가 삭제된 케이스 — 링크는 살아 있어 include의
+      // `tag: activeWhere`가 없으면 노출된다(가드 무검증 방지)
+      const deletedTag = await createTag('대상 삭제 태그');
       await prisma.productTag.createMany({
         data: [
           { product_id: product.id, tag_id: liveTag.id },
@@ -279,7 +282,12 @@ describe('ProductRepository (real DB)', () => {
             tag_id: linkDeletedTag.id,
             deleted_at: new Date(),
           },
+          { product_id: product.id, tag_id: deletedTag.id },
         ],
+      });
+      await prisma.tag.update({
+        where: { id: deletedTag.id },
+        data: { deleted_at: new Date() },
       });
 
       const result = await repo.findProductById({


### PR DESCRIPTION
릴리즈 PR #237의 CodeRabbit 지적을 반영합니다.

`findProductById`의 회귀 테스트가 카테고리는 **링크 삭제**(`productCategory.deleted_at`)와 **대상 삭제**(`category.deleted_at`)를 모두 만들어 검증하는데, 태그는 링크 삭제만 있었습니다. 그래서 include의 `tag: activeWhere` 필터가 사실상 무검증 상태였습니다 — 지적대로 그 필터를 지워도 테스트가 통과합니다.

활성 링크를 유지한 채 `tag.deleted_at`만 설정하는 케이스를 추가했습니다.

## 테스트가 실제로 가드를 지키는지 확인

추가만 하고 끝내면 같은 함정에 다시 빠지므로 뮤테이션으로 검증했습니다.

- 현재 상태: 통과
- `findProductById`의 `where: { ...activeWhere, tag: activeWhere }`에서 `tag: activeWhere` 제거 → **실패**(삭제된 태그가 결과 배열에 1건 새어나옴)

처음 뮤테이션 때 같은 파일의 `listProductsByStore` 쪽 블록을 건드려 "제거해도 통과"하는 결과가 나왔는데, 대상 메서드를 잘못 짚은 것이었습니다. `findProductById`의 블록(226행)으로 다시 확인해 위 결과를 얻었습니다.

`yarn validate` green — 193 suites / 1685 tests.