### PR TITLE
fix(product): 배너 PRODUCT 링크에 소속 매장 ID(linkProductStoreId) 추가

### DIFF
--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -66,7 +66,9 @@ type HomeBanner {
   linkUrl: String
   """linkType=PRODUCT일 때 상품 ID."""
   linkProductId: ID
-  """linkType=STORE일 때 매장 ID."""
+  """linkType=PRODUCT일 때 상품의 소속 매장 ID(상세 URL 구성용: /store/{linkProductStoreId}/products/{linkProductId})."""
+  linkProductStoreId: ID
+  """linkType=STORE일 때 이동 대상 매장 ID."""
   linkStoreId: ID
   """linkType=CATEGORY일 때 카테고리 ID(FE 카테고리 자동선택 이동)."""
   linkCategoryId: ID

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -68,6 +68,8 @@ export interface HomeBannerRow {
   link_type: BannerLinkType;
   link_url: string | null;
   link_product_id: bigint | null;
+  /** linkType=PRODUCT 상세 URL 구성용 소속 매장. 그 외 linkType이면 null. */
+  link_product: { store_id: bigint } | null;
   link_store_id: bigint | null;
   link_category_id: bigint | null;
 }
@@ -1299,6 +1301,10 @@ export class ProductRepository {
         link_type: true,
         link_url: true,
         link_product_id: true,
+        // 상세 URL(/store/{storeId}/products/{id}) 구성용 소속 매장 —
+        // where가 link_product를 visibleWhere + store: visibleWhere로 이미 게이트하므로
+        // nested select에 활성 조건을 중복하지 않는다.
+        link_product: { select: { store_id: true } },
         link_store_id: true,
         link_category_id: true,
       },

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -17,6 +17,7 @@ export function toHomeBanner(row: HomeBannerRow): HomeBanner {
     linkType: row.link_type,
     linkUrl: row.link_url,
     linkProductId: row.link_product_id?.toString() ?? null,
+    linkProductStoreId: row.link_product?.store_id.toString() ?? null,
     linkStoreId: row.link_store_id?.toString() ?? null,
     linkCategoryId: row.link_category_id?.toString() ?? null,
   };

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -269,6 +269,31 @@ describe('ProductHomeService (real DB)', () => {
       });
     });
 
+    // FE 상품 상세 경로가 /store/{storeId}/products/{productId}라 소속 매장 ID가 없으면
+    // PRODUCT 링크 배너의 이동 경로를 조립할 수 없다
+    it('PRODUCT 링크 배너는 상품의 소속 매장 ID를 함께 반환한다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/product-banner.png',
+          link_type: 'PRODUCT',
+          link_product_id: product.id,
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner).toMatchObject({
+        linkType: 'PRODUCT',
+        linkProductId: product.id.toString(),
+        linkProductStoreId: store.id.toString(),
+        // STORE 이동 목적지 필드는 PRODUCT 링크에서 비어 있어야 한다(용도 구분)
+        linkStoreId: null,
+      });
+    });
+
     it('categoryId 미지정(전체 칩) 시 HOME_MAIN 배너를 반환한다', async () => {
       await prisma.banner.create({
         data: {
@@ -287,6 +312,8 @@ describe('ProductHomeService (real DB)', () => {
         title: '메인 배너',
         linkType: 'URL',
         linkUrl: 'https://event.caquick.dev',
+        linkProductId: null,
+        linkProductStoreId: null,
         linkCategoryId: null,
       });
     });

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -10,6 +10,7 @@ export interface HomeBanner {
   linkType: 'NONE' | 'URL' | 'PRODUCT' | 'STORE' | 'CATEGORY';
   linkUrl: string | null;
   linkProductId: string | null;
+  linkProductStoreId: string | null;
   linkStoreId: string | null;
   linkCategoryId: string | null;
 }

--- a/src/features/search/services/search-entry.service.spec.ts
+++ b/src/features/search/services/search-entry.service.spec.ts
@@ -9,6 +9,7 @@ import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
 import {
   createAccount,
+  createProduct,
   createSearchHistory,
   createStore,
 } from '@/test/factories';
@@ -161,6 +162,9 @@ describe('SearchEntryService (real DB)', () => {
       expect(banner).toMatchObject({
         imageUrl: 'https://img/first.png',
         linkType: 'NONE',
+        linkProductId: null,
+        linkProductStoreId: null,
+        linkStoreId: null,
       });
     });
 
@@ -173,6 +177,37 @@ describe('SearchEntryService (real DB)', () => {
       await makeBanner({ link_type: 'STORE', link_store_id: closedStore.id });
 
       expect(await service.searchBanner()).toBeNull();
+    });
+
+    // FE 상품 상세 경로가 /store/{storeId}/products/{productId}라 소속 매장 ID가 없으면
+    // PRODUCT 링크 배너의 이동 경로를 조립할 수 없다
+    it('linkType=PRODUCT 배너는 상품의 소속 매장 ID를 함께 반환한다', async () => {
+      jest.spyOn(clock, 'now').mockReturnValue(now);
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await makeBanner({ link_type: 'PRODUCT', link_product_id: product.id });
+
+      const banner = await service.searchBanner();
+
+      expect(banner).toMatchObject({
+        linkType: 'PRODUCT',
+        linkProductId: product.id.toString(),
+        linkProductStoreId: store.id.toString(),
+        // STORE 이동 목적지 필드는 PRODUCT 링크에서 비어 있어야 한다(용도 구분)
+        linkStoreId: null,
+      });
+    });
+
+    it('linkType=STORE 배너는 linkProductStoreId를 채우지 않는다', async () => {
+      jest.spyOn(clock, 'now').mockReturnValue(now);
+      const store = await createStore(prisma);
+      await makeBanner({ link_type: 'STORE', link_store_id: store.id });
+
+      expect(await service.searchBanner()).toMatchObject({
+        linkType: 'STORE',
+        linkStoreId: store.id.toString(),
+        linkProductStoreId: null,
+      });
     });
   });
 });


### PR DESCRIPTION
## 배경

FE 리포트상 프론트 상품 상세 경로가 `/store/{storeId}/products/{productId}` 형태인데, `searchBanner` 응답에는 `linkProductId`만 있고 `storeId`는 없어 상품 상세 경로를 만들 수 없는 상태였다.

확인 결과 유효한 지적이고 **FE 우회 방법이 없다**:

- `HomeBanner.linkStoreId`는 `linkType=STORE`일 때의 **이동 목적지**이지 상품의 소속 매장이 아니다.
- 셀러 배너 저장 시 `buildBannerLinkFields`(`seller-banner.service.ts:310`)가 linkType에 해당하지 않는 링크 필드를 명시적으로 null로 정리한다 → `link_type='PRODUCT'` 배너의 `link_store_id`는 **항상 null**.
- 같은 레포의 `RandomCake`·`PopularCake`·`ProductSearchItem`·찜/주문 목록은 전부 `storeId`를 함께 내려주고 있다. `RandomCake`는 주석에 경로까지 명시(`"""소속 매장 ID(상세 URL 구성용: /store/{storeId}/products/{id})."""`). **`HomeBanner`만 누락**된 상태였다.

`HomeBanner`는 공용 타입이라 `searchBanner`(검색 진입)와 `popularCakes.banner`(홈 카테고리 배너) 양쪽 모두 동일 결함이었고, 한 번의 수정으로 함께 해결된다.

## 변경

- **SDL** — `HomeBanner.linkProductStoreId: ID` 추가. `linkStoreId` 주석을 "이동 대상 매장 ID"로 다듬어 두 필드의 용도 구분을 명시
- **repository** — `findFirstBanner` select에 `link_product: { select: { store_id: true } }`. `where`가 이미 `link_product`를 `visibleWhere` + `store: visibleWhere`로 게이트하고 있어 조인 추가 비용이 없고, nested select에 활성 조건을 중복하지 않는다
- **mapper** — `toHomeBanner`에서 `row.link_product?.store_id` 매핑
- 마이그레이션 불필요

## 하위 호환

기존 필드 변경·삭제 없이 필드 1개 추가 → **FE 배포 순서 제약 없음**.

## FE 전달 사항

- `HomeBanner.linkProductStoreId: ID` — `linkType === 'PRODUCT'`일 때만 채워짐
- 경로 조립: `` /store/${banner.linkProductStoreId}/products/${banner.linkProductId} ``
- `linkStoreId`는 그대로 `linkType === 'STORE'` 전용(매장 상세 이동) — 용도가 다르니 혼용 금지
- `searchBanner` · `popularCakes.banner` 양쪽 동일 적용

## 테스트

회귀 3건 추가 + 기존 2건 보강:

- `searchBanner`: PRODUCT 링크 시 `linkProductStoreId` 채움 / STORE 링크 시 null
- `popularCakes`: PRODUCT 링크 시 `linkProductStoreId` 채움
- 기존 NONE·URL 배너 케이스에 `linkProductStoreId: null` 검증 보강

`yarn validate` 통과 (208 suites / 1780 tests).