### PR TITLE
fix(build): tsbuildinfo를 dist 내부로 고정해 증분 빌드 산출물 증발 수정

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     // TS 6부터 출력 레이아웃 기준 디렉터리 명시 필수(TS5011). 기존 공통 소스
     // 디렉터리와 동일한 ./src라 dist 산출 구조는 변하지 않는다.
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // rootDir 지정 시 TS는 tsbuildinfo 경로를 resolve(outDir, relative(rootDir, config))로
+    // 계산해 dist 밖(루트)에 만든다. 그러면 deleteOutDir이 dist만 지우고 캐시는 살아남아
+    // tsc가 "전부 최신"으로 오판 → emit 0건 → dist/main.js가 사라진다. dist 안으로 고정해
+    // 캐시가 산출물과 같은 생명주기를 갖게 한다.
+    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]


### PR DESCRIPTION
## 배경

프론트엔드에서 `yarn start:dev` 시 `Cannot find module '.../dist/main'`이 반복된다는 제보. `deleteOutDir` 또는 `incremental` 중 하나를 빼달라는 요청이 왔고, 원인부터 확인했다.

## 원인

`rootDir`이 지정되면 TS는 tsbuildinfo 경로를 `resolve(outDir, relative(rootDir, config))`로 계산한다.

```
resolve("./dist", relative("./src", "./tsconfig.build"))
= resolve("./dist", "../tsconfig.build")
= ./tsconfig.build.tsbuildinfo   ← dist 밖
```

1. `deleteOutDir: true`가 `dist/`를 삭제
2. 루트의 `tsconfig.build.tsbuildinfo`는 생존
3. tsc가 캐시를 보고 "전부 최신" 판단 → **emit 0건**
4. `dist/main.js` 부재 → `MODULE_NOT_FOUND`

실측:

| 상황 | 생성된 .js |
| --- | --- |
| clean 빌드 | 396 |
| 무수정 재빌드 | 0 |
| 파일 1개 수정 후 재빌드 | 1 |

파일을 수정해도 그 파일만 재생성되므로 `dist`는 계속 깨진 상태로 남는다.

## 발생 시점

`1866d69` (TS 5.9 → 6.0, TS5011 대응으로 `rootDir` 추가)부터.
`outDir`·`incremental`·`deleteOutDir`은 `78609ba`부터 있었고 8개월간 무해했다. 같은 커밋에서 `.gitignore`에 `*.tsbuildinfo`를 추가한 것이 캐시가 루트로 밀려난 흔적이다.

CI는 clean 체크아웃 1회 빌드라 구조적으로 재현되지 않아 머지 게이트를 그대로 통과했다. 영향은 로컬 개발 한정.

## 변경

`tsconfig.build.json`에 `tsBuildInfoFile`을 dist 내부로 명시 — 캐시가 산출물과 같은 생명주기를 갖게 한다.

## 대안 검토

- **`rootDir` 제거**: `c43b5ba`가 고친 `dist/src/main.js` 레이아웃 회귀(PM2 부팅 실패)가 재발함을 실측 확인 → 불가
- **`incremental`/`deleteOutDir` 제거**: 증분 캐시 이점을 버리는 과한 대응이고, 원인(캐시 위치)을 그대로 둔다

## 검증

- `rm -rf dist` 후 연속 3회 빌드 → 모두 396개 + `dist/main.js` 생성, 루트 tsbuildinfo 미생성
- `yarn start:dev` → `MODULE_NOT_FOUND` 없이 `bootstrap` 도달
- `yarn validate` 통과 (207 suites / 1774 tests)

## 후속

회귀 방지 가드(설정 불변식 spec + CI 이중 빌드)는 별도 PR로 분리한다.