### PR TITLE
fix: 릴리즈 리뷰 반영 — 인기 검색어 trend 비교 소문자 키

### DIFF
--- a/src/features/search/services/search-keyword-rank.service.spec.ts
+++ b/src/features/search/services/search-keyword-rank.service.spec.ts
@@ -162,6 +162,24 @@ describe('SearchKeywordRankService (real DB)', () => {
       ]);
     });
 
+    it('직전 스냅샷과 대소문자 표기가 달라도 같은 검색어로 비교한다(NEW 오판 방지)', async () => {
+      await createKeywordRankSnapshot(prisma, {
+        ranked_at: PREV_AT,
+        keywords: [{ keyword: '3D' }, { keyword: '케이크' }],
+      });
+      await createKeywordRankSnapshot(prisma, {
+        ranked_at: RANKED_AT,
+        keywords: [{ keyword: '케이크' }, { keyword: '3d' }],
+      });
+
+      const result = await service.popularSearchKeywords();
+
+      expect(result.items.map((i) => [i.keyword, i.trend])).toEqual([
+        ['케이크', 'UP'],
+        ['3d', 'DOWN'],
+      ]);
+    });
+
     it('직전 스냅샷이 없으면 전부 NEW', async () => {
       await createKeywordRankSnapshot(prisma, {
         ranked_at: RANKED_AT,

--- a/src/features/search/services/search-keyword-rank.service.ts
+++ b/src/features/search/services/search-keyword-rank.service.ts
@@ -64,15 +64,22 @@ export class SearchKeywordRankService {
         ? Promise.resolve([])
         : this.repo.listSnapshotRows(previousAt),
     ]);
+    // GROUP BY는 collation(ci) 기준으로 묶여 스냅샷마다 대표 표기(대소문자)가 다를 수
+    // 있다('3d' ↔ '3D'). JS Map은 대소문자를 구분하므로 소문자 키로 비교해 같은
+    // 검색어가 NEW로 오판되지 않게 방어한다(릴리즈 리뷰 반영 — collation 완전 동치는
+    // 아니지만 실사용 대표 케이스).
     const previousRankByKeyword = new Map(
-      previous.map((row) => [row.keyword, row.rank]),
+      previous.map((row) => [row.keyword.toLowerCase(), row.rank]),
     );
 
     return {
       items: current.map((row) => ({
         rank: row.rank,
         keyword: row.keyword,
-        trend: resolveTrend(row.rank, previousRankByKeyword.get(row.keyword)),
+        trend: resolveTrend(
+          row.rank,
+          previousRankByKeyword.get(row.keyword.toLowerCase()),
+        ),
         searchCount: row.search_count,
       })),
       rankedAt,


### PR DESCRIPTION
릴리즈 PR #255 Codex 지적 반영. GROUP BY collation(ci) 대표 표기가 스냅샷마다 달라질 수 있어('3d'↔'3D') trend 비교가 NEW로 오판되는 문제 — 직전 순위 맵을 소문자 키로 비교. 회귀 테스트 1건.