### PR TITLE
chore: 릴리즈 — 빌드 산출물 증발 수정과 회귀 가드 2층, knip 정리

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -67,10 +67,16 @@ jobs:
           fail_ci_if_error: true
           verbose: true
 
-      - name: Build
+      - name: Build (연속 2회 — 증분 캐시 오염 회귀 검출)
         run: |
           yarn graphql:docs
           yarn build
+          # 왜 2회인가: deleteOutDir이 dist를 지우는데 tsbuildinfo가 dist 밖에 있으면
+          # 캐시만 살아남아 tsc가 "전부 최신"으로 오판, emit을 건너뛰고 dist가 빈 채로
+          # 남는다. clean 체크아웃 1회 빌드로는 이 상태가 재현되지 않아 PR #259 회귀가
+          # 8일간 CI를 그대로 통과했다. 2회차가 그 상태를 만들어 준다.
+          yarn build
+          test -f dist/main.js
 
   coverage-report:
     if: github.event_name == 'pull_request'

--- a/src/features/product/index.ts
+++ b/src/features/product/index.ts
@@ -15,7 +15,4 @@ export { toHomeBanner } from '@/features/product/services/product-home-mappers.h
 export type { RealtimeBestCakesResult } from '@/features/product/types/product-best-seller-output.type';
 export type { HomeBanner } from '@/features/product/types/product-home-output.type';
 // 검색 요약(search feature)의 상품 건수. 검색 조건은 product feature의 where 빌더가 단일 소스.
-export {
-  ProductSearchService,
-  type ProductSearchScope,
-} from '@/features/product/services/product-search.service';
+export { ProductSearchService } from '@/features/product/services/product-search.service';

--- a/src/features/store/index.ts
+++ b/src/features/store/index.ts
@@ -12,7 +12,4 @@ export { buildRegionLabel } from '@/features/store/services/store-mappers.helper
 export { StorePickupScheduleService } from '@/features/store/services/store-pickup-schedule.service';
 export { scoreAndSortByPopularity } from '@/features/store/services/store-ranking.helper';
 // 검색 요약(search feature)의 매장 건수. 검색 조건은 store feature의 where 빌더가 단일 소스.
-export {
-  StoreSearchService,
-  type StoreSearchScope,
-} from '@/features/store/services/store-search.service';
+export { StoreSearchService } from '@/features/store/services/store-search.service';

--- a/src/test/build-config.spec.ts
+++ b/src/test/build-config.spec.ts
@@ -67,4 +67,16 @@ describe('빌드 설정 불변식 (tsconfig.build.json × nest-cli.json)', () =>
       path.join('dist', 'main.js'),
     );
   });
+
+  it('빌드 설정이 .js를 실제로 방출하도록 되어 있다', () => {
+    const { options } = parseBuildTsconfig();
+
+    // 왜: 위 두 단언은 "설정상 어디로 나가야 하는가"만 본다. noEmit이나
+    // emitDeclarationOnly가 켜지면 getOutputFileNames는 이론상 경로를 그대로
+    // 돌려주므로 단언은 통과하는데 nest build는 exit 0으로 아무것도(또는 .d.ts만)
+    // 내보내지 않는다. 실측: noEmit → .js 0개, emitDeclarationOnly → .js 0개
+    // /.d.ts 396개. 둘 다 dist/main.js 부재로 이어지므로 함께 막는다.
+    expect(options.noEmit ?? false).toBe(false);
+    expect(options.emitDeclarationOnly ?? false).toBe(false);
+  });
 });

--- a/src/test/build-config.spec.ts
+++ b/src/test/build-config.spec.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+import * as ts from 'typescript';
+
+// 빌드 툴체인 설정(tsconfig.build.json × nest-cli.json)의 불변식을 고정한다.
+// 이 조합은 다른 게이트가 전부 비껴간다 — tsc --noEmit은 tsconfig.json을 읽고,
+// jest는 ts-jest로 자체 변환하며, CI 빌드는 clean 체크아웃 1회라 증분 캐시
+// 오염을 재현하지 못한다. 그래서 설정 자체를 단언 대상으로 삼는다.
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BUILD_TSCONFIG = path.join(REPO_ROOT, 'tsconfig.build.json');
+const NEST_CLI = path.join(REPO_ROOT, 'nest-cli.json');
+
+type NestCliJson = { compilerOptions?: { deleteOutDir?: boolean } };
+
+function parseBuildTsconfig(): ts.ParsedCommandLine {
+  const read = ts.readConfigFile(BUILD_TSCONFIG, ts.sys.readFile);
+  expect(read.error).toBeUndefined();
+
+  return ts.parseJsonConfigFileContent(
+    read.config,
+    ts.sys,
+    REPO_ROOT,
+    undefined,
+    BUILD_TSCONFIG,
+  );
+}
+
+describe('빌드 설정 불변식 (tsconfig.build.json × nest-cli.json)', () => {
+  it('deleteOutDir·incremental 동시 활성 시 tsbuildinfo는 outDir 안에 생성된다', () => {
+    const nestCli = JSON.parse(readFileSync(NEST_CLI, 'utf8')) as NestCliJson;
+    const { options } = parseBuildTsconfig();
+
+    // 아래 단언의 전제. 셋 중 하나라도 꺼지면 이 불변식 자체가 무의미해지므로
+    // 조용히 통과시키지 않고 전제가 깨진 사실을 드러낸다.
+    expect(nestCli.compilerOptions?.deleteOutDir).toBe(true);
+    expect(options.incremental).toBe(true);
+    expect(options.outDir).toBeDefined();
+
+    const buildInfo = ts.getTsBuildInfoEmitOutputFilePath(options);
+    expect(buildInfo).toBeDefined();
+
+    // 왜: buildinfo가 outDir 밖이면 deleteOutDir이 dist만 지우고 캐시는 살아남는다.
+    // tsc가 그 캐시를 보고 "전부 최신"으로 오판해 emit을 통째로 건너뛰고,
+    // dist/main.js가 없는 채 "Found 0 errors"만 출력된다 → 실행 시 MODULE_NOT_FOUND.
+    // rootDir 지정만으로 buildinfo가 루트로 밀려났던 회귀 이력이 있다(PR #60).
+    const relativeToOutDir = path.relative(
+      String(options.outDir),
+      String(buildInfo),
+    );
+    expect(relativeToOutDir.startsWith('..')).toBe(false);
+  });
+
+  it('src/main.ts는 dist/main.js로 출력된다', () => {
+    const parsed = parseBuildTsconfig();
+    const [jsOutput] = ts.getOutputFileNames(
+      parsed,
+      path.join(REPO_ROOT, 'src', 'main.ts'),
+      false,
+    );
+
+    // 왜: ecosystem.config.js(script: dist/main.js)와 start:prod(node dist/main)가
+    // 이 경로에 묶여 있다. rootDir/include가 흔들리면 공통 루트가 프로젝트 루트로
+    // 올라가 dist/src/main.js로 밀리고 PM2 부팅이 깨진다(회귀 이력: c43b5ba).
+    expect(path.relative(REPO_ROOT, jsOutput)).toBe(
+      path.join('dist', 'main.js'),
+    );
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     // TS 6부터 출력 레이아웃 기준 디렉터리 명시 필수(TS5011). 기존 공통 소스
     // 디렉터리와 동일한 ./src라 dist 산출 구조는 변하지 않는다.
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // rootDir 지정 시 TS는 tsbuildinfo 경로를 resolve(outDir, relative(rootDir, config))로
+    // 계산해 dist 밖(루트)에 만든다. 그러면 deleteOutDir이 dist만 지우고 캐시는 살아남아
+    // tsc가 "전부 최신"으로 오판 → emit 0건 → dist/main.js가 사라진다. dist 안으로 고정해
+    // 캐시가 산출물과 같은 생명주기를 갖게 한다.
+    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]


### PR DESCRIPTION
develop → main. PR 4건.

## 무엇을 고쳤나

로컬에서 **두 번째 빌드부터 `dist/main.js`가 사라져** `yarn start:dev`가 `Found 0 errors` 직후 `MODULE_NOT_FOUND`로 죽는 버그.

`tsconfig.build.json`의 `rootDir` 때문에 TS가 증분 캐시를 **`dist` 밖**에 만들고 있었다.

```
resolve("./dist", relative("./src", "./tsconfig.build")) = ./tsconfig.build.tsbuildinfo
```

`deleteOutDir`이 `dist`를 지워도 캐시는 생존 → tsc가 "전부 최신"으로 오판 → **emit 0건**.

| 상황 | 생성된 .js |
| --- | --- |
| clean 빌드 | 396 |
| 무수정 재빌드 | 0 |
| 파일 1개 수정 후 재빌드 | 1 |

`1866d69`(TS 5.9 → 6.0, TS5011 대응으로 `rootDir` 추가)부터 8일간 잠복. **CI/배포는 무관** — clean 체크아웃 1회 빌드라 구조적으로 재현되지 않았고, 그래서 머지 게이트를 그대로 통과했다. 영향은 로컬 개발 한정.

## 포함된 PR

| PR | 내용 |
| --- | --- |
| #259 | `tsBuildInfoFile`을 `dist` 안으로 고정 — 캐시가 산출물과 같은 생명주기를 갖게 한다 |
| #260 | 회귀 가드 층 1 — 설정 불변식 spec (순수 단위, 1.6초) |
| #261 | 회귀 가드 층 2 — CI 연속 2회 빌드 + `test -f dist/main.js` |
| #262 | knip 미사용 배럴 export 2건 정리 |

## 대안 검토 (#259)

- **`rootDir` 제거**: `c43b5ba`가 고쳤던 `dist/src/main.js` 레이아웃 회귀(PM2 부팅 실패)가 재발함을 실측 확인 → 불가
- **`incremental`/`deleteOutDir` 제거**(제보자 요청안): 증분 캐시 이점을 버리는 과한 대응이고 원인(캐시 위치)을 그대로 둔다

## 왜 가드를 2층으로 뒀나

이 버그가 8일간 안 걸린 건 우연이 아니라 **빌드 툴체인 설정을 검증하는 게이트가 없었기 때문**이다. `tsc --noEmit`은 `tsconfig.json`을 읽어 `tsconfig.build.json`을 건드리지 않고, jest는 ts-jest로 자체 변환하며, CI 빌드는 항상 clean이다.

- **층 1**(#260)은 TS 공개 API(`getTsBuildInfoEmitOutputFilePath`·`getOutputFileNames`)로 **경로 규칙을 재구현하지 않고 TS에게 직접 묻는다** — TS 버전이 올라가 알고리즘이 바뀌어도 따라간다.
- **층 2**(#261)는 실제 산출물을 본다. #260 리뷰에서 Codex가 짚었듯 정적 단언에는 한계가 있다(`noEmit`이 켜지면 `getOutputFileNames`는 이론상 경로를 그대로 반환한다). 그 구멍은 단언 추가로 막았지만, 산출물 기반 검증이 별도로 필요하다.

가드가 막는 회귀 4종을 **각각 재현해 빨간불이 뜨는 것까지 확인**했다: tsbuildinfo 위치 / `dist/main.js` 레이아웃 / `noEmit` / `emitDeclarationOnly`.

## 리스크

- **런타임 코드 변경 없음.** #259는 빌드 설정 1줄, #260은 테스트 추가, #261은 CI 설정, #262는 미사용 타입 re-export 제거(인터페이스 자체는 유지, 호출부는 구조적 타이핑이라 영향 없음).
- CI `check` job 추가 비용 약 7초(실측). #261 머지 시 실제 CI에서 26초/success로 동작 확인 완료.
- 배포(`deploy.yml`)는 수동 dispatch이고 현재 EC2/RDS 비활성이라 이번 릴리즈로 배포가 트리거되지 않는다.

## 검증

`yarn validate` 통과 (208 suites / 1777 tests). 4개 PR 모두 필수 체크 전부 pass + Codex 👍로 머지됨.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **빌드 및 품질 개선**
  * 빌드 결과가 `dist/main.js`로 정상 생성되는지 자동 검증합니다.
  * 증분 빌드 캐시가 출력 디렉터리에 생성되도록 빌드 구성을 개선했습니다.
  * 빌드 설정의 JavaScript 출력 및 경로 구성을 자동 테스트합니다.

* **API 정리**
  * 상품 및 매장 검색 범위 타입의 외부 재노출을 제거해 공개 API를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->