### PR TITLE
fix(product): 릴리즈 리뷰 반영 — HomeBanner 링크 필드를 linkType 기준으로 게이트

### DIFF
--- a/src/features/product/services/product-home-mappers.helper.spec.ts
+++ b/src/features/product/services/product-home-mappers.helper.spec.ts
@@ -1,0 +1,97 @@
+import type { HomeBannerRow } from '@/features/product/repositories/product.repository';
+import { toHomeBanner } from '@/features/product/services/product-home-mappers.helper';
+
+// 모든 링크 필드가 채워진 stale row — Banner 스키마에 상호 배타 제약이 없어
+// 시드·수동 DB·향후 어드민 경로로 실제 발생 가능한 형태다.
+function makeBannerRow(o: Partial<HomeBannerRow> = {}): HomeBannerRow {
+  return {
+    id: 1n,
+    image_url: 'https://img/banner.png',
+    title: '배너',
+    link_type: 'NONE',
+    link_url: 'https://event.caquick.dev',
+    link_product_id: 10n,
+    link_product: { store_id: 20n },
+    link_store_id: 30n,
+    link_category_id: 40n,
+    ...o,
+  };
+}
+
+describe('toHomeBanner', () => {
+  it('linkType=NONE이면 stale 링크 값이 남아 있어도 전부 null로 내린다', () => {
+    expect(toHomeBanner(makeBannerRow())).toMatchObject({
+      linkType: 'NONE',
+      linkUrl: null,
+      linkProductId: null,
+      linkProductStoreId: null,
+      linkStoreId: null,
+      linkCategoryId: null,
+    });
+  });
+
+  it('linkType=PRODUCT면 상품 ID와 소속 매장 ID만 채운다', () => {
+    expect(toHomeBanner(makeBannerRow({ link_type: 'PRODUCT' }))).toMatchObject(
+      {
+        linkProductId: '10',
+        linkProductStoreId: '20',
+        linkUrl: null,
+        linkStoreId: null,
+        linkCategoryId: null,
+      },
+    );
+  });
+
+  it('linkType=STORE면 매장 ID만 채운다', () => {
+    expect(toHomeBanner(makeBannerRow({ link_type: 'STORE' }))).toMatchObject({
+      linkStoreId: '30',
+      linkProductId: null,
+      linkProductStoreId: null,
+      linkUrl: null,
+      linkCategoryId: null,
+    });
+  });
+
+  it('linkType=CATEGORY면 카테고리 ID만 채운다', () => {
+    expect(
+      toHomeBanner(makeBannerRow({ link_type: 'CATEGORY' })),
+    ).toMatchObject({
+      linkCategoryId: '40',
+      linkProductId: null,
+      linkProductStoreId: null,
+      linkUrl: null,
+      linkStoreId: null,
+    });
+  });
+
+  it('linkType=URL이면 이동 URL만 채운다', () => {
+    expect(toHomeBanner(makeBannerRow({ link_type: 'URL' }))).toMatchObject({
+      linkUrl: 'https://event.caquick.dev',
+      linkProductId: null,
+      linkProductStoreId: null,
+      linkStoreId: null,
+      linkCategoryId: null,
+    });
+  });
+
+  // link_type과 링크 값이 동시에 비어 있는 정상 row에서도 null 안전해야 한다
+  it('linkType에 대응하는 링크 값이 없으면 null을 반환한다', () => {
+    expect(
+      toHomeBanner(
+        makeBannerRow({
+          link_type: 'PRODUCT',
+          link_product_id: null,
+          link_product: null,
+        }),
+      ),
+    ).toMatchObject({ linkProductId: null, linkProductStoreId: null });
+  });
+
+  it('id·이미지·제목은 그대로 매핑한다', () => {
+    expect(toHomeBanner(makeBannerRow({ id: 7n, title: null }))).toMatchObject({
+      id: '7',
+      imageUrl: 'https://img/banner.png',
+      title: null,
+    });
+  });
+});

--- a/src/features/product/services/product-home-mappers.helper.ts
+++ b/src/features/product/services/product-home-mappers.helper.ts
@@ -9,17 +9,35 @@ import type {
 } from '@/features/product/types/product-home-output.type';
 import { buildRegionLabel } from '@/features/store';
 
+/**
+ * SDL 계약("linkType에 대응하는 링크 필드 하나만 채워진다")을 매퍼에서 강제한다.
+ * Banner 스키마에 링크 필드 상호 배타 제약이 없어 시드·수동 DB·향후 어드민 경로로
+ * stale 값이 남을 수 있고, findFirstBanner의 where도 NONE/URL 배너의 link_*_id는 보지 않아
+ * 그대로 통과한다 — 게이트가 없으면 linkType과 어긋난 링크 필드가 FE로 새어 나간다.
+ */
 export function toHomeBanner(row: HomeBannerRow): HomeBanner {
+  const isProductLink = row.link_type === 'PRODUCT';
+
   return {
     id: row.id.toString(),
     imageUrl: row.image_url,
     title: row.title,
     linkType: row.link_type,
-    linkUrl: row.link_url,
-    linkProductId: row.link_product_id?.toString() ?? null,
-    linkProductStoreId: row.link_product?.store_id.toString() ?? null,
-    linkStoreId: row.link_store_id?.toString() ?? null,
-    linkCategoryId: row.link_category_id?.toString() ?? null,
+    linkUrl: row.link_type === 'URL' ? row.link_url : null,
+    linkProductId: isProductLink
+      ? (row.link_product_id?.toString() ?? null)
+      : null,
+    linkProductStoreId: isProductLink
+      ? (row.link_product?.store_id.toString() ?? null)
+      : null,
+    linkStoreId:
+      row.link_type === 'STORE'
+        ? (row.link_store_id?.toString() ?? null)
+        : null,
+    linkCategoryId:
+      row.link_type === 'CATEGORY'
+        ? (row.link_category_id?.toString() ?? null)
+        : null,
   };
 }
 

--- a/src/features/search/services/search-entry.service.spec.ts
+++ b/src/features/search/services/search-entry.service.spec.ts
@@ -198,6 +198,28 @@ describe('SearchEntryService (real DB)', () => {
       });
     });
 
+    // Banner 스키마에 링크 필드 상호 배타 제약이 없어 stale 값이 남을 수 있고,
+    // findFirstBanner의 where는 NONE/URL 배너의 link_*_id를 보지 않는다
+    it('linkType=NONE 배너에 stale 링크 값이 남아 있어도 노출하지 않는다', async () => {
+      jest.spyOn(clock, 'now').mockReturnValue(now);
+      const store = await createStore(prisma);
+      const product = await createProduct(prisma, { store_id: store.id });
+      await makeBanner({
+        link_type: 'NONE',
+        link_url: 'https://stale.caquick.dev',
+        link_product_id: product.id,
+        link_store_id: store.id,
+      });
+
+      expect(await service.searchBanner()).toMatchObject({
+        linkType: 'NONE',
+        linkUrl: null,
+        linkProductId: null,
+        linkProductStoreId: null,
+        linkStoreId: null,
+      });
+    });
+
     it('linkType=STORE 배너는 linkProductStoreId를 채우지 않는다', async () => {
       jest.spyOn(clock, 'now').mockReturnValue(now);
       const store = await createStore(prisma);


### PR DESCRIPTION
릴리즈 PR #265 CodeRabbit 지적 반영. 릴리즈 지적은 main에 직접 커밋하지 않고 develop 경유.

## 지적

> `Banner` 스키마에는 링크 필드의 상호 배타성을 보장하는 제약이 없습니다. `toHomeBanner`는 `link_type`을 확인하지 않으므로, 비상품 링크 행에 `link_product_id`가 남아 있으면 `linkProductStoreId`가 반환되어 GraphQL 계약을 위반합니다.

## 판단 — 유효

SDL이 `"""홈 카테고리 대표 배너. linkType에 대응하는 링크 필드 하나만 채워진다."""`라고 선언하는데 매퍼가 이를 강제하지 않는다.

- 셀러 경로는 `buildBannerLinkFields`가 비활성 링크 필드를 null로 정리하지만, **시드·수동 DB·향후 어드민 경로는 보장 밖**이다.
- `findFirstBanner`의 where는 `link_type in (NONE, URL)` 브랜치에서 `link_*_id`를 전혀 보지 않아 stale 행이 그대로 통과한다.

## 반영 범위 — 지적보다 넓힘

지적은 `linkProductStoreId` 한 필드였으나, 동일한 노출이 `linkUrl`·`linkProductId`·`linkStoreId`·`linkCategoryId`에도 그대로 있다. 신규 필드만 게이트하면 오히려 기존 필드와 동작이 어긋나므로 **매퍼가 자기 계약을 강제하도록 네 필드 전부** `link_type` 기준으로 게이트했다.

## 변경

- `toHomeBanner`: `link_type`에 대응하지 않는 링크 필드는 전부 `null` 반환

동작 변화는 stale 행에 한정 — 정상 행의 응답은 이전과 동일하므로 FE 영향 없음.

## 테스트

회귀 8건 추가:

- `product-home-mappers.helper.spec.ts` **신설**(순수 단위 7건) — 모든 링크 필드가 채워진 stale row를 linkType별로 통과시켜 대응 필드 1개만 남는지 검증
- `searchBanner`: `linkType=NONE` + stale `link_url`/`link_product_id`/`link_store_id` 행이 전부 null로 내려가는지 실DB 경로로 확인

`yarn validate` 통과 (209 suites / 1788 tests).