### PR TITLE
chore: 릴리즈 — 배너 PRODUCT 링크 소속 매장 ID 추가

### DIFF
--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -66,7 +66,9 @@ type HomeBanner {
   linkUrl: String
   """linkType=PRODUCT일 때 상품 ID."""
   linkProductId: ID
-  """linkType=STORE일 때 매장 ID."""
+  """linkType=PRODUCT일 때 상품의 소속 매장 ID(상세 URL 구성용: /store/{linkProductStoreId}/products/{linkProductId})."""
+  linkProductStoreId: ID
+  """linkType=STORE일 때 이동 대상 매장 ID."""
   linkStoreId: ID
   """linkType=CATEGORY일 때 카테고리 ID(FE 카테고리 자동선택 이동)."""
   linkCategoryId: ID

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -68,6 +68,8 @@ export interface HomeBannerRow {
   link_type: BannerLinkType;
   link_url: string | null;
   link_product_id: bigint | null;
+  /** linkType=PRODUCT 상세 URL 구성용 소속 매장. 그 외 linkType이면 null. */
+  link_product: { store_id: bigint } | null;
   link_store_id: bigint | null;
   link_category_id: bigint | null;
 }
@@ -1299,6 +1301,10 @@ export class ProductRepository {
         link_type: true,
         link_url: true,
         link_product_id: true,
+        // 상세 URL(/store/{storeId}/products/{id}) 구성용 소속 매장 —
+        // where가 link_product를 visibleWhere + store: visibleWhere로 이미 게이트하므로
+        // nested select에 활성 조건을 중복하지 않는다.
+        link_product: { select: { store_id: true } },
         link_store_id: true,
         link_category_id: true,
       },

--- a/src/features/product/services/product-home-mappers.helper.spec.ts
+++ b/src/features/product/services/product-home-mappers.helper.spec.ts
@@ -1,0 +1,97 @@
+import type { HomeBannerRow } from '@/features/product/repositories/product.repository';
+import { toHomeBanner } from '@/features/product/services/product-home-mappers.helper';
+
+// 모든 링크 필드가 채워진 stale row — Banner 스키마에 상호 배타 제약이 없어
+// 시드·수동 DB·향후 어드민 경로로 실제 발생 가능한 형태다.
+function makeBannerRow(o: Partial<HomeBannerRow> = {}): HomeBannerRow {
+  return {
+    id: 1n,
+    image_url: 'https://img/banner.png',
+    title: '배너',
+    link_type: 'NONE',
+    link_url: 'https://event.caquick.dev',
+    link_product_id: 10n,
+    link_product: { store_id: 20n },
+    link_store_id: 30n,
+    link_category_id: 40n,
+    ...o,
+  };
+}
+
+describe('toHomeBanner', () => {
+  it('linkType=NONE이면 stale 링크 값이 남아 있어도 전부 null로 내린다', () => {
+    expect(toHomeBanner(makeBannerRow())).toMatchObject({
+      linkType: 'NONE',
+      linkUrl: null,
+      linkProductId: null,
+      linkProductStoreId: null,
+      linkStoreId: null,
+      linkCategoryId: null,
+    });
+  });
+
+  it('linkType=PRODUCT면 상품 ID와 소속 매장 ID만 채운다', () => {
+    expect(toHomeBanner(makeBannerRow({ link_type: 'PRODUCT' }))).toMatchObject(
+      {
+        linkProductId: '10',
+        linkProductStoreId: '20',
+        linkUrl: null,
+        linkStoreId: null,
+        linkCategoryId: null,
+      },
+    );
+  });
+
+  it('linkType=STORE면 매장 ID만 채운다', () => {
+    expect(toHomeBanner(makeBannerRow({ link_type: 'STORE' }))).toMatchObject({
+      linkStoreId: '30',
+      linkProductId: null,
+      linkProductStoreId: null,
+      linkUrl: null,
+      linkCategoryId: null,
+    });
+  });
+
+  it('linkType=CATEGORY면 카테고리 ID만 채운다', () => {
+    expect(
+      toHomeBanner(makeBannerRow({ link_type: 'CATEGORY' })),
+    ).toMatchObject({
+      linkCategoryId: '40',
+      linkProductId: null,
+      linkProductStoreId: null,
+      linkUrl: null,
+      linkStoreId: null,
+    });
+  });
+
+  it('linkType=URL이면 이동 URL만 채운다', () => {
+    expect(toHomeBanner(makeBannerRow({ link_type: 'URL' }))).toMatchObject({
+      linkUrl: 'https://event.caquick.dev',
+      linkProductId: null,
+      linkProductStoreId: null,
+      linkStoreId: null,
+      linkCategoryId: null,
+    });
+  });
+
+  // link_type과 링크 값이 동시에 비어 있는 정상 row에서도 null 안전해야 한다
+  it('linkType에 대응하는 링크 값이 없으면 null을 반환한다', () => {
+    expect(
+      toHomeBanner(
+        makeBannerRow({
+          link_type: 'PRODUCT',
+          link_product_id: null,
+          link_product: null,
+        }),
+      ),
+    ).toMatchObject({ linkProductId: null, linkProductStoreId: null });
+  });
+
+  it('id·이미지·제목은 그대로 매핑한다', () => {
+    expect(toHomeBanner(makeBannerRow({ id: 7n, title: null }))).toMatchObject({
+      id: '7',
+      imageUrl: 'https://img/banner.png',
+      title: null,
+    });
+  });
+});

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -17,6 +17,7 @@ export function toHomeBanner(row: HomeBannerRow): HomeBanner {
     linkType: row.link_type,
     linkUrl: row.link_url,
     linkProductId: row.link_product_id?.toString() ?? null,
+    linkProductStoreId: row.link_product?.store_id.toString() ?? null,
     linkStoreId: row.link_store_id?.toString() ?? null,
     linkCategoryId: row.link_category_id?.toString() ?? null,
   };

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -9,17 +9,35 @@ import type {
 } from '@/features/product/types/product-home-output.type';
 import { buildRegionLabel } from '@/features/store';
 
+/**
+ * SDL 계약("linkType에 대응하는 링크 필드 하나만 채워진다")을 매퍼에서 강제한다.
+ * Banner 스키마에 링크 필드 상호 배타 제약이 없어 시드·수동 DB·향후 어드민 경로로
+ * stale 값이 남을 수 있고, findFirstBanner의 where도 NONE/URL 배너의 link_*_id는 보지 않아
+ * 그대로 통과한다 — 게이트가 없으면 linkType과 어긋난 링크 필드가 FE로 새어 나간다.
+ */
 export function toHomeBanner(row: HomeBannerRow): HomeBanner {
+  const isProductLink = row.link_type === 'PRODUCT';
+
   return {
     id: row.id.toString(),
     imageUrl: row.image_url,
     title: row.title,
     linkType: row.link_type,
-    linkUrl: row.link_url,
-    linkProductId: row.link_product_id?.toString() ?? null,
-    linkProductStoreId: row.link_product?.store_id.toString() ?? null,
-    linkStoreId: row.link_store_id?.toString() ?? null,
-    linkCategoryId: row.link_category_id?.toString() ?? null,
+    linkUrl: row.link_type === 'URL' ? row.link_url : null,
+    linkProductId: isProductLink
+      ? (row.link_product_id?.toString() ?? null)
+      : null,
+    linkProductStoreId: isProductLink
+      ? (row.link_product?.store_id.toString() ?? null)
+      : null,
+    linkStoreId:
+      row.link_type === 'STORE'
+        ? (row.link_store_id?.toString() ?? null)
+        : null,
+    linkCategoryId:
+      row.link_type === 'CATEGORY'
+        ? (row.link_category_id?.toString() ?? null)
+        : null,
   };
 }
 

--- a/src/features/product/services/product-home.service.spec.ts
+++ b/src/features/product/services/product-home.service.spec.ts
@@ -269,6 +269,31 @@ describe('ProductHomeService (real DB)', () => {
       });
     });
 
+    // FE 상품 상세 경로가 /store/{storeId}/products/{productId}라 소속 매장 ID가 없으면
+    // PRODUCT 링크 배너의 이동 경로를 조립할 수 없다
+    it('PRODUCT 링크 배너는 상품의 소속 매장 ID를 함께 반환한다', async () => {
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await prisma.banner.create({
+        data: {
+          placement: 'HOME_MAIN',
+          image_url: 'https://img/product-banner.png',
+          link_type: 'PRODUCT',
+          link_product_id: product.id,
+        },
+      });
+
+      const result = await service.popularCakes();
+
+      expect(result.banner).toMatchObject({
+        linkType: 'PRODUCT',
+        linkProductId: product.id.toString(),
+        linkProductStoreId: store.id.toString(),
+        // STORE 이동 목적지 필드는 PRODUCT 링크에서 비어 있어야 한다(용도 구분)
+        linkStoreId: null,
+      });
+    });
+
     it('categoryId 미지정(전체 칩) 시 HOME_MAIN 배너를 반환한다', async () => {
       await prisma.banner.create({
         data: {
@@ -287,6 +312,8 @@ describe('ProductHomeService (real DB)', () => {
         title: '메인 배너',
         linkType: 'URL',
         linkUrl: 'https://event.caquick.dev',
+        linkProductId: null,
+        linkProductStoreId: null,
         linkCategoryId: null,
       });
     });

--- a/src/features/product/types/product-home-output.type.ts
+++ b/src/features/product/types/product-home-output.type.ts
@@ -10,6 +10,7 @@ export interface HomeBanner {
   linkType: 'NONE' | 'URL' | 'PRODUCT' | 'STORE' | 'CATEGORY';
   linkUrl: string | null;
   linkProductId: string | null;
+  linkProductStoreId: string | null;
   linkStoreId: string | null;
   linkCategoryId: string | null;
 }

--- a/src/features/search/services/search-entry.service.spec.ts
+++ b/src/features/search/services/search-entry.service.spec.ts
@@ -198,6 +198,28 @@ describe('SearchEntryService (real DB)', () => {
       });
     });
 
+    // Banner 스키마에 링크 필드 상호 배타 제약이 없어 stale 값이 남을 수 있고,
+    // findFirstBanner의 where는 NONE/URL 배너의 link_*_id를 보지 않는다
+    it('linkType=NONE 배너에 stale 링크 값이 남아 있어도 노출하지 않는다', async () => {
+      jest.spyOn(clock, 'now').mockReturnValue(now);
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await makeBanner({
+        link_type: 'NONE',
+        link_url: 'https://stale.caquick.dev',
+        link_product_id: product.id,
+        link_store_id: store.id,
+      });
+
+      expect(await service.searchBanner()).toMatchObject({
+        linkType: 'NONE',
+        linkUrl: null,
+        linkProductId: null,
+        linkProductStoreId: null,
+        linkStoreId: null,
+      });
+    });
+
     it('linkType=STORE 배너는 linkProductStoreId를 채우지 않는다', async () => {
       jest.spyOn(clock, 'now').mockReturnValue(now);
       const store = await createStore(prisma);

--- a/src/features/search/services/search-entry.service.spec.ts
+++ b/src/features/search/services/search-entry.service.spec.ts
@@ -9,6 +9,7 @@ import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
 import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
 import {
   createAccount,
+  createProduct,
   createSearchHistory,
   createStore,
 } from '@/test/factories';
@@ -161,6 +162,9 @@ describe('SearchEntryService (real DB)', () => {
       expect(banner).toMatchObject({
         imageUrl: 'https://img/first.png',
         linkType: 'NONE',
+        linkProductId: null,
+        linkProductStoreId: null,
+        linkStoreId: null,
       });
     });
 
@@ -173,6 +177,37 @@ describe('SearchEntryService (real DB)', () => {
       await makeBanner({ link_type: 'STORE', link_store_id: closedStore.id });
 
       expect(await service.searchBanner()).toBeNull();
+    });
+
+    // FE 상품 상세 경로가 /store/{storeId}/products/{productId}라 소속 매장 ID가 없으면
+    // PRODUCT 링크 배너의 이동 경로를 조립할 수 없다
+    it('linkType=PRODUCT 배너는 상품의 소속 매장 ID를 함께 반환한다', async () => {
+      jest.spyOn(clock, 'now').mockReturnValue(now);
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await makeBanner({ link_type: 'PRODUCT', link_product_id: product.id });
+
+      const banner = await service.searchBanner();
+
+      expect(banner).toMatchObject({
+        linkType: 'PRODUCT',
+        linkProductId: product.id.toString(),
+        linkProductStoreId: store.id.toString(),
+        // STORE 이동 목적지 필드는 PRODUCT 링크에서 비어 있어야 한다(용도 구분)
+        linkStoreId: null,
+      });
+    });
+
+    it('linkType=STORE 배너는 linkProductStoreId를 채우지 않는다', async () => {
+      jest.spyOn(clock, 'now').mockReturnValue(now);
+      const store = await createStore(prisma);
+      await makeBanner({ link_type: 'STORE', link_store_id: store.id });
+
+      expect(await service.searchBanner()).toMatchObject({
+        linkType: 'STORE',
+        linkStoreId: store.id.toString(),
+        linkProductStoreId: null,
+      });
     });
   });
 });


### PR DESCRIPTION
## 포함 변경

- #264 `fix(product): 배너 PRODUCT 링크에 소속 매장 ID(linkProductStoreId) 추가`

## 배경

FE 리포트: 상품 상세 경로가 `/store/{storeId}/products/{productId}`인데 `searchBanner` 응답에 `linkProductId`만 있어 경로 조립 불가.

`HomeBanner.linkStoreId`는 `linkType=STORE`일 때의 이동 목적지이지 상품의 소속 매장이 아니고, 셀러 배너 저장 시 linkType에 해당하지 않는 링크 필드가 null로 정리되므로 PRODUCT 배너의 `link_store_id`는 항상 null — FE 우회 불가였다. 레포의 다른 상품 카드 타입(`RandomCake`·`PopularCake`·`ProductSearchItem` 등)은 전부 `storeId`를 함께 내려주고 있어 `HomeBanner`만 누락된 상태였다.

## 변경 요약

- `HomeBanner.linkProductStoreId: ID` 추가 (`searchBanner` · `popularCakes.banner` 양쪽 적용)
- `findFirstBanner` select에 `link_product.store_id` — where가 이미 해당 relation을 게이트해 조인 추가 비용 없음
- `linkStoreId` 주석을 "이동 대상 매장 ID"로 명확화
- 마이그레이션 없음, 기존 필드 변경·삭제 없음 → FE 배포 순서 제약 없음

## 검증

`yarn validate` 통과 (208 suites / 1780 tests), 회귀 3건 추가 + 기존 2건 보강.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 상품 링크형 홈 배너와 검색 배너에서 상품 ID와 함께 소속 매장 ID를 제공합니다.
  - 배너 상품 상세 페이지로 이동할 때 매장 정보가 포함된 URL을 사용할 수 있습니다.
  - 링크 유형에 따라 관련 ID가 올바르게 제공되며, 해당하지 않는 ID는 비워집니다.

- **테스트**
  - 상품, 매장, 링크 없음 유형별 배너 정보 검증을 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->