### PR TITLE
feat(user): 알림센터 알림 탭 대응 — event·연관 정보 노출, 3개월 필터, 커서 전환

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -61,7 +61,7 @@ async function main(): Promise<void> {
     await seedRecentViews(prisma, { users, stores });
 
     log('알림 시드 중...');
-    await seedNotifications(prisma, { users });
+    await seedNotifications(prisma, { users, stores, orders });
 
     log('커스텀 드래프트 시드 중...');
     await seedCustomDrafts(prisma, { users, stores });

--- a/prisma/seed/notifications.ts
+++ b/prisma/seed/notifications.ts
@@ -1,48 +1,95 @@
 /**
- * 시드 알림 (user1, 3건). 읽음 1 / 안읽음 2 → unreadNotificationCount=2.
+ * 시드 알림 (user1, 5건).
+ * - 3개월 내 4건(읽음 1 / 안읽음 3 → unreadNotificationCount=3):
+ *   주문확정·제작완료·픽업완료·리뷰 좋아요 — 알림센터 4종 이벤트 재현.
+ * - 3개월 경과 1건: myNotifications 3개월 노출 필터 검증용(목록·배지에서 제외).
+ * 문구는 notification feature 상수(figma notification-center 톤)와 동일하게 유지.
  */
 import type { PrismaClient } from '@prisma/client';
 
+import type { SeededOrders } from './orders';
+import type { SeededStores } from './stores';
 import type { SeededUser } from './users';
 
 export async function seedNotifications(
   prisma: PrismaClient,
-  ctx: { users: SeededUser[] },
+  ctx: { users: SeededUser[]; stores: SeededStores; orders: SeededOrders },
 ): Promise<void> {
   const user1 = ctx.users[0];
   if (!user1) throw new Error('seedUsers must run before seedNotifications');
+  const [p1, p2, p3] = ctx.stores.products;
+  if (!p1 || !p2 || !p3) {
+    throw new Error('seedStores must run before seedNotifications');
+  }
+
+  // 리뷰 좋아요 알림은 seedReviews가 만든 user1 리뷰(p1, storeA)에 연결한다.
+  const review = await prisma.review.findFirstOrThrow({
+    where: { account_id: user1.id, product_id: p1.id },
+    select: { id: true, store_id: true, product_id: true },
+  });
 
   const now = Date.now();
   const hour = 60 * 60 * 1000;
+  const day = 24 * hour;
 
   await prisma.notification.createMany({
     data: [
       {
         account_id: user1.id,
-        type: 'ORDER_STATUS',
-        event: 'ORDER_CONFIRMED',
-        title: '주문이 확정되었습니다',
-        body: 'SEED-O2-CONF 주문이 확정되었습니다.',
+        type: 'REVIEW_LIKE',
+        event: 'REVIEW_LIKED',
+        title: '리뷰 좋아요',
+        body: '다른 사람이 내가 남긴 리뷰를 좋아했어요.',
+        review_id: review.id,
+        store_id: review.store_id,
+        product_id: review.product_id,
         read_at: null,
         created_at: new Date(now - 1 * hour),
       },
       {
         account_id: user1.id,
         type: 'ORDER_STATUS',
-        event: 'ORDER_MADE',
-        title: '주문이 제작 완료되었습니다',
-        body: 'SEED-O3-MADE 주문의 상품 제작이 완료되었습니다.',
+        event: 'ORDER_CONFIRMED',
+        title: '주문확정',
+        body: 'SEED-O2-CONF 주문이 확정되었어요.',
+        order_id: ctx.orders.o2Confirmed,
+        store_id: p2.store_id,
+        product_id: p2.id,
         read_at: null,
-        created_at: new Date(now - 24 * hour),
+        created_at: new Date(now - 5 * hour),
       },
       {
         account_id: user1.id,
         type: 'ORDER_STATUS',
+        event: 'ORDER_MADE',
+        title: '제작완료',
+        body: 'SEED-O3-MADE 주문하신 케이크 제작이 완료되었어요.',
+        order_id: ctx.orders.o3Made,
+        store_id: p3.store_id,
+        product_id: p3.id,
+        read_at: null,
+        created_at: new Date(now - 1 * day),
+      },
+      {
+        // 연관 ID 미저장 과거 주문 알림 재현 — 조회 시 order.items 폴백 검증용.
+        account_id: user1.id,
+        type: 'ORDER_STATUS',
         event: 'ORDER_PICKED_UP',
-        title: '주문이 픽업 처리되었습니다',
-        body: 'SEED-O4-PICKED-RE 주문이 픽업 완료 처리되었습니다.',
-        read_at: new Date(now - 9 * 24 * hour),
-        created_at: new Date(now - 10 * 24 * hour),
+        title: '픽업완료',
+        body: 'SEED-O4-PICKED-RE 케이크 픽업이 완료되었어요.',
+        order_id: ctx.orders.o4PickedUpReviewed,
+        read_at: new Date(now - 9 * day),
+        created_at: new Date(now - 10 * day),
+      },
+      {
+        // 3개월(+7일) 경과 — 알림센터 목록·배지 어디에도 노출되지 않아야 한다.
+        account_id: user1.id,
+        type: 'ORDER_STATUS',
+        event: 'ORDER_PICKED_UP',
+        title: '픽업완료',
+        body: 'SEED-OLD 케이크 픽업이 완료되었어요.',
+        read_at: null,
+        created_at: new Date(now - 97 * day),
       },
     ],
   });

--- a/src/features/notification/constants/notification-messages.ts
+++ b/src/features/notification/constants/notification-messages.ts
@@ -1,24 +1,32 @@
 import { OrderStatus } from '@prisma/client';
 
-/** 주문 상태별 알림 제목. 매핑이 없는 상태는 알림을 만들지 않는다. */
+/**
+ * 주문 상태별 알림 제목(알림센터 라벨). 매핑이 없는 상태는 알림을 만들지 않는다.
+ * 문구는 figma notification-center 알림 목록 화면 기준.
+ */
 export const ORDER_STATUS_NOTIFICATION_TITLES: Partial<
   Record<OrderStatus, string>
 > = {
-  [OrderStatus.CONFIRMED]: '주문이 확정되었습니다',
-  [OrderStatus.MADE]: '주문이 제작 완료되었습니다',
-  [OrderStatus.PICKED_UP]: '주문이 픽업 처리되었습니다',
+  [OrderStatus.CONFIRMED]: '주문확정',
+  [OrderStatus.MADE]: '제작완료',
+  [OrderStatus.PICKED_UP]: '픽업완료',
 };
 
-/** 주문 상태별 알림 본문. 주문번호를 앞에 붙여 조립한다. */
+/**
+ * 주문 상태별 알림 본문. 주문번호를 앞에 붙여 조립한다.
+ * (figma 알림센터에는 주문번호가 노출되지 않지만, 식별 필요 가능성에 대비해
+ * prefix는 유지한다 — 표시 여부는 FE 판단. 사용자 확정 정책)
+ */
 export const ORDER_STATUS_NOTIFICATION_BODIES: Partial<
   Record<OrderStatus, string>
 > = {
-  [OrderStatus.CONFIRMED]: '주문이 확정되었습니다.',
-  [OrderStatus.MADE]: '주문의 상품 제작이 완료되었습니다.',
-  [OrderStatus.PICKED_UP]: '주문이 픽업 완료 처리되었습니다.',
+  [OrderStatus.CONFIRMED]: '주문이 확정되었어요.',
+  [OrderStatus.MADE]: '주문하신 케이크 제작이 완료되었어요.',
+  [OrderStatus.PICKED_UP]: '케이크 픽업이 완료되었어요.',
 };
 
+// 문구는 figma notification-center 알림 목록 화면 기준.
 export const REVIEW_LIKED_NOTIFICATION = {
-  title: '리뷰에 좋아요가 추가되었습니다',
-  body: '회원님의 리뷰를 다른 사용자가 좋아합니다.',
+  title: '리뷰 좋아요',
+  body: '다른 사람이 내가 남긴 리뷰를 좋아했어요.',
 } as const;

--- a/src/features/notification/services/notification-payloads.helper.spec.ts
+++ b/src/features/notification/services/notification-payloads.helper.spec.ts
@@ -17,8 +17,8 @@ describe('notification-payloads.helper', () => {
       ).toEqual({
         type: NotificationType.ORDER_STATUS,
         event: NotificationEvent.ORDER_CONFIRMED,
-        title: '주문이 확정되었습니다',
-        body: 'ORD-1 주문이 확정되었습니다.',
+        title: '주문확정',
+        body: 'ORD-1 주문이 확정되었어요.',
       });
     });
 
@@ -26,16 +26,16 @@ describe('notification-payloads.helper', () => {
       expect(buildOrderStatusNotification('ORD-2', OrderStatus.MADE)).toEqual({
         type: NotificationType.ORDER_STATUS,
         event: NotificationEvent.ORDER_MADE,
-        title: '주문이 제작 완료되었습니다',
-        body: 'ORD-2 주문의 상품 제작이 완료되었습니다.',
+        title: '제작완료',
+        body: 'ORD-2 주문하신 케이크 제작이 완료되었어요.',
       });
       expect(
         buildOrderStatusNotification('ORD-3', OrderStatus.PICKED_UP),
       ).toEqual({
         type: NotificationType.ORDER_STATUS,
         event: NotificationEvent.ORDER_PICKED_UP,
-        title: '주문이 픽업 처리되었습니다',
-        body: 'ORD-3 주문이 픽업 완료 처리되었습니다.',
+        title: '픽업완료',
+        body: 'ORD-3 케이크 픽업이 완료되었어요.',
       });
     });
 
@@ -54,8 +54,8 @@ describe('notification-payloads.helper', () => {
       expect(buildReviewLikedNotification()).toEqual({
         type: NotificationType.REVIEW_LIKE,
         event: NotificationEvent.REVIEW_LIKED,
-        title: '리뷰에 좋아요가 추가되었습니다',
-        body: '회원님의 리뷰를 다른 사용자가 좋아합니다.',
+        title: '리뷰 좋아요',
+        body: '다른 사람이 내가 남긴 리뷰를 좋아했어요.',
       });
     });
   });

--- a/src/features/order/repositories/order.repository.spec.ts
+++ b/src/features/order/repositories/order.repository.spec.ts
@@ -552,6 +552,9 @@ describe('OrderRepository (real DB)', () => {
       expect(notifications).toHaveLength(1);
       expect(notifications[0].event).toBe('ORDER_CONFIRMED');
       expect(notifications[0].account_id).toBe(buyer.id);
+      // 알림센터 서브라인·딥링크용 연관 ID까지 저장한다
+      expect(notifications[0].store_id).toBe(store.id);
+      expect(notifications[0].product_id).not.toBeNull();
 
       const auditLogs = await prisma.auditLog.findMany({
         where: { target_id: order.id, target_type: 'ORDER' },

--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -720,10 +720,19 @@ export class OrderRepository {
         args.toStatus,
       );
       if (notification) {
+        // 알림센터 서브라인·딥링크용 연관 ID. 주문은 단일 상품 구조라
+        // 첫 item으로 상품이 확정된다(다상품 확장 시 재검토).
+        const firstItem = await tx.orderItem.findFirst({
+          where: { order_id: order.id },
+          orderBy: { id: 'asc' },
+          select: { product_id: true },
+        });
         await tx.notification.create({
           data: {
             account_id: order.account_id,
             order_id: order.id,
+            store_id: args.storeId,
+            product_id: firstItem?.product_id ?? null,
             ...notification,
           },
         });

--- a/src/features/user/constants/user-notification-error-messages.ts
+++ b/src/features/user/constants/user-notification-error-messages.ts
@@ -1,0 +1,5 @@
+export const USER_NOTIFICATION_ERRORS = {
+  NOTIFICATION_NOT_FOUND: 'Notification not found.',
+  // 커서는 "<createdAtMs>:<id>" 불투명 토큰 — 형식이 다르면 클라이언트 버그다.
+  INVALID_CURSOR: 'Invalid notification cursor.',
+} as const;

--- a/src/features/user/constants/user.constants.ts
+++ b/src/features/user/constants/user.constants.ts
@@ -30,3 +30,6 @@ export const MAX_REVIEW_COMMENT_LENGTH = 500;
 // figma notification-center: "최근 3개월 내의 알림만 확인할 수 있어요."
 // 삭제가 아니라 조회 필터로만 강제한다(사용자 확정 정책).
 export const NOTIFICATION_VISIBLE_MONTHS = 3;
+
+// DB UNSIGNED BIGINT 상한(2^64-1). 커서 등 외부 입력 id의 범위 방어에 쓴다.
+export const MAX_UNSIGNED_BIGINT = 18446744073709551615n;

--- a/src/features/user/constants/user.constants.ts
+++ b/src/features/user/constants/user.constants.ts
@@ -24,3 +24,9 @@ export const MAX_PAGINATION_LIMIT = 50;
 // ── 리뷰 댓글 ──
 
 export const MAX_REVIEW_COMMENT_LENGTH = 500;
+
+// ── 알림 ──
+
+// figma notification-center: "최근 3개월 내의 알림만 확인할 수 있어요."
+// 삭제가 아니라 조회 필터로만 강제한다(사용자 확정 정책).
+export const NOTIFICATION_VISIBLE_MONTHS = 3;

--- a/src/features/user/dto/inputs/my-notifications.input.spec.ts
+++ b/src/features/user/dto/inputs/my-notifications.input.spec.ts
@@ -10,25 +10,39 @@ function build(plain: object): MyNotificationsInput {
 }
 
 describe('MyNotificationsInput', () => {
-  it('unreadOnly true 허용', async () => {
-    const dto = build({ unreadOnly: true, offset: 0, limit: 20 });
+  it('unreadOnly·cursor·limit 정상 조합 허용', async () => {
+    const dto = build({ unreadOnly: true, cursor: '123:45', limit: 20 });
     expect(await validate(dto)).toHaveLength(0);
   });
 
-  it('unreadOnly 누락 허용', async () => {
-    const dto = build({ offset: 0, limit: 20 });
+  it('모든 필드 누락 허용(기본값은 서비스가 처리)', async () => {
+    const dto = build({});
     expect(await validate(dto)).toHaveLength(0);
   });
 
   it('unreadOnly 가 boolean 이 아니면 거절', async () => {
-    const dto = build({ unreadOnly: 'yes', offset: 0, limit: 20 });
+    const dto = build({ unreadOnly: 'yes' });
     const errors = await validate(dto);
     expect(errors).toHaveLength(1);
     expect(errors[0].property).toBe('unreadOnly');
   });
 
-  it('상속된 페이지네이션 검증도 적용 (limit > 50)', async () => {
-    const dto = build({ unreadOnly: false, offset: 0, limit: 51 });
+  it('빈 문자열 커서 거절', async () => {
+    const dto = build({ cursor: '' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('cursor');
+  });
+
+  it('limit > 50 거절', async () => {
+    const dto = build({ limit: 51 });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('limit');
+  });
+
+  it('limit 0 거절', async () => {
+    const dto = build({ limit: 0 });
     const errors = await validate(dto);
     expect(errors).toHaveLength(1);
     expect(errors[0].property).toBe('limit');

--- a/src/features/user/dto/inputs/my-notifications.input.ts
+++ b/src/features/user/dto/inputs/my-notifications.input.ts
@@ -1,9 +1,28 @@
-import { IsBoolean, IsOptional } from 'class-validator';
+import {
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
-import { UserPaginationInput } from '@/features/user/dto/inputs/user-pagination.input';
+import { MAX_PAGINATION_LIMIT } from '@/features/user/constants/user.constants';
 
-export class MyNotificationsInput extends UserPaginationInput {
+export class MyNotificationsInput {
   @IsOptional()
   @IsBoolean()
   unreadOnly?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  cursor?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(MAX_PAGINATION_LIMIT)
+  limit?: number;
 }

--- a/src/features/user/repositories/user.repository.ts
+++ b/src/features/user/repositories/user.repository.ts
@@ -3,13 +3,54 @@ import {
   AccountType,
   CustomDraftStatus,
   IdentityProvider,
-  NotificationType,
   Prisma,
 } from '@prisma/client';
 
 import { buildWithdrawnProviderSubject } from '@/common/utils/withdrawn-identity';
 import { buildReviewLikedNotification } from '@/features/notification';
 import { activeWhere, PrismaService, visibleWhere } from '@/prisma';
+
+/**
+ * 알림 목록 select. 서브라인·딥링크용 연관 정보를 함께 당긴다.
+ * - 직접 연결(store/product): 리뷰 좋아요 알림 등이 사용.
+ * - order.items 폴백: 연관 ID를 저장하지 않던 과거 주문 알림 보강용.
+ *   상품명은 주문 시점 스냅샷(product_name_snapshot)을 써 상품 삭제에도 안전하다.
+ * nested select라 soft-delete 자동 필터가 닿지 않지만, 삭제된 매장·상품이어도
+ * 알림 표기용 이름은 그대로 보여주는 게 정책이다(이름만 노출, 이동은 FE 판단).
+ */
+const notificationListSelect = {
+  id: true,
+  type: true,
+  event: true,
+  title: true,
+  body: true,
+  read_at: true,
+  created_at: true,
+  store_id: true,
+  product_id: true,
+  order_id: true,
+  review_id: true,
+  store: { select: { store_name: true } },
+  product: { select: { name: true } },
+  order: {
+    select: {
+      items: {
+        select: {
+          store_id: true,
+          product_id: true,
+          product_name_snapshot: true,
+          store: { select: { store_name: true } },
+        },
+        orderBy: { id: 'asc' as const },
+        take: 1,
+      },
+    },
+  },
+} satisfies Prisma.NotificationSelect;
+
+export type NotificationListRow = Prisma.NotificationGetPayload<{
+  select: typeof notificationListSelect;
+}>;
 
 export interface UserAccountIdentity {
   provider: IdentityProvider;
@@ -244,17 +285,23 @@ export class UserRepository {
     }
   }
 
-  async getViewerCounts(accountId: bigint): Promise<{
+  async getViewerCounts(args: {
+    accountId: bigint;
+    notificationSince: Date;
+  }): Promise<{
     unreadNotificationCount: number;
     cartItemCount: number;
     wishlistCount: number;
   }> {
+    const { accountId, notificationSince } = args;
     const [unreadNotificationCount, cartItemCount, wishlistCount] =
       await this.prisma.$transaction([
+        // 3개월 밖 미읽 알림까지 세면 목록(myNotifications)과 배지 수가 어긋난다
         this.prisma.notification.count({
           where: {
             account_id: accountId,
             read_at: null,
+            created_at: { gte: notificationSince },
           },
         }),
         this.prisma.cartItem.count({
@@ -273,38 +320,44 @@ export class UserRepository {
   async listNotifications(args: {
     accountId: bigint;
     unreadOnly: boolean;
-    offset: number;
     limit: number;
+    since: Date;
+    cursor?: { createdAt: Date; id: bigint };
   }): Promise<{
-    items: {
-      id: bigint;
-      type: NotificationType;
-      title: string;
-      body: string;
-      read_at: Date | null;
-      created_at: Date;
-    }[];
+    items: NotificationListRow[];
     totalCount: number;
   }> {
-    const where = {
+    const where: Prisma.NotificationWhereInput = {
       account_id: args.accountId,
+      created_at: { gte: args.since },
       ...(args.unreadOnly ? { read_at: null } : {}),
     };
 
+    // (created_at, id) desc 키셋. created_at이 같은 행이 있어도 id 타이브레이크로
+    // 페이지 중복/누락이 없다. since 조건과 키가 겹쳐 AND 배열로 분리한다.
+    const pageWhere: Prisma.NotificationWhereInput = args.cursor
+      ? {
+          AND: [
+            where,
+            {
+              OR: [
+                { created_at: { lt: args.cursor.createdAt } },
+                {
+                  created_at: args.cursor.createdAt,
+                  id: { lt: args.cursor.id },
+                },
+              ],
+            },
+          ],
+        }
+      : where;
+
     const [items, totalCount] = await this.prisma.$transaction([
       this.prisma.notification.findMany({
-        where,
-        orderBy: { created_at: 'desc' },
-        skip: args.offset,
-        take: args.limit,
-        select: {
-          id: true,
-          type: true,
-          title: true,
-          body: true,
-          read_at: true,
-          created_at: true,
-        },
+        where: pageWhere,
+        orderBy: [{ created_at: 'desc' }, { id: 'desc' }],
+        take: args.limit + 1,
+        select: notificationListSelect,
       }),
       this.prisma.notification.count({ where }),
     ]);

--- a/src/features/user/resolvers/user-notification.resolver.spec.ts
+++ b/src/features/user/resolvers/user-notification.resolver.spec.ts
@@ -53,7 +53,7 @@ describe('User Notification Resolvers (real DB)', () => {
 
     const result = await queryResolver.myNotifications(
       { accountId: account.id.toString() },
-      { unreadOnly: true, offset: 0, limit: 10 },
+      { unreadOnly: true, limit: 10 },
     );
 
     expect(result.totalCount).toBe(1);

--- a/src/features/user/services/user-notification-mappers.helper.spec.ts
+++ b/src/features/user/services/user-notification-mappers.helper.spec.ts
@@ -37,7 +37,7 @@ describe('toNotificationItem', () => {
     });
   });
 
-  it('직접 연결(store/product/review)을 우선 사용한다', () => {
+  it('주문이 없는 알림(리뷰 좋아요)은 직접 연결의 현재 상품명을 쓴다', () => {
     const item = toNotificationItem(
       baseRow({
         event: 'REVIEW_LIKED',
@@ -46,17 +46,6 @@ describe('toNotificationItem', () => {
         review_id: BigInt(30),
         store: { store_name: '달콤 케이크' },
         product: { name: '크리스마스 케이크' },
-        // 직접 컬럼이 있으면 order 폴백은 쓰지 않는다
-        order: {
-          items: [
-            {
-              store_id: BigInt(99),
-              product_id: BigInt(98),
-              product_name_snapshot: '스냅샷',
-              store: { store_name: '다른 매장' },
-            },
-          ],
-        },
       }),
     );
 
@@ -67,6 +56,38 @@ describe('toNotificationItem', () => {
       productId: '20',
       productName: '크리스마스 케이크',
       reviewId: '30',
+    });
+  });
+
+  it('주문 연결 알림은 product 직접 연결이 있어도 상품명은 스냅샷을 우선한다', () => {
+    const item = toNotificationItem(
+      baseRow({
+        event: 'ORDER_CONFIRMED',
+        order_id: BigInt(5),
+        store_id: BigInt(10),
+        product_id: BigInt(20),
+        store: { store_name: '달콤 케이크' },
+        // 체크아웃 이후 개명된 현재 상품명 — 알림에는 노출되면 안 된다
+        product: { name: '개명된 케이크' },
+        order: {
+          items: [
+            {
+              store_id: BigInt(10),
+              product_id: BigInt(20),
+              product_name_snapshot: '주문 시점 상품명',
+              store: { store_name: '달콤 케이크' },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(item).toMatchObject({
+      orderId: '5',
+      storeId: '10',
+      storeName: '달콤 케이크',
+      productId: '20',
+      productName: '주문 시점 상품명',
     });
   });
 

--- a/src/features/user/services/user-notification-mappers.helper.spec.ts
+++ b/src/features/user/services/user-notification-mappers.helper.spec.ts
@@ -1,0 +1,113 @@
+import type { NotificationListRow } from '@/features/user/repositories/user.repository';
+import { toNotificationItem } from '@/features/user/services/user-notification-mappers.helper';
+
+function baseRow(overrides: Partial<NotificationListRow>): NotificationListRow {
+  return {
+    id: BigInt(1),
+    type: 'SYSTEM',
+    event: null,
+    title: '제목',
+    body: '본문',
+    read_at: null,
+    created_at: new Date('2026-08-01T00:00:00Z'),
+    store_id: null,
+    product_id: null,
+    order_id: null,
+    review_id: null,
+    store: null,
+    product: null,
+    order: null,
+    ...overrides,
+  };
+}
+
+describe('toNotificationItem', () => {
+  it('연관 엔티티가 없으면 부가 필드를 모두 null로 매핑한다', () => {
+    const item = toNotificationItem(baseRow({}));
+
+    expect(item).toMatchObject({
+      id: '1',
+      event: null,
+      orderId: null,
+      storeId: null,
+      productId: null,
+      reviewId: null,
+      storeName: null,
+      productName: null,
+    });
+  });
+
+  it('직접 연결(store/product/review)을 우선 사용한다', () => {
+    const item = toNotificationItem(
+      baseRow({
+        event: 'REVIEW_LIKED',
+        store_id: BigInt(10),
+        product_id: BigInt(20),
+        review_id: BigInt(30),
+        store: { store_name: '달콤 케이크' },
+        product: { name: '크리스마스 케이크' },
+        // 직접 컬럼이 있으면 order 폴백은 쓰지 않는다
+        order: {
+          items: [
+            {
+              store_id: BigInt(99),
+              product_id: BigInt(98),
+              product_name_snapshot: '스냅샷',
+              store: { store_name: '다른 매장' },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(item).toMatchObject({
+      event: 'REVIEW_LIKED',
+      storeId: '10',
+      storeName: '달콤 케이크',
+      productId: '20',
+      productName: '크리스마스 케이크',
+      reviewId: '30',
+    });
+  });
+
+  it('직접 컬럼이 없으면 order.items 폴백으로 채운다(상품명은 스냅샷)', () => {
+    const item = toNotificationItem(
+      baseRow({
+        event: 'ORDER_PICKED_UP',
+        order_id: BigInt(5),
+        order: {
+          items: [
+            {
+              store_id: BigInt(10),
+              product_id: BigInt(20),
+              product_name_snapshot: '주문 시점 상품명',
+              store: { store_name: '해즈 케이크' },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(item).toMatchObject({
+      orderId: '5',
+      storeId: '10',
+      storeName: '해즈 케이크',
+      productId: '20',
+      productName: '주문 시점 상품명',
+    });
+  });
+
+  it('order.items가 비어 있어도 안전하게 null로 남긴다', () => {
+    const item = toNotificationItem(
+      baseRow({ order_id: BigInt(5), order: { items: [] } }),
+    );
+
+    expect(item).toMatchObject({
+      orderId: '5',
+      storeId: null,
+      storeName: null,
+      productId: null,
+      productName: null,
+    });
+  });
+});

--- a/src/features/user/services/user-notification-mappers.helper.ts
+++ b/src/features/user/services/user-notification-mappers.helper.ts
@@ -1,0 +1,36 @@
+import type { NotificationListRow } from '@/features/user/repositories/user.repository';
+import type { NotificationItem } from '@/features/user/types/user-output.type';
+
+/**
+ * 알림 row → 출력 매핑. DI-free 순수 함수.
+ *
+ * 연관 매장·상품은 직접 컬럼(store/product) 우선, 없으면 order.items 폴백 —
+ * 연관 ID를 저장하지 않던 과거 주문 알림도 서브라인·딥링크 정보를 채우기 위함.
+ * 주문 폴백의 상품명은 주문 시점 스냅샷이라 이후 상품명 변경·삭제와 무관하다.
+ */
+export function toNotificationItem(row: NotificationListRow): NotificationItem {
+  const orderItem = row.order?.items[0] ?? null;
+
+  const storeId = row.store_id ?? orderItem?.store_id ?? null;
+  const storeName =
+    row.store?.store_name ?? orderItem?.store.store_name ?? null;
+  const productId = row.product_id ?? orderItem?.product_id ?? null;
+  const productName =
+    row.product?.name ?? orderItem?.product_name_snapshot ?? null;
+
+  return {
+    id: row.id.toString(),
+    type: row.type,
+    event: row.event,
+    title: row.title,
+    body: row.body,
+    orderId: row.order_id?.toString() ?? null,
+    storeId: storeId?.toString() ?? null,
+    productId: productId?.toString() ?? null,
+    reviewId: row.review_id?.toString() ?? null,
+    storeName,
+    productName,
+    readAt: row.read_at,
+    createdAt: row.created_at,
+  };
+}

--- a/src/features/user/services/user-notification-mappers.helper.ts
+++ b/src/features/user/services/user-notification-mappers.helper.ts
@@ -4,9 +4,9 @@ import type { NotificationItem } from '@/features/user/types/user-output.type';
 /**
  * 알림 row → 출력 매핑. DI-free 순수 함수.
  *
- * 연관 매장·상품은 직접 컬럼(store/product) 우선, 없으면 order.items 폴백 —
+ * 연관 ID·매장명은 직접 컬럼(store/product) 우선, 없으면 order.items 폴백 —
  * 연관 ID를 저장하지 않던 과거 주문 알림도 서브라인·딥링크 정보를 채우기 위함.
- * 주문 폴백의 상품명은 주문 시점 스냅샷이라 이후 상품명 변경·삭제와 무관하다.
+ * 단 상품명은 주문 연결 알림이면 항상 주문 시점 스냅샷(이후 개명·삭제와 무관).
  */
 export function toNotificationItem(row: NotificationListRow): NotificationItem {
   const orderItem = row.order?.items[0] ?? null;
@@ -15,8 +15,12 @@ export function toNotificationItem(row: NotificationListRow): NotificationItem {
   const storeName =
     row.store?.store_name ?? orderItem?.store.store_name ?? null;
   const productId = row.product_id ?? orderItem?.product_id ?? null;
-  const productName =
-    row.product?.name ?? orderItem?.product_name_snapshot ?? null;
+  // 주문 연결 알림은 product_id가 저장돼 있어도 주문 시점 스냅샷을 우선한다
+  // (SDL 계약) — 체크아웃 이후 상품 개명이 알림 문맥을 바꾸면 안 된다.
+  // 주문이 없는 알림(리뷰 좋아요 등)만 현재 상품명을 쓴다.
+  const productName = orderItem
+    ? orderItem.product_name_snapshot
+    : (row.product?.name ?? null);
 
   return {
     id: row.id.toString(),

--- a/src/features/user/services/user-notification.service.spec.ts
+++ b/src/features/user/services/user-notification.service.spec.ts
@@ -188,6 +188,10 @@ describe('UserNotificationService (real DB)', () => {
       await expect(
         service.myNotifications(account.id, { cursor: `${'9'.repeat(30)}:1` }),
       ).rejects.toThrow(BadRequestException);
+      // 안전 정수지만 Date 지원 범위(±8.64e15ms)를 넘는 timestamp
+      await expect(
+        service.myNotifications(account.id, { cursor: '9000000000000000:1' }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('3개월 지난 알림은 목록·totalCount에서 제외한다', async () => {

--- a/src/features/user/services/user-notification.service.spec.ts
+++ b/src/features/user/services/user-notification.service.spec.ts
@@ -192,6 +192,12 @@ describe('UserNotificationService (real DB)', () => {
       await expect(
         service.myNotifications(account.id, { cursor: '9000000000000000:1' }),
       ).rejects.toThrow(BadRequestException);
+      // UNSIGNED BIGINT 상한을 넘는 id
+      await expect(
+        service.myNotifications(account.id, {
+          cursor: `1700000000000:${'9'.repeat(30)}`,
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('3개월 지난 알림은 목록·totalCount에서 제외한다', async () => {

--- a/src/features/user/services/user-notification.service.spec.ts
+++ b/src/features/user/services/user-notification.service.spec.ts
@@ -1,4 +1,8 @@
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import {
+  BadRequestException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import type { PrismaClient } from '@prisma/client';
 
 import { UserRepository } from '@/features/user/repositories/user.repository';
@@ -8,6 +12,11 @@ import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
 import {
   createAccount,
   createNotification,
+  createOrder,
+  createOrderItem,
+  createProduct,
+  createReview,
+  createStore,
   createUserProfile,
 } from '@/test/factories';
 import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
@@ -39,6 +48,11 @@ describe('UserNotificationService (real DB)', () => {
     return account;
   }
 
+  // 3개월 노출 필터가 "지금" 기준이라 케이스 날짜도 상대 시각으로 만든다
+  function daysAgo(days: number): Date {
+    return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  }
+
   // ─── viewerCounts ───
   describe('viewerCounts', () => {
     it('미읽 알림 수 / 장바구니 / 위시리스트 수를 반환한다', async () => {
@@ -59,6 +73,19 @@ describe('UserNotificationService (real DB)', () => {
       expect(result.wishlistCount).toBe(0);
     });
 
+    it('3개월 지난 미읽 알림은 배지 수에서 제외한다(목록과 일치)', async () => {
+      const account = await setupUser();
+      await createNotification(prisma, { account_id: account.id });
+      await createNotification(prisma, {
+        account_id: account.id,
+        created_at: daysAgo(100),
+      });
+
+      const result = await service.viewerCounts(account.id);
+
+      expect(result.unreadNotificationCount).toBe(1);
+    });
+
     it('계정이 없으면 UnauthorizedException을 던진다', async () => {
       await expect(service.viewerCounts(BigInt(999999))).rejects.toThrow(
         UnauthorizedException,
@@ -75,26 +102,30 @@ describe('UserNotificationService (real DB)', () => {
         account_id: account.id,
         title: '오래된',
         body: '바디1',
-        created_at: new Date('2026-04-01'),
+        created_at: daysAgo(2),
       });
       const newer = await createNotification(prisma, {
         account_id: account.id,
         title: '최근',
         body: '바디2',
-        created_at: new Date('2026-04-20'),
+        event: 'ORDER_CONFIRMED',
+        created_at: daysAgo(1),
       });
 
-      const result = await service.myNotifications(account.id, {
-        offset: 0,
-        limit: 10,
-      });
+      const result = await service.myNotifications(account.id, { limit: 10 });
 
       expect(result.totalCount).toBe(2);
       expect(result.hasMore).toBe(false);
+      expect(result.nextCursor).toBeNull();
       expect(result.items[0].id).toBe(newer.id.toString());
       expect(result.items[1].id).toBe(older.id.toString());
       expect(result.items[0].title).toBe('최근');
+      expect(result.items[0].event).toBe('ORDER_CONFIRMED');
       expect(result.items[0].readAt).toBeNull();
+      // 연관 엔티티가 없는 알림은 부가 필드가 모두 null
+      expect(result.items[0].storeId).toBeNull();
+      expect(result.items[0].storeName).toBeNull();
+      expect(result.items[0].productName).toBeNull();
     });
 
     it('unreadOnly=true면 read_at이 null인 것만 반환한다', async () => {
@@ -107,7 +138,6 @@ describe('UserNotificationService (real DB)', () => {
 
       const result = await service.myNotifications(account.id, {
         unreadOnly: true,
-        offset: 0,
         limit: 10,
       });
 
@@ -115,23 +145,133 @@ describe('UserNotificationService (real DB)', () => {
       expect(result.items[0].readAt).toBeNull();
     });
 
-    it('offset + limit < totalCount면 hasMore true', async () => {
+    it('커서로 다음 페이지를 이어간다 — 같은 created_at은 id로 타이브레이크', async () => {
       const account = await setupUser();
+      const sameMoment = daysAgo(1);
+      const ids: bigint[] = [];
       for (let i = 0; i < 3; i++) {
-        await createNotification(prisma, {
+        const n = await createNotification(prisma, {
           account_id: account.id,
-          created_at: new Date(2026, 3, 20 - i),
+          created_at: sameMoment,
         });
+        ids.push(n.id);
       }
+      const idDesc = [...ids].sort((a, b) => (a < b ? 1 : -1));
 
-      const result = await service.myNotifications(account.id, {
-        offset: 0,
+      const page1 = await service.myNotifications(account.id, { limit: 2 });
+      expect(page1.totalCount).toBe(3);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.nextCursor).not.toBeNull();
+      expect(page1.items.map((i) => i.id)).toEqual([
+        idDesc[0].toString(),
+        idDesc[1].toString(),
+      ]);
+
+      const page2 = await service.myNotifications(account.id, {
         limit: 2,
+        cursor: page1.nextCursor!,
+      });
+      expect(page2.items.map((i) => i.id)).toEqual([idDesc[2].toString()]);
+      expect(page2.hasMore).toBe(false);
+      expect(page2.nextCursor).toBeNull();
+      // totalCount는 커서와 무관하게 전체 기준을 유지한다
+      expect(page2.totalCount).toBe(3);
+    });
+
+    it('형식이 잘못된 커서는 거절한다', async () => {
+      const account = await setupUser();
+
+      await expect(
+        service.myNotifications(account.id, { cursor: 'abc' }),
+      ).rejects.toThrow(BadRequestException);
+      // 자릿수 폭탄 — Number 변환 시 안전 정수 범위를 벗어나는 값
+      await expect(
+        service.myNotifications(account.id, { cursor: `${'9'.repeat(30)}:1` }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('3개월 지난 알림은 목록·totalCount에서 제외한다', async () => {
+      const account = await setupUser();
+      const recent = await createNotification(prisma, {
+        account_id: account.id,
+        created_at: daysAgo(80),
+      });
+      await createNotification(prisma, {
+        account_id: account.id,
+        created_at: daysAgo(100),
       });
 
-      expect(result.totalCount).toBe(3);
-      expect(result.hasMore).toBe(true);
-      expect(result.items).toHaveLength(2);
+      const result = await service.myNotifications(account.id);
+
+      expect(result.totalCount).toBe(1);
+      expect(result.items.map((i) => i.id)).toEqual([recent.id.toString()]);
+    });
+
+    it('직접 연결된 매장·상품·리뷰 정보를 노출한다(리뷰 좋아요 형태)', async () => {
+      const account = await setupUser();
+      const store = await createStore(prisma, { store_name: '달콤 케이크' });
+      const product = await createProduct(prisma, {
+        store_id: store.id,
+        name: '크리스마스 케이크',
+      });
+      const review = await createReview(prisma, {
+        order_item_id: (
+          await createOrderItem(prisma, { product_id: product.id })
+        ).id,
+      });
+
+      const notif = await createNotification(prisma, {
+        account_id: account.id,
+        type: 'REVIEW_LIKE',
+        event: 'REVIEW_LIKED',
+        store_id: store.id,
+        product_id: product.id,
+        review_id: review.id,
+      });
+
+      const result = await service.myNotifications(account.id);
+
+      const item = result.items.find((i) => i.id === notif.id.toString());
+      expect(item).toMatchObject({
+        event: 'REVIEW_LIKED',
+        storeId: store.id.toString(),
+        storeName: '달콤 케이크',
+        productId: product.id.toString(),
+        productName: '크리스마스 케이크',
+        reviewId: review.id.toString(),
+      });
+    });
+
+    it('연관 ID가 없는 과거 주문 알림은 order.items로 매장·상품을 보강한다', async () => {
+      const account = await setupUser();
+      const store = await createStore(prisma, { store_name: '해즈 케이크' });
+      const product = await createProduct(prisma, { store_id: store.id });
+      const order = await createOrder(prisma, { account_id: account.id });
+      await createOrderItem(prisma, {
+        order_id: order.id,
+        product_id: product.id,
+        product_name_snapshot: '주문 시점 상품명',
+      });
+
+      const notif = await createNotification(prisma, {
+        account_id: account.id,
+        type: 'ORDER_STATUS',
+        event: 'ORDER_PICKED_UP',
+        order_id: order.id,
+        // store_id / product_id 미저장 — 과거 데이터 재현
+      });
+
+      const result = await service.myNotifications(account.id);
+
+      const item = result.items.find((i) => i.id === notif.id.toString());
+      expect(item).toMatchObject({
+        orderId: order.id.toString(),
+        storeId: store.id.toString(),
+        storeName: '해즈 케이크',
+        productId: product.id.toString(),
+        // 주문 폴백의 상품명은 스냅샷을 쓴다(상품 삭제·개명에도 안전)
+        productName: '주문 시점 상품명',
+      });
     });
 
     it('다른 계정의 알림은 섞여 나오지 않는다', async () => {

--- a/src/features/user/services/user-notification.service.ts
+++ b/src/features/user/services/user-notification.service.ts
@@ -8,6 +8,7 @@ import { sliceCursorPage } from '@/common/utils/pagination';
 import { USER_NOTIFICATION_ERRORS } from '@/features/user/constants/user-notification-error-messages';
 import {
   DEFAULT_PAGINATION_LIMIT,
+  MAX_UNSIGNED_BIGINT,
   NOTIFICATION_VISIBLE_MONTHS,
 } from '@/features/user/constants/user.constants';
 import type { MyNotificationsInput } from '@/features/user/dto/inputs/my-notifications.input';
@@ -124,6 +125,12 @@ export class UserNotificationService extends UserBaseService {
     if (Number.isNaN(createdAt.getTime())) {
       throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
     }
-    return { createdAt, id: BigInt(match[2]) };
+    const id = BigInt(match[2]);
+    // id 컬럼은 UNSIGNED BIGINT — 그 최댓값을 넘는 값도 커넥터 범위 오류로
+    // 번지기 전에 형식 오류로 거부한다.
+    if (id > MAX_UNSIGNED_BIGINT) {
+      throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
+    }
+    return { createdAt, id };
   }
 }

--- a/src/features/user/services/user-notification.service.ts
+++ b/src/features/user/services/user-notification.service.ts
@@ -1,9 +1,19 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 
-import { hasMoreByOffset } from '@/common/utils/pagination';
+import { sliceCursorPage } from '@/common/utils/pagination';
+import { USER_NOTIFICATION_ERRORS } from '@/features/user/constants/user-notification-error-messages';
+import {
+  DEFAULT_PAGINATION_LIMIT,
+  NOTIFICATION_VISIBLE_MONTHS,
+} from '@/features/user/constants/user.constants';
 import type { MyNotificationsInput } from '@/features/user/dto/inputs/my-notifications.input';
 import { UserRepository } from '@/features/user/repositories/user.repository';
 import { UserBaseService } from '@/features/user/services/user-base.service';
+import { toNotificationItem } from '@/features/user/services/user-notification-mappers.helper';
 import type {
   NotificationConnection,
   ViewerCounts,
@@ -17,7 +27,10 @@ export class UserNotificationService extends UserBaseService {
 
   async viewerCounts(accountId: bigint): Promise<ViewerCounts> {
     await this.requireActiveUser(accountId);
-    return this.repo.getViewerCounts(accountId);
+    return this.repo.getViewerCounts({
+      accountId,
+      notificationSince: this.notificationVisibleSince(),
+    });
   }
 
   async myNotifications(
@@ -26,25 +39,32 @@ export class UserNotificationService extends UserBaseService {
   ): Promise<NotificationConnection> {
     await this.requireActiveUser(accountId);
 
-    const { offset, limit, unreadOnly } = this.normalizePaginationInput(input);
+    const limit = input?.limit ?? DEFAULT_PAGINATION_LIMIT;
+    const unreadOnly = Boolean(input?.unreadOnly);
+    const cursor = input?.cursor
+      ? this.parseNotificationCursor(input.cursor)
+      : undefined;
+
     const result = await this.repo.listNotifications({
       accountId,
       unreadOnly,
-      offset,
       limit,
+      since: this.notificationVisibleSince(),
+      cursor,
     });
 
+    // (created_at, id) desc 정렬과 결합된 커서 — 정렬이 바뀌면 무효다.
+    const page = sliceCursorPage(
+      result.items,
+      limit,
+      (last) => `${last.created_at.getTime()}:${last.id.toString()}`,
+    );
+
     return {
-      items: result.items.map((item) => ({
-        id: item.id.toString(),
-        type: item.type,
-        title: item.title,
-        body: item.body,
-        readAt: item.read_at,
-        createdAt: item.created_at,
-      })),
+      items: page.items.map(toNotificationItem),
       totalCount: result.totalCount,
-      hasMore: hasMoreByOffset(offset, limit, result.totalCount),
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
     };
   }
 
@@ -61,7 +81,9 @@ export class UserNotificationService extends UserBaseService {
     });
 
     if (!updated) {
-      throw new NotFoundException('Notification not found.');
+      throw new NotFoundException(
+        USER_NOTIFICATION_ERRORS.NOTIFICATION_NOT_FOUND,
+      );
     }
 
     return true;
@@ -71,5 +93,31 @@ export class UserNotificationService extends UserBaseService {
     await this.requireActiveUser(accountId);
     await this.repo.markAllNotificationsRead({ accountId, now: new Date() });
     return true;
+  }
+
+  /**
+   * "최근 3개월" 노출 하한. setMonth 롤오버(예: 5/31 → 3/1 아님, 3/3)로
+   * 말일 경계가 며칠 어긋날 수 있으나 안내 문구 수준의 정밀도로 충분하다.
+   */
+  private notificationVisibleSince(): Date {
+    const since = new Date();
+    since.setMonth(since.getMonth() - NOTIFICATION_VISIBLE_MONTHS);
+    return since;
+  }
+
+  /** 커서 파싱: "<createdAtMs>:<id>". 형식·안전 정수 범위를 벗어나면 거부. */
+  private parseNotificationCursor(raw: string): {
+    createdAt: Date;
+    id: bigint;
+  } {
+    const match = /^(\d+):(\d+)$/.exec(raw);
+    if (!match) {
+      throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
+    }
+    const createdAtMs = Number(match[1]);
+    if (!Number.isSafeInteger(createdAtMs)) {
+      throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
+    }
+    return { createdAt: new Date(createdAtMs), id: BigInt(match[2]) };
   }
 }

--- a/src/features/user/services/user-notification.service.ts
+++ b/src/features/user/services/user-notification.service.ts
@@ -118,6 +118,12 @@ export class UserNotificationService extends UserBaseService {
     if (!Number.isSafeInteger(createdAtMs)) {
       throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
     }
-    return { createdAt: new Date(createdAtMs), id: BigInt(match[2]) };
+    const createdAt = new Date(createdAtMs);
+    // 안전 정수여도 Date 지원 범위(±8.64e15ms) 밖이면 Invalid Date가 되어
+    // Prisma 필터에서 내부 오류로 번진다 — 형식 오류로 선제 거부한다.
+    if (Number.isNaN(createdAt.getTime())) {
+      throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
+    }
+    return { createdAt, id: BigInt(match[2]) };
   }
 }

--- a/src/features/user/types/user-output.type.ts
+++ b/src/features/user/types/user-output.type.ts
@@ -1,6 +1,7 @@
 import type {
   AccountType,
   IdentityProvider,
+  NotificationEvent,
   NotificationType,
 } from '@prisma/client';
 
@@ -35,8 +36,15 @@ export interface ViewerCounts {
 export interface NotificationItem {
   id: string;
   type: NotificationType;
+  event: NotificationEvent | null;
   title: string;
   body: string;
+  orderId: string | null;
+  storeId: string | null;
+  productId: string | null;
+  reviewId: string | null;
+  storeName: string | null;
+  productName: string | null;
   readAt: Date | null;
   createdAt: Date;
 }
@@ -45,6 +53,7 @@ export interface NotificationConnection {
   items: NotificationItem[];
   totalCount: number;
   hasMore: boolean;
+  nextCursor: string | null;
 }
 
 export interface SearchHistoryItem {

--- a/src/features/user/user-common.graphql
+++ b/src/features/user/user-common.graphql
@@ -10,3 +10,11 @@ enum NotificationType {
   SYSTEM
   MARKETING
 }
+
+"""알림 이벤트. 알림센터의 아이콘·라벨 매핑 기준 (figma notification-center)"""
+enum NotificationEvent {
+  REVIEW_LIKED
+  ORDER_CONFIRMED
+  ORDER_MADE
+  ORDER_PICKED_UP
+}

--- a/src/features/user/user-notification.graphql
+++ b/src/features/user/user-notification.graphql
@@ -26,20 +26,22 @@ type ViewerCounts {
 input MyNotificationsInput {
   """읽지 않은 알림만 조회"""
   unreadOnly: Boolean = false
-  """오프셋"""
-  offset: Int = 0
+  """이전 응답의 nextCursor(불투명 토큰). 미지정 시 첫 페이지"""
+  cursor: String
   """조회 개수(최대 50)"""
   limit: Int = 20
 }
 
-"""알림 목록 응답"""
+"""알림 목록 응답. 최근 3개월 내 알림만 노출한다."""
 type NotificationConnection {
   """알림 아이템 목록"""
   items: [NotificationItem!]!
-  """전체 개수"""
+  """전체 개수(3개월 내 기준)"""
   totalCount: Int!
   """다음 페이지 존재 여부"""
   hasMore: Boolean!
+  """다음 페이지 커서. 없으면 null"""
+  nextCursor: String
 }
 
 """알림 아이템"""
@@ -48,10 +50,24 @@ type NotificationItem {
   id: ID!
   """알림 타입"""
   type: NotificationType!
+  """알림 이벤트(아이콘·라벨 매핑용). 이벤트 없는 일반 알림은 null"""
+  event: NotificationEvent
   """제목"""
   title: String!
   """내용"""
   body: String!
+  """연관 주문 ID(딥링크용)"""
+  orderId: ID
+  """연관 매장 ID(딥링크용)"""
+  storeId: ID
+  """연관 상품 ID(딥링크용)"""
+  productId: ID
+  """연관 리뷰 ID(리뷰 보러가기 딥링크용)"""
+  reviewId: ID
+  """서브라인 조립용 매장명. 연관 매장이 없으면 null"""
+  storeName: String
+  """서브라인 조립용 상품명(주문 알림은 주문 시점 스냅샷). 없으면 null"""
+  productName: String
   """읽음 처리 시각"""
   readAt: DateTime
   """생성 시각"""


### PR DESCRIPTION
## 배경

figma 알림센터(알림 탭) 화면 대응 1/4. 기존 `myNotifications`는 초기 스캐폴드 산물이라 화면이 요구하는 이벤트 라벨·서브라인·딥링크 정보가 없었다.

## 변경점

- **SDL 확장**: `NotificationItem`에 `event`(NotificationEvent enum 노출)·`orderId`·`storeId`·`productId`·`reviewId`·`storeName`·`productName` 추가. 서브라인 조립("[매장] '상품'…")은 FE 담당.
- **키셋 커서 전환**: offset → `"<createdAtMs>:<id>"` 커서(created_at·id desc, id 타이브레이크). FE 실사용 전이라 breaking 전환을 지금 수행.
- **3개월 노출 필터**: 목록·totalCount·`viewerCounts.unreadNotificationCount`에 `created_at ≥ now-3개월` 공통 적용(삭제 아님).
- **문구 갱신**: figma 톤("주문이 확정되었어요." 등). 주문번호 prefix는 유지(사용자 확정 — 표시 여부는 FE 판단).
- **연관 ID 저장**: 주문 상태 알림 생성 시 `store_id`·`product_id` 저장. 과거 row는 조회 시 `order.items` 폴백으로 보강(상품명은 주문 시점 스냅샷).
- **시드 재구성**: 4종 이벤트 + 3개월 경과 알림.

## 테스트

- service 12케이스(커서 연속 조회·타이브레이크·잘못된 커서 거절·3개월 필터·직접 연결/주문 폴백 매핑·배지 일치)
- 매퍼 helper 순수 단위 4케이스 / input 6케이스 / resolver 통합 2케이스 / order.repository 연관 ID 저장 검증
- `yarn validate` 전체 통과 (210 suites / 1799 tests)