### PR TITLE
test(build): 빌드 설정 불변식 회귀 가드 spec

### DIFF
--- a/src/test/build-config.spec.ts
+++ b/src/test/build-config.spec.ts
@@ -67,4 +67,16 @@ describe('빌드 설정 불변식 (tsconfig.build.json × nest-cli.json)', () =>
       path.join('dist', 'main.js'),
     );
   });
+
+  it('빌드 설정이 .js를 실제로 방출하도록 되어 있다', () => {
+    const { options } = parseBuildTsconfig();
+
+    // 왜: 위 두 단언은 "설정상 어디로 나가야 하는가"만 본다. noEmit이나
+    // emitDeclarationOnly가 켜지면 getOutputFileNames는 이론상 경로를 그대로
+    // 돌려주므로 단언은 통과하는데 nest build는 exit 0으로 아무것도(또는 .d.ts만)
+    // 내보내지 않는다. 실측: noEmit → .js 0개, emitDeclarationOnly → .js 0개
+    // /.d.ts 396개. 둘 다 dist/main.js 부재로 이어지므로 함께 막는다.
+    expect(options.noEmit ?? false).toBe(false);
+    expect(options.emitDeclarationOnly ?? false).toBe(false);
+  });
 });

--- a/src/test/build-config.spec.ts
+++ b/src/test/build-config.spec.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+import * as ts from 'typescript';
+
+// 빌드 툴체인 설정(tsconfig.build.json × nest-cli.json)의 불변식을 고정한다.
+// 이 조합은 다른 게이트가 전부 비껴간다 — tsc --noEmit은 tsconfig.json을 읽고,
+// jest는 ts-jest로 자체 변환하며, CI 빌드는 clean 체크아웃 1회라 증분 캐시
+// 오염을 재현하지 못한다. 그래서 설정 자체를 단언 대상으로 삼는다.
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BUILD_TSCONFIG = path.join(REPO_ROOT, 'tsconfig.build.json');
+const NEST_CLI = path.join(REPO_ROOT, 'nest-cli.json');
+
+type NestCliJson = { compilerOptions?: { deleteOutDir?: boolean } };
+
+function parseBuildTsconfig(): ts.ParsedCommandLine {
+  const read = ts.readConfigFile(BUILD_TSCONFIG, ts.sys.readFile);
+  expect(read.error).toBeUndefined();
+
+  return ts.parseJsonConfigFileContent(
+    read.config,
+    ts.sys,
+    REPO_ROOT,
+    undefined,
+    BUILD_TSCONFIG,
+  );
+}
+
+describe('빌드 설정 불변식 (tsconfig.build.json × nest-cli.json)', () => {
+  it('deleteOutDir·incremental 동시 활성 시 tsbuildinfo는 outDir 안에 생성된다', () => {
+    const nestCli = JSON.parse(readFileSync(NEST_CLI, 'utf8')) as NestCliJson;
+    const { options } = parseBuildTsconfig();
+
+    // 아래 단언의 전제. 셋 중 하나라도 꺼지면 이 불변식 자체가 무의미해지므로
+    // 조용히 통과시키지 않고 전제가 깨진 사실을 드러낸다.
+    expect(nestCli.compilerOptions?.deleteOutDir).toBe(true);
+    expect(options.incremental).toBe(true);
+    expect(options.outDir).toBeDefined();
+
+    const buildInfo = ts.getTsBuildInfoEmitOutputFilePath(options);
+    expect(buildInfo).toBeDefined();
+
+    // 왜: buildinfo가 outDir 밖이면 deleteOutDir이 dist만 지우고 캐시는 살아남는다.
+    // tsc가 그 캐시를 보고 "전부 최신"으로 오판해 emit을 통째로 건너뛰고,
+    // dist/main.js가 없는 채 "Found 0 errors"만 출력된다 → 실행 시 MODULE_NOT_FOUND.
+    // rootDir 지정만으로 buildinfo가 루트로 밀려났던 회귀 이력이 있다(PR #60).
+    const relativeToOutDir = path.relative(
+      String(options.outDir),
+      String(buildInfo),
+    );
+    expect(relativeToOutDir.startsWith('..')).toBe(false);
+  });
+
+  it('src/main.ts는 dist/main.js로 출력된다', () => {
+    const parsed = parseBuildTsconfig();
+    const [jsOutput] = ts.getOutputFileNames(
+      parsed,
+      path.join(REPO_ROOT, 'src', 'main.ts'),
+      false,
+    );
+
+    // 왜: ecosystem.config.js(script: dist/main.js)와 start:prod(node dist/main)가
+    // 이 경로에 묶여 있다. rootDir/include가 흔들리면 공통 루트가 프로젝트 루트로
+    // 올라가 dist/src/main.js로 밀리고 PM2 부팅이 깨진다(회귀 이력: c43b5ba).
+    expect(path.relative(REPO_ROOT, jsOutput)).toBe(
+      path.join('dist', 'main.js'),
+    );
+  });
+});


### PR DESCRIPTION
## 배경

PR #259(tsbuildinfo가 dist 밖에 생성돼 재빌드 시 `dist/main.js` 증발)가 8일간 발견되지 않은 이유는 **빌드 툴체인 설정을 검증하는 게이트가 없었기 때문**이다.

| 기존 게이트 | 못 잡은 이유 |
| --- | --- |
| `npx tsc --noEmit` | `tsconfig.json`을 읽는다 — `tsconfig.build.json`이 실행 경로에 없음. `--noEmit`이라 emit 스킵 자체가 관측 불가 |
| `yarn test:cov` | ts-jest 자체 변환 — `nest build` 경로 미사용 |
| `yarn build` (CI) | **clean 체크아웃 1회 빌드** — stale 캐시가 존재할 수 없음 |
| `arch:check` / `dto:check` | 소스 의존성·SDL 대상. 빌드 산출물과 무관 |

이 버그는 **"직전 빌드 흔적이 남아 있을 때만" 발현**하는데 CI는 정의상 항상 clean이다. 그래서 설정 자체를 단언 대상으로 삼는다.

## 변경

`src/test/build-config.spec.ts` — 순수 단위, DB 불필요, 1.6초.

- **tsbuildinfo가 `outDir` 안인지** — `ts.getTsBuildInfoEmitOutputFilePath`로 TS에게 직접 경로를 묻는다. 경로 규칙을 재구현하지 않으므로 TS 버전이 올라가 알고리즘이 바뀌어도 따라간다.
- **`src/main.ts` → `dist/main.js`** — `ts.getOutputFileNames`. `ecosystem.config.js`(`script: 'dist/main.js'`)와 `start:prod`가 이 경로에 묶여 있어, `rootDir`/`include`가 흔들리면 `dist/src/main.js`로 밀려 PM2 부팅이 깨진다(이력: `c43b5ba`).

두 API 모두 `typescript.d.ts`에 정식 선언된 공개 API다.

## 가드가 실제로 동작하는지 확인

장식이 아님을 회귀 재현으로 증명했다.

| 재현한 상태 | 결과 |
| --- | --- |
| 수정 적용 (현재) | 2 passed |
| `tsBuildInfoFile` 제거 (#259 버그) | `Expected: false / Received: true` 로 실패 |
| `rootDir` 제거 (`c43b5ba` 회귀) | `Expected: "dist/main.js" / Received: "dist/src/main.js"` 로 실패 |

## 이 PR에서 빠진 것

**CI 연속 2회 빌드 가드(층 2)** 를 함께 넣으려 했으나, 현재 토큰에 `workflow` 스코프가 없어 `.github/workflows/pr-check.yml` push가 거부됐다(`refusing to allow an OAuth App to create or update workflow ... without workflow scope`).

정적 단언만으로는 assets 글롭·`nest-cli.json` 조합 회귀를 못 잡으므로 후속으로 반영이 필요하다. 변경 내용은 검증까지 마쳐 패치로 보관해 뒀다(`docs/ci-double-build.patch`, gitignore 대상). 실측 추가 비용 약 7초.

## 판단 기록

- **로컬 `yarn validate`에는 build를 넣지 않는다** — `start:dev` 중 `dist`를 덮어써 개발 흐름을 방해한다. CI 전용으로 둔다.
- **커버리지 임계 영향 없음** — 신규 spec은 src 코드를 import하지 않고 `collectCoverageFrom`이 `test/**`를 제외한다.

## 검증

`yarn validate` 통과 (208 suites / 1776 tests).