### PR TITLE
chore: knip 미사용 배럴 export 정리 (ProductSearchScope·StoreSearchScope)

### DIFF
--- a/src/features/product/index.ts
+++ b/src/features/product/index.ts
@@ -15,7 +15,4 @@ export { toHomeBanner } from '@/features/product/services/product-home-mappers.h
 export type { RealtimeBestCakesResult } from '@/features/product/types/product-best-seller-output.type';
 export type { HomeBanner } from '@/features/product/types/product-home-output.type';
 // 검색 요약(search feature)의 상품 건수. 검색 조건은 product feature의 where 빌더가 단일 소스.
-export {
-  ProductSearchService,
-  type ProductSearchScope,
-} from '@/features/product/services/product-search.service';
+export { ProductSearchService } from '@/features/product/services/product-search.service';

--- a/src/features/store/index.ts
+++ b/src/features/store/index.ts
@@ -12,7 +12,4 @@ export { buildRegionLabel } from '@/features/store/services/store-mappers.helper
 export { StorePickupScheduleService } from '@/features/store/services/store-pickup-schedule.service';
 export { scoreAndSortByPopularity } from '@/features/store/services/store-ranking.helper';
 // 검색 요약(search feature)의 매장 건수. 검색 조건은 store feature의 where 빌더가 단일 소스.
-export {
-  StoreSearchService,
-  type StoreSearchScope,
-} from '@/features/store/services/store-search.service';
+export { StoreSearchService } from '@/features/store/services/store-search.service';


### PR DESCRIPTION
knip 리포트 3건 중 2건 반영. 나머지 1건은 근거를 남기고 미반영.

## 반영 — 미사용 배럴 re-export 2건

`ProductSearchScope`·`StoreSearchScope`는 각 feature 내부에서 `countProducts`·`countStores`의 파라미터 타입으로만 쓰인다. 유일한 cross-feature 호출부인 `search-result.service.ts:26-27`은 객체 리터럴을 넘기는 구조적 타이핑이라 타입 import가 필요 없다.

인터페이스 자체는 서비스 파일에 유지하고 **배럴 노출만** 걷어냈다.

- `src/features/product/index.ts` — `type ProductSearchScope` re-export 제거
- `src/features/store/index.ts` — `type StoreSearchScope` re-export 제거

## 미반영 — Duplicate exports

`KEYWORD_RANK_SNAPSHOT_SIZE` | `MAX_POPULAR_KEYWORDS_LIMIT`. 값이 같을 뿐 **의미가 다른 두 상수**다.

| 상수 | 의미 | 사용처 |
| --- | --- | --- |
| `KEYWORD_RANK_SNAPSHOT_SIZE` | 스냅샷당 저장 순위 수 | repository 슬라이싱, 집계 limit |
| `MAX_POPULAR_KEYWORDS_LIMIT` | `popularSearchKeywords`의 limit 입력 상한 | DTO `@Max`, 서비스 |

`MAX = SNAPSHOT_SIZE`는 우연한 중복이 아니라 *"저장한 것보다 많이 반환할 수 없다"* 는 파생 관계를 매직넘버 20 대신 명시한 것이다. 합치면 DTO가 `SNAPSHOT_SIZE`라는 이름으로 API 상한을 검증하게 돼 호출부 의미가 어긋나고, 스냅샷 크기만 바꾸려 할 때 API 계약이 조용히 따라 움직인다.

## 검증

`yarn knip` 잔여 1건(위 duplicate만), `yarn validate` 통과 (208 suites / 1777 tests).