### PR TITLE
ci: Build 단계를 연속 2회 빌드로 바꿔 증분 캐시 오염 회귀 검출

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -67,10 +67,16 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-      - name: Build
+      - name: Build (연속 2회 — 증분 캐시 오염 회귀 검출)
         run: |
           yarn graphql:docs
           yarn build
+          # 왜 2회인가: deleteOutDir이 dist를 지우는데 tsbuildinfo가 dist 밖에 있으면
+          # 캐시만 살아남아 tsc가 "전부 최신"으로 오판, emit을 건너뛰고 dist가 빈 채로
+          # 남는다. clean 체크아웃 1회 빌드로는 이 상태가 재현되지 않아 PR #259 회귀가
+          # 8일간 CI를 그대로 통과했다. 2회차가 그 상태를 만들어 준다.
+          yarn build
+          test -f dist/main.js
 
   coverage-report:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
빌드 회귀 가드 2층 중 **층 2**. 층 1(설정 불변식 spec)은 #260으로 머지됨.

## 배경

PR #259(tsbuildinfo가 dist 밖에 생성돼 재빌드 시 `dist/main.js` 증발)가 8일간 CI를 그대로 통과한 이유는 Build 단계가 **clean 체크아웃에서 1회만 빌드**하기 때문이다.

이 버그는 *"직전 빌드 흔적이 남아 있을 때만"* 발현하는데 CI는 정의상 항상 clean이다. 그 상태를 명시적으로 만들어주지 않으면 원리상 재현되지 않는다.

## 왜 #260만으로 부족한가

#260이 설정 불변식을 spec으로 고정했지만 정적 단언에는 한계가 있다. #260 리뷰에서 Codex가 짚었듯 `getOutputFileNames`는 `noEmit`이 켜져 있어도 이론상 경로를 그대로 반환한다 — 그 구멍은 단언 추가로 막았지만, **설정을 아무리 검사해도 실제 산출물을 보는 것만 못하다**는 한계 자체는 남는다.

층 2는 진짜 빌드를 돌려 산출물 실존을 확인하므로, 아직 예상하지 못한 실패 모드(assets 글롭, `nest-cli.json` 조합 등)까지 커버한다.

## 변경

```yaml
- name: Build (연속 2회 — 증분 캐시 오염 회귀 검출)
  run: |
    yarn graphql:docs
    yarn build
    yarn build          # 2회차가 "캐시가 남은 상태"를 성립시킨다
    test -f dist/main.js
```

실측 추가 비용 **약 7초**(1회차 7초 / 2회차 6초, job timeout 10분).

## 가드가 실제로 동작하는지 확인

CI 단계 시퀀스를 로컬에서 그대로 재현했다.

| 상태 | 결과 |
| --- | --- |
| 현재 (수정 적용) | PASS — .js 396개 |
| `tsBuildInfoFile` 제거 (#259 버그 재현) | **FAIL — `dist/main.js` 없음, .js 0개** |
| 복원 후 | PASS — .js 396개 |

## 판단 기록

- **로컬 `yarn validate`에는 넣지 않는다** — `start:dev` 중 `dist`를 덮어써 개발 흐름을 방해한다. CI 전용.
- `yarn build` 중복은 오타가 아니라 의도다. 다음 사람이 군더더기로 보고 지우지 않도록 워크플로에 이유를 주석으로 남겼다.