### PR TITLE
feat(conversation): 구매자 문의 채팅 기반 — 진입 컨텍스트·메시지 전송·FAQ 자동응답·인사말

### DIFF
--- a/prisma/migrations/20260901175648_add_store_greeting_message/migration.sql
+++ b/prisma/migrations/20260901175648_add_store_greeting_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `store` ADD COLUMN `greeting_message` VARCHAR(500) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -359,6 +359,8 @@ model Store {
   website_url String? @db.VarChar(2048)
   // 매장 프로필(로고) 이미지. 찜/매장별 보기 카드의 원형 프로필 표기용 (figma liked 02·04)
   profile_image_url String? @db.VarChar(2048)
+  // 문의 채팅 인사말 템플릿({nickname}/{storeName} 치환). null이면 서버 기본 문구 (figma notification-center)
+  greeting_message String? @db.VarChar(500)
   is_active         Boolean @default(true) @db.TinyInt
 
   created_at DateTime  @default(now()) @db.DateTime(3)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -13,6 +13,7 @@ import { PrismaClient } from '@prisma/client';
 
 import { seedBanners } from './seed/banners';
 import { seedCategories } from './seed/categories';
+import { seedConversations } from './seed/conversations';
 import { seedCustomDrafts } from './seed/custom-drafts';
 import { resetSeedScope } from './seed/idempotent';
 import { seedNotifications } from './seed/notifications';
@@ -62,6 +63,9 @@ async function main(): Promise<void> {
 
     log('알림 시드 중...');
     await seedNotifications(prisma, { users, stores, orders });
+
+    log('대화 + FAQ 시드 중...');
+    await seedConversations(prisma, { users, stores });
 
     log('커스텀 드래프트 시드 중...');
     await seedCustomDrafts(prisma, { users, stores });

--- a/prisma/seed/conversations.ts
+++ b/prisma/seed/conversations.ts
@@ -1,0 +1,151 @@
+/**
+ * 시드 대화 + FAQ 칩 (figma notification-center 대화 탭·문의 채팅 재현).
+ *
+ * - storeA: 커스텀 인사말 + FAQ 5종(질문 칩) 등록.
+ *   user1 대화 = 인사말 → 칩 질문("케이크 보관 방법") → HTML 자동응답.
+ * - storeB: 인사말 미설정(기본 문구 사용 경로 검증).
+ *   user1 대화 = 인사말 → 유저 자유 텍스트 → 판매자 답장 3건(안읽음 배지 재현,
+ *   last_read_at은 유저 메시지 시점까지만).
+ */
+import type { PrismaClient } from '@prisma/client';
+
+import type { SeededStores } from './stores';
+import type { SeededUser } from './users';
+
+export async function seedConversations(
+  prisma: PrismaClient,
+  ctx: { users: SeededUser[]; stores: SeededStores },
+): Promise<void> {
+  const user1 = ctx.users[0];
+  if (!user1) throw new Error('seedUsers must run before seedConversations');
+  const [storeA, storeB] = ctx.stores.stores;
+  if (!storeA || !storeB) {
+    throw new Error('seedStores must run before seedConversations');
+  }
+
+  const now = Date.now();
+  const hour = 60 * 60 * 1000;
+  const day = 24 * hour;
+
+  // ── storeA: 커스텀 인사말 + FAQ 칩 ──
+  await prisma.store.update({
+    where: { id: storeA.id },
+    data: {
+      greeting_message:
+        '안녕하세요! {nickname} 고객님.\n{storeName} 입니다 😄\n무엇을 도와드릴까요?',
+    },
+  });
+
+  const faqRows = [
+    { title: '날짜 변경', answer_html: '<p>픽업 1일 전까지 채팅으로 요청해 주시면 일정 확인 후 변경해 드려요.</p>' },
+    {
+      title: '케이크 보관 방법',
+      answer_html:
+        '<p>🎂 <strong>케이크 보관 방법</strong></p><ul><li>냉장보관시 최대 3일</li><li>생크림 케이크는 당일 드시는 걸 권장해요</li></ul>',
+    },
+    { title: '가게 위치 정보', answer_html: '<p>매장 상세의 찾아오는 길 안내를 확인해 주세요.</p>' },
+    { title: '제일 많이 물어보는 질문', answer_html: '<p>레터링 문구는 주문 시 요청사항에 남겨 주시면 반영돼요.</p>' },
+    { title: '예약 가능 일정', answer_html: '<p>캘린더에서 픽업 가능 날짜·시간대를 확인할 수 있어요.</p>' },
+  ];
+  const faqs = [] as { id: bigint; title: string; answer_html: string }[];
+  for (const [i, row] of faqRows.entries()) {
+    faqs.push(
+      await prisma.storeFaqTopic.create({
+        data: { store_id: storeA.id, sort_order: i + 1, ...row },
+      }),
+    );
+  }
+
+  // ── user1 ↔ storeA: 칩 문답 대화 ──
+  const convA = await prisma.storeConversation.create({
+    data: {
+      account_id: user1.id,
+      store_id: storeA.id,
+      last_message_at: new Date(now - 1 * day),
+      last_read_at: new Date(now - 1 * day),
+    },
+  });
+  const keepFaq = faqs[1];
+  await prisma.storeConversationMessage.createMany({
+    data: [
+      {
+        conversation_id: convA.id,
+        sender_type: 'STORE',
+        body_format: 'TEXT',
+        body_text:
+          '안녕하세요! seedTester1 고객님.\n[SEED] 케이크샵 A 입니다 😄\n무엇을 도와드릴까요?',
+        created_at: new Date(now - 1 * day - 2 * 60 * 1000),
+      },
+      {
+        conversation_id: convA.id,
+        sender_type: 'USER',
+        sender_account_id: user1.id,
+        body_format: 'TEXT',
+        body_text: keepFaq?.title ?? '케이크 보관 방법',
+        created_at: new Date(now - 1 * day - 60 * 1000),
+      },
+      {
+        conversation_id: convA.id,
+        sender_type: 'STORE',
+        body_format: 'HTML',
+        body_html: keepFaq?.answer_html ?? '<p>보관 안내</p>',
+        created_at: new Date(now - 1 * day),
+      },
+    ],
+  });
+
+  // ── user1 ↔ storeB: 자유 문의 + 판매자 답장 3건(안읽음) ──
+  const convB = await prisma.storeConversation.create({
+    data: {
+      account_id: user1.id,
+      store_id: storeB.id,
+      last_message_at: new Date(now - 5 * hour),
+      // 유저가 마지막으로 읽은 시점 = 본인 메시지 직후 → 판매자 답장 3건 안읽음
+      last_read_at: new Date(now - 8 * hour),
+    },
+  });
+  await prisma.storeConversationMessage.createMany({
+    data: [
+      {
+        conversation_id: convB.id,
+        sender_type: 'STORE',
+        body_format: 'TEXT',
+        body_text:
+          '안녕하세요! seedTester1 고객님.\n[SEED] 도넛샵 B 입니다 😄\n무엇을 도와드릴까요?',
+        created_at: new Date(now - 9 * hour),
+      },
+      {
+        conversation_id: convB.id,
+        sender_type: 'USER',
+        sender_account_id: user1.id,
+        body_format: 'TEXT',
+        body_text: '주문한 도넛 픽업 시간을 30분 늦출 수 있을까요?',
+        created_at: new Date(now - 8 * hour),
+      },
+      {
+        conversation_id: convB.id,
+        sender_type: 'STORE',
+        sender_account_id: storeB.seller_account_id,
+        body_format: 'TEXT',
+        body_text: '고객님이 말씀해 주신 문의사항에 대한 답변 드리겠습니다.',
+        created_at: new Date(now - 7 * hour),
+      },
+      {
+        conversation_id: convB.id,
+        sender_type: 'STORE',
+        sender_account_id: storeB.seller_account_id,
+        body_format: 'TEXT',
+        body_text: '네, 30분 늦은 픽업 가능합니다.',
+        created_at: new Date(now - 6 * hour),
+      },
+      {
+        conversation_id: convB.id,
+        sender_type: 'STORE',
+        sender_account_id: storeB.seller_account_id,
+        body_format: 'TEXT',
+        body_text: '방문 시 매장 카운터에서 주문번호를 말씀해 주세요.',
+        created_at: new Date(now - 5 * hour),
+      },
+    ],
+  });
+}

--- a/prisma/seed/idempotent.ts
+++ b/prisma/seed/idempotent.ts
@@ -109,6 +109,21 @@ export async function resetSeedScope(prisma: PrismaClient): Promise<void> {
     });
 
     // 알림
+    // 대화(메시지 → 본체). 시드 유저 소유 대화만 정리한다
+    const userConversations = await prisma.storeConversation.findMany({
+      where: { account_id: { in: userIds } },
+      select: { id: true },
+    });
+    const userConversationIds = userConversations.map((c) => c.id);
+    if (userConversationIds.length > 0) {
+      await prisma.storeConversationMessage.deleteMany({
+        where: { conversation_id: { in: userConversationIds } },
+      });
+      await prisma.storeConversation.deleteMany({
+        where: { id: { in: userConversationIds } },
+      });
+    }
+
     await prisma.notification.deleteMany({
       where: { account_id: { in: userIds } },
     });
@@ -243,6 +258,24 @@ export async function resetSeedScope(prisma: PrismaClient): Promise<void> {
 
       await prisma.product.deleteMany({ where: { id: { in: productIds } } });
     }
+
+    // 시드 매장을 참조하는 대화(다른 유저 소유 포함)와 FAQ — store FK 선정리
+    const storeConversations = await prisma.storeConversation.findMany({
+      where: { store_id: { in: storeIds } },
+      select: { id: true },
+    });
+    const storeConversationIds = storeConversations.map((c) => c.id);
+    if (storeConversationIds.length > 0) {
+      await prisma.storeConversationMessage.deleteMany({
+        where: { conversation_id: { in: storeConversationIds } },
+      });
+      await prisma.storeConversation.deleteMany({
+        where: { id: { in: storeConversationIds } },
+      });
+    }
+    await prisma.storeFaqTopic.deleteMany({
+      where: { store_id: { in: storeIds } },
+    });
 
     await prisma.storeBusinessHour.deleteMany({
       where: { store_id: { in: storeIds } },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import docsConfig from '@/config/docs.config';
 import oidcConfig from '@/config/oidc.config';
 import s3Config from '@/config/s3.config';
 import { AuthModule } from '@/features/auth/auth.module';
+import { ConversationModule } from '@/features/conversation';
 import { PickupModule } from '@/features/pickup';
 import { RegionModule } from '@/features/region';
 import { SearchModule } from '@/features/search/search.module';
@@ -92,6 +93,7 @@ import { PrismaModule } from '@/prisma';
     }),
     SystemModule,
     AuthModule,
+    ConversationModule,
     PickupModule,
     RegionModule,
     SearchModule,

--- a/src/features/conversation/constants/conversation-error-messages.ts
+++ b/src/features/conversation/constants/conversation-error-messages.ts
@@ -1,0 +1,9 @@
+export const CONVERSATION_ERRORS = {
+  STORE_NOT_FOUND: 'Store not found.',
+  FAQ_TOPIC_NOT_FOUND: 'FAQ topic not found.',
+  // 활성 USER 판정 실패 메시지 — user feature와 동일 의미론(판정은 정책 헬퍼 공유)
+  ACCOUNT_NOT_FOUND: 'Account not found.',
+  ACCOUNT_DELETED: 'Account is deleted.',
+  NOT_USER: 'Only USER account is allowed.',
+  PROFILE_INACTIVE: 'User profile not found.',
+} as const;

--- a/src/features/conversation/constants/conversation.constants.ts
+++ b/src/features/conversation/constants/conversation.constants.ts
@@ -1,0 +1,11 @@
+// 인사말 템플릿 placeholder. 매장 커스텀 인사말과 기본 문구가 공유한다.
+export const GREETING_NICKNAME_PLACEHOLDER = '{nickname}';
+export const GREETING_STORE_NAME_PLACEHOLDER = '{storeName}';
+
+// figma notification-center 문의 채팅 인사말 기준(자체 판단: placeholder 형식).
+// 매장이 greeting_message를 설정하지 않았을 때 사용한다.
+export const DEFAULT_GREETING_TEMPLATE =
+  '안녕하세요! {nickname} 고객님.\n{storeName} 입니다 😄\n무엇을 도와드릴까요?';
+
+// 구매자 텍스트 메시지 상한. 판매자 측 MAX_CONVERSATION_BODY_TEXT_LENGTH와 동일 정책.
+export const MAX_INQUIRY_BODY_TEXT_LENGTH = 2000;

--- a/src/features/conversation/conversation-inquiry.graphql
+++ b/src/features/conversation/conversation-inquiry.graphql
@@ -1,0 +1,95 @@
+extend type Query {
+  """
+  문의 채팅 진입 컨텍스트(구매자). 매장 프로필·상담시간·치환 완료 인사말·질문 칩을
+  한 번에 내려준다. 아직 대화가 없어도 조회 가능하며 그 경우 conversationId는 null.
+  """
+  storeInquiryContext(storeId: ID!): StoreInquiryContext!
+}
+
+extend type Mutation {
+  """
+  구매자 텍스트 메시지 전송. 해당 매장과의 대화가 없으면 이 시점에 생성하고,
+  치환 완료된 인사말을 매장 메시지로 먼저 저장한 뒤 유저 메시지를 저장한다.
+  """
+  sendConversationMessage(input: SendConversationMessageInput!): ConversationMessagesPayload!
+  """
+  질문 칩(FAQ) 전송. 유저 메시지(칩 제목)와 매장 자동응답(FAQ 답변 HTML)을
+  한 트랜잭션으로 저장한다. 첫 전송이면 대화 생성 + 인사말 저장도 함께 수행.
+  """
+  sendConversationFaqMessage(input: SendConversationFaqMessageInput!): ConversationMessagesPayload!
+}
+
+"""대화 메시지 발신자 유형"""
+enum ConversationSenderType {
+  USER
+  STORE
+  SYSTEM
+}
+
+"""대화 메시지 본문 형식"""
+enum ConversationBodyFormat {
+  TEXT
+  HTML
+}
+
+"""문의 채팅 진입 컨텍스트"""
+type StoreInquiryContext {
+  storeId: ID!
+  storeName: String!
+  """매장 프로필(로고) 이미지 URL. 미등록 시 null"""
+  profileImageUrl: String
+  """요일별 상담시간(영업시간과 동일 정책). FE가 "월/화/수… 10:00~18:00" 형식으로 조합"""
+  businessHours: [InquiryBusinessHour!]!
+  """닉네임·매장명 치환이 끝난 인사말"""
+  greetingMessage: String!
+  """질문 칩 목록(활성 FAQ, 노출 순서대로)"""
+  faqTopics: [InquiryFaqTopic!]!
+  """기존 대화가 있으면 그 ID, 없으면 null"""
+  conversationId: ID
+}
+
+"""요일별 상담시간"""
+type InquiryBusinessHour {
+  """0=일 ~ 6=토"""
+  dayOfWeek: Int!
+  isClosed: Boolean!
+  """오픈 시각 "HH:mm". 휴무면 null"""
+  openTime: String
+  """마감 시각 "HH:mm". 휴무면 null"""
+  closeTime: String
+}
+
+"""질문 칩(매장 FAQ)"""
+type InquiryFaqTopic {
+  id: ID!
+  title: String!
+}
+
+"""대화 메시지"""
+type ConversationMessage {
+  id: ID!
+  conversationId: ID!
+  senderType: ConversationSenderType!
+  bodyFormat: ConversationBodyFormat!
+  bodyText: String
+  bodyHtml: String
+  createdAt: DateTime!
+}
+
+"""메시지 전송 결과. 이번 호출로 저장된 메시지들을 생성 순으로 담는다(첫 전송이면 인사말 포함)"""
+type ConversationMessagesPayload {
+  conversationId: ID!
+  messages: [ConversationMessage!]!
+}
+
+"""구매자 텍스트 메시지 전송 입력"""
+input SendConversationMessageInput {
+  storeId: ID!
+  bodyText: String!
+}
+
+"""질문 칩(FAQ) 전송 입력"""
+input SendConversationFaqMessageInput {
+  storeId: ID!
+  faqTopicId: ID!
+}

--- a/src/features/conversation/conversation.module.ts
+++ b/src/features/conversation/conversation.module.ts
@@ -1,9 +1,17 @@
 import { Module } from '@nestjs/common';
 
 import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { ConversationInquiryMutationResolver } from '@/features/conversation/resolvers/conversation-inquiry-mutation.resolver';
+import { ConversationInquiryQueryResolver } from '@/features/conversation/resolvers/conversation-inquiry-query.resolver';
+import { ConversationInquiryService } from '@/features/conversation/services/conversation-inquiry.service';
 
 @Module({
-  providers: [ConversationRepository],
+  providers: [
+    ConversationRepository,
+    ConversationInquiryService,
+    ConversationInquiryQueryResolver,
+    ConversationInquiryMutationResolver,
+  ],
   exports: [ConversationRepository],
 })
 export class ConversationModule {}

--- a/src/features/conversation/dto/inputs/send-conversation-faq-message.input.spec.ts
+++ b/src/features/conversation/dto/inputs/send-conversation-faq-message.input.spec.ts
@@ -1,0 +1,27 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { SendConversationFaqMessageInput } from '@/features/conversation/dto/inputs/send-conversation-faq-message.input';
+
+function build(plain: object): SendConversationFaqMessageInput {
+  return plainToInstance(SendConversationFaqMessageInput, plain);
+}
+
+describe('SendConversationFaqMessageInput', () => {
+  it('storeId·faqTopicId 정상 조합 허용', async () => {
+    const dto = build({ storeId: '1', faqTopicId: '2' });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('faqTopicId 누락 거절', async () => {
+    const errors = await validate(build({ storeId: '1' }));
+    expect(errors.map((e) => e.property)).toEqual(['faqTopicId']);
+  });
+
+  it('storeId 빈 문자열 거절', async () => {
+    const errors = await validate(build({ storeId: '', faqTopicId: '2' }));
+    expect(errors.map((e) => e.property)).toEqual(['storeId']);
+  });
+});

--- a/src/features/conversation/dto/inputs/send-conversation-faq-message.input.ts
+++ b/src/features/conversation/dto/inputs/send-conversation-faq-message.input.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SendConversationFaqMessageInput {
+  @IsString()
+  @IsNotEmpty()
+  storeId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  faqTopicId!: string;
+}

--- a/src/features/conversation/dto/inputs/send-conversation-message.input.spec.ts
+++ b/src/features/conversation/dto/inputs/send-conversation-message.input.spec.ts
@@ -1,0 +1,27 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { SendConversationMessageInput } from '@/features/conversation/dto/inputs/send-conversation-message.input';
+
+function build(plain: object): SendConversationMessageInput {
+  return plainToInstance(SendConversationMessageInput, plain);
+}
+
+describe('SendConversationMessageInput', () => {
+  it('storeId·bodyText 정상 조합 허용', async () => {
+    const dto = build({ storeId: '1', bodyText: '문의합니다' });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('storeId 누락 거절', async () => {
+    const errors = await validate(build({ bodyText: '문의합니다' }));
+    expect(errors.map((e) => e.property)).toEqual(['storeId']);
+  });
+
+  it('bodyText 빈 문자열 거절', async () => {
+    const errors = await validate(build({ storeId: '1', bodyText: '' }));
+    expect(errors.map((e) => e.property)).toEqual(['bodyText']);
+  });
+});

--- a/src/features/conversation/dto/inputs/send-conversation-message.input.ts
+++ b/src/features/conversation/dto/inputs/send-conversation-message.input.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class SendConversationMessageInput {
+  @IsString()
+  @IsNotEmpty()
+  storeId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  bodyText!: string;
+}

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -1,7 +1,20 @@
 import { Injectable } from '@nestjs/common';
-import { ConversationBodyFormat, ConversationSenderType } from '@prisma/client';
+import {
+  ConversationBodyFormat,
+  ConversationSenderType,
+  Prisma,
+} from '@prisma/client';
 
-import { PrismaService } from '@/prisma';
+import { activeWhere, PrismaService, visibleWhere } from '@/prisma';
+
+/** 구매자 메시지 전송 시 한 트랜잭션으로 저장할 메시지 명세. */
+export interface ConversationMessageEntry {
+  senderType: ConversationSenderType;
+  senderAccountId: bigint | null;
+  bodyFormat: ConversationBodyFormat;
+  bodyText: string | null;
+  bodyHtml: string | null;
+}
 
 @Injectable()
 export class ConversationRepository {
@@ -46,6 +59,170 @@ export class ConversationRepository {
       },
       orderBy: { id: 'desc' },
       take: args.limit + 1,
+    });
+  }
+
+  /** 활성 USER 계정 판정용 부분집합 조회(user feature 정책 헬퍼와 계약 공유). */
+  async findUserAccountForInquiry(accountId: bigint) {
+    return this.prisma.account.findFirst({
+      where: { id: accountId },
+      select: {
+        id: true,
+        account_type: true,
+        deleted_at: true,
+        user_profile: { select: { nickname: true, deleted_at: true } },
+      },
+    });
+  }
+
+  /** 문의 가능 매장(활성·미삭제) + 요일별 영업시간. 없으면 null. */
+  async findInquiryStore(storeId: bigint) {
+    return this.prisma.store.findFirst({
+      where: { id: storeId, ...visibleWhere },
+      select: {
+        id: true,
+        store_name: true,
+        profile_image_url: true,
+        greeting_message: true,
+        business_hours: {
+          where: activeWhere,
+          orderBy: { day_of_week: 'asc' },
+          select: {
+            day_of_week: true,
+            is_closed: true,
+            open_time: true,
+            close_time: true,
+          },
+        },
+      },
+    });
+  }
+
+  /** 질문 칩 노출용 활성 FAQ 목록(노출 순서). */
+  async listActiveFaqTopics(storeId: bigint) {
+    return this.prisma.storeFaqTopic.findMany({
+      where: { store_id: storeId, is_active: true },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      select: { id: true, title: true },
+    });
+  }
+
+  /** 칩 전송 대상 FAQ 단건(활성만). */
+  async findActiveFaqTopic(args: { storeId: bigint; faqTopicId: bigint }) {
+    return this.prisma.storeFaqTopic.findFirst({
+      where: {
+        id: args.faqTopicId,
+        store_id: args.storeId,
+        is_active: true,
+      },
+      select: { id: true, title: true, answer_html: true },
+    });
+  }
+
+  async findConversationByAccountAndStore(args: {
+    accountId: bigint;
+    storeId: bigint;
+  }) {
+    return this.prisma.storeConversation.findFirst({
+      where: { account_id: args.accountId, store_id: args.storeId },
+    });
+  }
+
+  /**
+   * 구매자 메시지 저장. 대화가 없으면 이 트랜잭션에서 생성하고, 그 경우에만
+   * 인사말(STORE 발신)을 유저 메시지보다 먼저 저장한다 — 인사말은 대화당 1회.
+   *
+   * 동시 첫 전송 레이스: findFirst 이후 create가 (account_id, store_id) 유니크에
+   * 걸릴 수 있다 → P2002면 기존 대화를 다시 찾아 인사말 없이 이어간다.
+   */
+  async createBuyerMessages(args: {
+    accountId: bigint;
+    storeId: bigint;
+    greetingBodyText: string;
+    entries: ConversationMessageEntry[];
+    now: Date;
+  }) {
+    return this.prisma.$transaction(async (tx) => {
+      // (account_id, store_id) 유니크는 soft-delete된 row도 잡는다 — 조회를
+      // 활성만으로 좁히면 삭제 row 존재 시 create가 항상 P2002로 터지므로,
+      // deleted_at 필터를 명시 해제(undefined)해 유니크 제약과 같은 범위로 찾는다.
+      let conversation = await tx.storeConversation.findFirst({
+        where: {
+          account_id: args.accountId,
+          store_id: args.storeId,
+          deleted_at: undefined,
+        },
+      });
+
+      let withGreeting = false;
+      if (!conversation) {
+        try {
+          conversation = await tx.storeConversation.create({
+            data: {
+              account_id: args.accountId,
+              store_id: args.storeId,
+              created_at: args.now,
+            },
+          });
+          withGreeting = true;
+        } catch (e) {
+          if (
+            e instanceof Prisma.PrismaClientKnownRequestError &&
+            e.code === 'P2002'
+          ) {
+            conversation = await tx.storeConversation.findFirstOrThrow({
+              where: {
+                account_id: args.accountId,
+                store_id: args.storeId,
+                deleted_at: undefined,
+              },
+            });
+          } else {
+            throw e;
+          }
+        }
+      }
+
+      const toCreate: ConversationMessageEntry[] = [
+        ...(withGreeting
+          ? [
+              {
+                senderType: ConversationSenderType.STORE,
+                senderAccountId: null,
+                bodyFormat: ConversationBodyFormat.TEXT,
+                bodyText: args.greetingBodyText,
+                bodyHtml: null,
+              },
+            ]
+          : []),
+        ...args.entries,
+      ];
+
+      // createMany는 생성 row를 돌려주지 않아 순서 보존 개별 create로 저장한다
+      // (한 호출당 최대 3건이라 비용 문제 없음)
+      const messages = [];
+      for (const entry of toCreate) {
+        messages.push(
+          await tx.storeConversationMessage.create({
+            data: {
+              conversation_id: conversation.id,
+              sender_type: entry.senderType,
+              sender_account_id: entry.senderAccountId,
+              body_format: entry.bodyFormat,
+              body_text: entry.bodyText,
+              body_html: entry.bodyHtml,
+              created_at: args.now,
+            },
+          }),
+        );
+      }
+
+      await tx.storeConversation.update({
+        where: { id: conversation.id },
+        data: { last_message_at: args.now, updated_at: args.now },
+      });
+
+      return { conversationId: conversation.id, messages };
     });
   }
 

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -129,8 +129,13 @@ export class ConversationRepository {
   }
 
   /**
-   * 구매자 메시지 저장. 대화가 없으면 먼저 생성하고, 새로 생성한 경우에만
-   * 인사말(STORE 발신)을 유저 메시지보다 앞서 저장한다 — 인사말은 대화당 1회.
+   * 구매자 메시지 저장. 대화가 없으면 같은 트랜잭션에서 생성하고, 인사말은
+   * "대화의 첫 메시지"일 때만(메시지 0건) 유저 메시지보다 앞서 저장한다.
+   *
+   * 대화 생성과 메시지 저장을 한 트랜잭션으로 묶는다 — 대화 row가 먼저
+   * 커밋되면 판매자 목록에 빈 대화가 노출되고, 이후 메시지 저장이 실패하면
+   * 유령 대화가 남는다(리뷰 반영). 실패 시 전체가 롤백되므로 재시도에서
+   * 인사말 계약도 유지된다.
    */
   async createBuyerMessages(args: {
     accountId: bigint;
@@ -139,21 +144,15 @@ export class ConversationRepository {
     entries: ConversationMessageEntry[];
     now: Date;
   }) {
-    // 대화 확보는 메시지 트랜잭션 밖에서 수행한다 — REPEATABLE READ 스냅샷
-    // 안에서 P2002 복구 재조회를 하면 경쟁 트랜잭션이 커밋한 row가 보이지
-    // 않을 수 있다(리뷰 반영). 메시지 삽입 전에 대화 row가 확정되면 충분하고,
-    // 이후 메시지 트랜잭션이 실패해도 빈 대화 row는 목록에 노출되지 않는다
-    // (last_message_at null).
-    const { conversation } = await this.getOrCreateConversation(args);
-
     return this.prisma.$transaction(async (tx) => {
-      // 첫 메시지 초기화(인사말) 직렬화 — 대화 row를 잠근 뒤 실제 메시지
-      // 수로 인사말 필요 여부를 판정한다(리뷰 반영). "생성 여부" 플래그는
-      // 동시 첫 전송·생성 후 실패 재시도에서 인사말 계약(항상 첫 메시지)을
-      // 깨뜨린다. raw SQL이라 soft-delete 필터는 무관(id 지정 잠금).
-      await tx.$queryRaw`SELECT id FROM store_conversation WHERE id = ${conversation.id} FOR UPDATE`;
+      const conversationId = await this.lockOrCreateConversation(tx, args);
+
+      // 인사말 필요 여부는 실제 메시지 수로 판정한다 — "생성 여부" 플래그는
+      // 동시 첫 전송·실패 재시도에서 인사말 계약(항상 첫 메시지)을 깨뜨린다.
+      // 위에서 row를 잠갔거나(기존 대화) 본 트랜잭션이 만들었으므로(신규)
+      // count 판정은 직렬화된다.
       const messageCount = await tx.storeConversationMessage.count({
-        where: { conversation_id: conversation.id },
+        where: { conversation_id: conversationId },
       });
 
       const toCreate: ConversationMessageEntry[] = [
@@ -178,7 +177,7 @@ export class ConversationRepository {
         messages.push(
           await tx.storeConversationMessage.create({
             data: {
-              conversation_id: conversation.id,
+              conversation_id: conversationId,
               sender_type: entry.senderType,
               sender_account_id: entry.senderAccountId,
               body_format: entry.bodyFormat,
@@ -191,7 +190,7 @@ export class ConversationRepository {
       }
 
       await tx.storeConversation.update({
-        where: { id: conversation.id },
+        where: { id: conversationId },
         data: {
           last_message_at: args.now,
           updated_at: args.now,
@@ -202,52 +201,62 @@ export class ConversationRepository {
         },
       });
 
-      return { conversationId: conversation.id, messages };
+      return { conversationId, messages };
     });
   }
 
   /**
-   * (account_id, store_id) 대화 확보. 유니크 제약은 soft-delete row도 잡으므로
-   * 조회 범위를 제약과 동일하게(삭제 포함, deleted_at 필터 명시 해제) 맞춘다.
-   * 동시 첫 전송 레이스는 P2002 후 새 문장(새 스냅샷) 재조회로 승자 row를 얻는다.
+   * 트랜잭션 안에서 (account_id, store_id) 대화를 잠그거나 생성한다.
+   * - 기존 대화: id FOR UPDATE 잠금(초기화 직렬화). 유니크 제약은 soft-delete
+   *   row도 잡으므로 조회 범위를 제약과 동일하게(deleted_at 필터 해제) 맞춘다.
+   * - 부재: 본 트랜잭션에서 생성. 동시 첫 전송의 패자는 승자 커밋 후 P2002를
+   *   받는데, REPEATABLE READ 스냅샷의 일반 재조회는 승자 row를 못 볼 수 있어
+   *   FOR UPDATE 잠금 조회(locking read — MVCC 스냅샷 우회, 최신 커밋을 읽음)로
+   *   복구한다.
    */
-  private async getOrCreateConversation(args: {
-    accountId: bigint;
-    storeId: bigint;
-    now: Date;
-  }) {
+  private async lockOrCreateConversation(
+    tx: Prisma.TransactionClient,
+    args: { accountId: bigint; storeId: bigint; now: Date },
+  ): Promise<bigint> {
+    const lockExisting = async (): Promise<bigint | null> => {
+      const rows = await tx.$queryRaw<{ id: bigint }[]>`
+        SELECT id FROM store_conversation
+        WHERE account_id = ${args.accountId} AND store_id = ${args.storeId}
+        FOR UPDATE`;
+      return rows[0]?.id ?? null;
+    };
+
     const existing = await this.prisma.storeConversation.findFirst({
       where: {
         account_id: args.accountId,
         store_id: args.storeId,
         deleted_at: undefined,
       },
+      select: { id: true },
     });
-    if (existing) return { conversation: existing };
+    if (existing) {
+      const locked = await lockExisting();
+      if (locked !== null) return locked;
+      // 조회와 잠금 사이 hard delete는 운영상 없는 경로 — 생성 재시도로 폴백
+    }
 
     try {
-      const conversation = await this.prisma.storeConversation.create({
+      const created = await tx.storeConversation.create({
         data: {
           account_id: args.accountId,
           store_id: args.storeId,
           created_at: args.now,
         },
+        select: { id: true },
       });
-      return { conversation };
+      return created.id;
     } catch (e) {
       if (
         e instanceof Prisma.PrismaClientKnownRequestError &&
         e.code === 'P2002'
       ) {
-        const conversation =
-          await this.prisma.storeConversation.findFirstOrThrow({
-            where: {
-              account_id: args.accountId,
-              store_id: args.storeId,
-              deleted_at: undefined,
-            },
-          });
-        return { conversation };
+        const locked = await lockExisting();
+        if (locked !== null) return locked;
       }
       throw e;
     }

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -129,11 +129,8 @@ export class ConversationRepository {
   }
 
   /**
-   * 구매자 메시지 저장. 대화가 없으면 이 트랜잭션에서 생성하고, 그 경우에만
-   * 인사말(STORE 발신)을 유저 메시지보다 먼저 저장한다 — 인사말은 대화당 1회.
-   *
-   * 동시 첫 전송 레이스: findFirst 이후 create가 (account_id, store_id) 유니크에
-   * 걸릴 수 있다 → P2002면 기존 대화를 다시 찾아 인사말 없이 이어간다.
+   * 구매자 메시지 저장. 대화가 없으면 먼저 생성하고, 새로 생성한 경우에만
+   * 인사말(STORE 발신)을 유저 메시지보다 앞서 저장한다 — 인사말은 대화당 1회.
    */
   async createBuyerMessages(args: {
     accountId: bigint;
@@ -142,62 +139,29 @@ export class ConversationRepository {
     entries: ConversationMessageEntry[];
     now: Date;
   }) {
-    return this.prisma.$transaction(async (tx) => {
-      // (account_id, store_id) 유니크는 soft-delete된 row도 잡는다 — 조회를
-      // 활성만으로 좁히면 삭제 row 존재 시 create가 항상 P2002로 터지므로,
-      // deleted_at 필터를 명시 해제(undefined)해 유니크 제약과 같은 범위로 찾는다.
-      let conversation = await tx.storeConversation.findFirst({
-        where: {
-          account_id: args.accountId,
-          store_id: args.storeId,
-          deleted_at: undefined,
-        },
-      });
+    // 대화 확보는 메시지 트랜잭션 밖에서 수행한다 — REPEATABLE READ 스냅샷
+    // 안에서 P2002 복구 재조회를 하면 경쟁 트랜잭션이 커밋한 row가 보이지
+    // 않을 수 있다(리뷰 반영). 메시지 삽입 전에 대화 row가 확정되면 충분하고,
+    // 이후 메시지 트랜잭션이 실패해도 빈 대화 row는 목록에 노출되지 않는다
+    // (last_message_at null).
+    const { conversation, created } = await this.getOrCreateConversation(args);
 
-      let withGreeting = false;
-      if (!conversation) {
-        try {
-          conversation = await tx.storeConversation.create({
-            data: {
-              account_id: args.accountId,
-              store_id: args.storeId,
-              created_at: args.now,
+    const toCreate: ConversationMessageEntry[] = [
+      ...(created
+        ? [
+            {
+              senderType: ConversationSenderType.STORE,
+              senderAccountId: null,
+              bodyFormat: ConversationBodyFormat.TEXT,
+              bodyText: args.greetingBodyText,
+              bodyHtml: null,
             },
-          });
-          withGreeting = true;
-        } catch (e) {
-          if (
-            e instanceof Prisma.PrismaClientKnownRequestError &&
-            e.code === 'P2002'
-          ) {
-            conversation = await tx.storeConversation.findFirstOrThrow({
-              where: {
-                account_id: args.accountId,
-                store_id: args.storeId,
-                deleted_at: undefined,
-              },
-            });
-          } else {
-            throw e;
-          }
-        }
-      }
+          ]
+        : []),
+      ...args.entries,
+    ];
 
-      const toCreate: ConversationMessageEntry[] = [
-        ...(withGreeting
-          ? [
-              {
-                senderType: ConversationSenderType.STORE,
-                senderAccountId: null,
-                bodyFormat: ConversationBodyFormat.TEXT,
-                bodyText: args.greetingBodyText,
-                bodyHtml: null,
-              },
-            ]
-          : []),
-        ...args.entries,
-      ];
-
+    return this.prisma.$transaction(async (tx) => {
       // createMany는 생성 row를 돌려주지 않아 순서 보존 개별 create로 저장한다
       // (한 호출당 최대 3건이라 비용 문제 없음)
       const messages = [];
@@ -219,11 +183,65 @@ export class ConversationRepository {
 
       await tx.storeConversation.update({
         where: { id: conversation.id },
-        data: { last_message_at: args.now, updated_at: args.now },
+        data: {
+          last_message_at: args.now,
+          updated_at: args.now,
+          // soft-delete된 대화를 재사용한 경우 복구한다 — 삭제 상태로 두면
+          // 구매자·판매자 어느 조회에도 잡히지 않아 메시지가 유실돼 보인다
+          // (리뷰 반영). 평상시엔 이미 null이라 no-op.
+          deleted_at: null,
+        },
       });
 
       return { conversationId: conversation.id, messages };
     });
+  }
+
+  /**
+   * (account_id, store_id) 대화 확보. 유니크 제약은 soft-delete row도 잡으므로
+   * 조회 범위를 제약과 동일하게(삭제 포함, deleted_at 필터 명시 해제) 맞춘다.
+   * 동시 첫 전송 레이스는 P2002 후 새 문장(새 스냅샷) 재조회로 승자 row를 얻는다.
+   */
+  private async getOrCreateConversation(args: {
+    accountId: bigint;
+    storeId: bigint;
+    now: Date;
+  }) {
+    const existing = await this.prisma.storeConversation.findFirst({
+      where: {
+        account_id: args.accountId,
+        store_id: args.storeId,
+        deleted_at: undefined,
+      },
+    });
+    if (existing) return { conversation: existing, created: false };
+
+    try {
+      const conversation = await this.prisma.storeConversation.create({
+        data: {
+          account_id: args.accountId,
+          store_id: args.storeId,
+          created_at: args.now,
+        },
+      });
+      return { conversation, created: true };
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        const conversation =
+          await this.prisma.storeConversation.findFirstOrThrow({
+            where: {
+              account_id: args.accountId,
+              store_id: args.storeId,
+              deleted_at: undefined,
+            },
+          });
+        return { conversation, created: false };
+      }
+      throw e;
+    }
   }
 
   async createSellerConversationMessage(args: {

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -226,7 +226,11 @@ export class ConversationRepository {
       return rows[0]?.id ?? null;
     };
 
-    const existing = await this.prisma.storeConversation.findFirst({
+    // 사전 조회도 tx 경유 — 트랜잭션 안에서 루트 클라이언트를 쓰면 풀
+    // 커넥션을 2개 점유해 동시 전송이 풀을 소진하면 상호 대기가 난다(리뷰
+    // 반영). tx 스냅샷이 경쟁 커밋을 못 봐도 create → P2002 → 잠금 조회
+    // 경로가 복구하므로 안전하다.
+    const existing = await tx.storeConversation.findFirst({
       where: {
         account_id: args.accountId,
         store_id: args.storeId,

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -144,24 +144,33 @@ export class ConversationRepository {
     // 않을 수 있다(리뷰 반영). 메시지 삽입 전에 대화 row가 확정되면 충분하고,
     // 이후 메시지 트랜잭션이 실패해도 빈 대화 row는 목록에 노출되지 않는다
     // (last_message_at null).
-    const { conversation, created } = await this.getOrCreateConversation(args);
-
-    const toCreate: ConversationMessageEntry[] = [
-      ...(created
-        ? [
-            {
-              senderType: ConversationSenderType.STORE,
-              senderAccountId: null,
-              bodyFormat: ConversationBodyFormat.TEXT,
-              bodyText: args.greetingBodyText,
-              bodyHtml: null,
-            },
-          ]
-        : []),
-      ...args.entries,
-    ];
+    const { conversation } = await this.getOrCreateConversation(args);
 
     return this.prisma.$transaction(async (tx) => {
+      // 첫 메시지 초기화(인사말) 직렬화 — 대화 row를 잠근 뒤 실제 메시지
+      // 수로 인사말 필요 여부를 판정한다(리뷰 반영). "생성 여부" 플래그는
+      // 동시 첫 전송·생성 후 실패 재시도에서 인사말 계약(항상 첫 메시지)을
+      // 깨뜨린다. raw SQL이라 soft-delete 필터는 무관(id 지정 잠금).
+      await tx.$queryRaw`SELECT id FROM store_conversation WHERE id = ${conversation.id} FOR UPDATE`;
+      const messageCount = await tx.storeConversationMessage.count({
+        where: { conversation_id: conversation.id },
+      });
+
+      const toCreate: ConversationMessageEntry[] = [
+        ...(messageCount === 0
+          ? [
+              {
+                senderType: ConversationSenderType.STORE,
+                senderAccountId: null,
+                bodyFormat: ConversationBodyFormat.TEXT,
+                bodyText: args.greetingBodyText,
+                bodyHtml: null,
+              },
+            ]
+          : []),
+        ...args.entries,
+      ];
+
       // createMany는 생성 row를 돌려주지 않아 순서 보존 개별 create로 저장한다
       // (한 호출당 최대 3건이라 비용 문제 없음)
       const messages = [];
@@ -214,7 +223,7 @@ export class ConversationRepository {
         deleted_at: undefined,
       },
     });
-    if (existing) return { conversation: existing, created: false };
+    if (existing) return { conversation: existing };
 
     try {
       const conversation = await this.prisma.storeConversation.create({
@@ -224,7 +233,7 @@ export class ConversationRepository {
           created_at: args.now,
         },
       });
-      return { conversation, created: true };
+      return { conversation };
     } catch (e) {
       if (
         e instanceof Prisma.PrismaClientKnownRequestError &&
@@ -238,7 +247,7 @@ export class ConversationRepository {
               deleted_at: undefined,
             },
           });
-        return { conversation, created: false };
+        return { conversation };
       }
       throw e;
     }

--- a/src/features/conversation/resolvers/conversation-inquiry-mutation.resolver.ts
+++ b/src/features/conversation/resolvers/conversation-inquiry-mutation.resolver.ts
@@ -1,0 +1,37 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+
+import { SendConversationFaqMessageInput } from '@/features/conversation/dto/inputs/send-conversation-faq-message.input';
+import { SendConversationMessageInput } from '@/features/conversation/dto/inputs/send-conversation-message.input';
+import { ConversationInquiryService } from '@/features/conversation/services/conversation-inquiry.service';
+import type { ConversationMessagesPayload } from '@/features/conversation/types/conversation-output.type';
+import {
+  CurrentUser,
+  JwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+@Resolver('Mutation')
+@UseGuards(JwtAuthGuard)
+export class ConversationInquiryMutationResolver {
+  constructor(private readonly inquiryService: ConversationInquiryService) {}
+
+  @Mutation('sendConversationMessage')
+  sendConversationMessage(
+    @CurrentUser() user: JwtUser,
+    @Args('input') input: SendConversationMessageInput,
+  ): Promise<ConversationMessagesPayload> {
+    const accountId = parseAccountId(user);
+    return this.inquiryService.sendConversationMessage(accountId, input);
+  }
+
+  @Mutation('sendConversationFaqMessage')
+  sendConversationFaqMessage(
+    @CurrentUser() user: JwtUser,
+    @Args('input') input: SendConversationFaqMessageInput,
+  ): Promise<ConversationMessagesPayload> {
+    const accountId = parseAccountId(user);
+    return this.inquiryService.sendConversationFaqMessage(accountId, input);
+  }
+}

--- a/src/features/conversation/resolvers/conversation-inquiry-query.resolver.ts
+++ b/src/features/conversation/resolvers/conversation-inquiry-query.resolver.ts
@@ -1,0 +1,26 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { ConversationInquiryService } from '@/features/conversation/services/conversation-inquiry.service';
+import type { StoreInquiryContextOutput } from '@/features/conversation/types/conversation-output.type';
+import {
+  CurrentUser,
+  JwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+@Resolver('Query')
+@UseGuards(JwtAuthGuard)
+export class ConversationInquiryQueryResolver {
+  constructor(private readonly inquiryService: ConversationInquiryService) {}
+
+  @Query('storeInquiryContext')
+  storeInquiryContext(
+    @CurrentUser() user: JwtUser,
+    @Args('storeId') storeId: string,
+  ): Promise<StoreInquiryContextOutput> {
+    const accountId = parseAccountId(user);
+    return this.inquiryService.storeInquiryContext(accountId, storeId);
+  }
+}

--- a/src/features/conversation/resolvers/conversation-inquiry.resolver.spec.ts
+++ b/src/features/conversation/resolvers/conversation-inquiry.resolver.spec.ts
@@ -1,0 +1,91 @@
+// 전체 경로(리졸버→서비스→레포→DB) 통합 검증만 담당. 분기·예외 세부는 service.spec.ts에서 담당
+import type { PrismaClient } from '@prisma/client';
+
+import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { ConversationInquiryMutationResolver } from '@/features/conversation/resolvers/conversation-inquiry-mutation.resolver';
+import { ConversationInquiryQueryResolver } from '@/features/conversation/resolvers/conversation-inquiry-query.resolver';
+import { ConversationInquiryService } from '@/features/conversation/services/conversation-inquiry.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createStore,
+  createUserProfile,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('Conversation Inquiry Resolvers (real DB)', () => {
+  let queryResolver: ConversationInquiryQueryResolver;
+  let mutationResolver: ConversationInquiryMutationResolver;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        ConversationInquiryQueryResolver,
+        ConversationInquiryMutationResolver,
+        ConversationInquiryService,
+        ConversationRepository,
+      ],
+    });
+    queryResolver = module.get(ConversationInquiryQueryResolver);
+    mutationResolver = module.get(ConversationInquiryMutationResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('Query.storeInquiryContext → Mutation.sendConversationMessage 전체 경로', async () => {
+    const buyer = await createAccount(prisma, { account_type: 'USER' });
+    await createUserProfile(prisma, { account_id: buyer.id, nickname: '현진' });
+    const store = await createStore(prisma, { store_name: '해즈 케이크' });
+    const jwtUser = { accountId: buyer.id.toString() };
+
+    const context = await queryResolver.storeInquiryContext(
+      jwtUser,
+      store.id.toString(),
+    );
+    expect(context.storeName).toBe('해즈 케이크');
+    expect(context.conversationId).toBeNull();
+
+    const sent = await mutationResolver.sendConversationMessage(jwtUser, {
+      storeId: store.id.toString(),
+      bodyText: '픽업 문의드립니다',
+    });
+    expect(sent.messages.map((m) => m.senderType)).toEqual(['STORE', 'USER']);
+
+    const after = await queryResolver.storeInquiryContext(
+      jwtUser,
+      store.id.toString(),
+    );
+    expect(after.conversationId).toBe(sent.conversationId);
+  });
+
+  it('Mutation.sendConversationFaqMessage가 질문+자동응답을 저장한다', async () => {
+    const buyer = await createAccount(prisma, { account_type: 'USER' });
+    await createUserProfile(prisma, { account_id: buyer.id });
+    const store = await createStore(prisma);
+    const faq = await prisma.storeFaqTopic.create({
+      data: {
+        store_id: store.id,
+        title: '예약 가능 일정',
+        answer_html: '<p>캘린더를 확인해 주세요.</p>',
+      },
+    });
+
+    const result = await mutationResolver.sendConversationFaqMessage(
+      { accountId: buyer.id.toString() },
+      { storeId: store.id.toString(), faqTopicId: faq.id.toString() },
+    );
+
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[2].bodyHtml).toBe('<p>캘린더를 확인해 주세요.</p>');
+  });
+});

--- a/src/features/conversation/services/conversation-inquiry-mappers.helper.spec.ts
+++ b/src/features/conversation/services/conversation-inquiry-mappers.helper.spec.ts
@@ -1,0 +1,75 @@
+import {
+  formatTimeOfDay,
+  renderGreeting,
+  toInquiryBusinessHour,
+} from '@/features/conversation/services/conversation-inquiry-mappers.helper';
+
+describe('conversation-inquiry-mappers.helper', () => {
+  describe('renderGreeting', () => {
+    it('템플릿이 없으면 기본 문구에 닉네임·매장명을 치환한다', () => {
+      const result = renderGreeting(null, {
+        nickname: '김현진',
+        storeName: '해즈 케이크',
+      });
+
+      expect(result).toContain('김현진 고객님');
+      expect(result).toContain('해즈 케이크');
+      expect(result).not.toContain('{nickname}');
+      expect(result).not.toContain('{storeName}');
+    });
+
+    it('커스텀 템플릿의 placeholder를 전부 치환한다(다회 등장 포함)', () => {
+      const result = renderGreeting(
+        '{nickname}님! {storeName}입니다. {nickname}님 환영해요.',
+        { nickname: '현진', storeName: '달콤' },
+      );
+
+      expect(result).toBe('현진님! 달콤입니다. 현진님 환영해요.');
+    });
+
+    it('placeholder가 없는 템플릿은 그대로 반환한다', () => {
+      expect(
+        renderGreeting('반갑습니다.', { nickname: 'a', storeName: 'b' }),
+      ).toBe('반갑습니다.');
+    });
+  });
+
+  describe('formatTimeOfDay', () => {
+    it('Time 컬럼 Date를 UTC 기준 "HH:mm"으로 만든다', () => {
+      expect(formatTimeOfDay(new Date('1970-01-01T09:05:00Z'))).toBe('09:05');
+      expect(formatTimeOfDay(null)).toBeNull();
+    });
+  });
+
+  describe('toInquiryBusinessHour', () => {
+    it('영업일은 시각을 채우고, 휴무일은 시각을 null로 만든다', () => {
+      expect(
+        toInquiryBusinessHour({
+          day_of_week: 1,
+          is_closed: false,
+          open_time: new Date('1970-01-01T10:00:00Z'),
+          close_time: new Date('1970-01-01T18:00:00Z'),
+        }),
+      ).toEqual({
+        dayOfWeek: 1,
+        isClosed: false,
+        openTime: '10:00',
+        closeTime: '18:00',
+      });
+
+      expect(
+        toInquiryBusinessHour({
+          day_of_week: 0,
+          is_closed: true,
+          open_time: new Date('1970-01-01T10:00:00Z'),
+          close_time: null,
+        }),
+      ).toEqual({
+        dayOfWeek: 0,
+        isClosed: true,
+        openTime: null,
+        closeTime: null,
+      });
+    });
+  });
+});

--- a/src/features/conversation/services/conversation-inquiry-mappers.helper.ts
+++ b/src/features/conversation/services/conversation-inquiry-mappers.helper.ts
@@ -1,0 +1,69 @@
+import {
+  DEFAULT_GREETING_TEMPLATE,
+  GREETING_NICKNAME_PLACEHOLDER,
+  GREETING_STORE_NAME_PLACEHOLDER,
+} from '@/features/conversation/constants/conversation.constants';
+import type {
+  ConversationMessageOutput,
+  InquiryBusinessHourOutput,
+} from '@/features/conversation/types/conversation-output.type';
+
+/** DI-free 순수 함수만 둔다 — 인사말 치환·시각 포맷·메시지 매핑. */
+
+/**
+ * 인사말 렌더링. 매장 커스텀 템플릿이 없으면 기본 문구를 쓴다.
+ * placeholder는 등장 위치·횟수 제한 없이 전부 치환한다.
+ */
+export function renderGreeting(
+  template: string | null,
+  args: { nickname: string; storeName: string },
+): string {
+  return (template ?? DEFAULT_GREETING_TEMPLATE)
+    .replaceAll(GREETING_NICKNAME_PLACEHOLDER, args.nickname)
+    .replaceAll(GREETING_STORE_NAME_PLACEHOLDER, args.storeName);
+}
+
+/**
+ * Prisma Time(@db.Time) → "HH:mm". Time 컬럼은 UTC 기준 Date로 돌아오므로
+ * UTC 게터를 써야 저장값 그대로 나온다(business-hours-formatter와 동일 규칙).
+ */
+export function formatTimeOfDay(date: Date | null): string | null {
+  if (!date) return null;
+  const h = date.getUTCHours().toString().padStart(2, '0');
+  const m = date.getUTCMinutes().toString().padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+export function toInquiryBusinessHour(row: {
+  day_of_week: number;
+  is_closed: boolean;
+  open_time: Date | null;
+  close_time: Date | null;
+}): InquiryBusinessHourOutput {
+  return {
+    dayOfWeek: row.day_of_week,
+    isClosed: row.is_closed,
+    openTime: row.is_closed ? null : formatTimeOfDay(row.open_time),
+    closeTime: row.is_closed ? null : formatTimeOfDay(row.close_time),
+  };
+}
+
+export function toConversationMessageOutput(row: {
+  id: bigint;
+  conversation_id: bigint;
+  sender_type: 'USER' | 'STORE' | 'SYSTEM';
+  body_format: 'TEXT' | 'HTML';
+  body_text: string | null;
+  body_html: string | null;
+  created_at: Date;
+}): ConversationMessageOutput {
+  return {
+    id: row.id.toString(),
+    conversationId: row.conversation_id.toString(),
+    senderType: row.sender_type,
+    bodyFormat: row.body_format,
+    bodyText: row.body_text,
+    bodyHtml: row.body_html,
+    createdAt: row.created_at,
+  };
+}

--- a/src/features/conversation/services/conversation-inquiry.service.spec.ts
+++ b/src/features/conversation/services/conversation-inquiry.service.spec.ts
@@ -236,6 +236,11 @@ describe('ConversationInquiryService (real DB)', () => {
       // 기존 대화 재사용이므로 인사말은 다시 저장하지 않는다
       expect(result.messages).toHaveLength(1);
       expect(result.messages[0].senderType).toBe('USER');
+      // 재사용 시 복구 — 삭제 상태로 두면 어느 조회에도 잡히지 않는다
+      const restored = await prisma.storeConversation.findUniqueOrThrow({
+        where: { id: softDeleted.id },
+      });
+      expect(restored.deleted_at).toBeNull();
     });
 
     it('공백뿐인 본문·2000자 초과 본문은 거절한다', async () => {

--- a/src/features/conversation/services/conversation-inquiry.service.spec.ts
+++ b/src/features/conversation/services/conversation-inquiry.service.spec.ts
@@ -1,0 +1,344 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { PrismaClient } from '@prisma/client';
+
+import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { ConversationInquiryService } from '@/features/conversation/services/conversation-inquiry.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createStore,
+  createUserProfile,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('ConversationInquiryService (real DB)', () => {
+  let service: ConversationInquiryService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ConversationInquiryService, ConversationRepository],
+    });
+    service = module.get(ConversationInquiryService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  async function setupBuyer(nickname = '김현진') {
+    const account = await createAccount(prisma, { account_type: 'USER' });
+    await createUserProfile(prisma, { account_id: account.id, nickname });
+    return account;
+  }
+
+  async function createFaq(
+    storeId: bigint,
+    overrides: {
+      title?: string;
+      answer_html?: string;
+      sort_order?: number;
+      is_active?: boolean;
+    } = {},
+  ) {
+    return prisma.storeFaqTopic.create({
+      data: {
+        store_id: storeId,
+        title: overrides.title ?? '케이크 보관 방법',
+        answer_html: overrides.answer_html ?? '<p>냉장보관시 최대 3일</p>',
+        sort_order: overrides.sort_order ?? 0,
+        is_active: overrides.is_active ?? true,
+      },
+    });
+  }
+
+  async function messagesOf(conversationId: bigint) {
+    return prisma.storeConversationMessage.findMany({
+      where: { conversation_id: conversationId },
+      orderBy: { id: 'asc' },
+    });
+  }
+
+  // ─── storeInquiryContext ───
+  describe('storeInquiryContext', () => {
+    it('매장 정보·기본 인사말·FAQ 칩·요일별 상담시간을 반환한다', async () => {
+      const buyer = await setupBuyer('김현진');
+      const store = await createStore(prisma, { store_name: '해즈 케이크' });
+      await prisma.storeBusinessHour.createMany({
+        data: [
+          {
+            store_id: store.id,
+            day_of_week: 1,
+            is_closed: false,
+            open_time: new Date('1970-01-01T10:00:00Z'),
+            close_time: new Date('1970-01-01T18:00:00Z'),
+          },
+          { store_id: store.id, day_of_week: 0, is_closed: true },
+        ],
+      });
+      await createFaq(store.id, { title: '날짜 변경', sort_order: 2 });
+      await createFaq(store.id, { title: '케이크 보관 방법', sort_order: 1 });
+      await createFaq(store.id, { title: '비활성 칩', is_active: false });
+
+      const result = await service.storeInquiryContext(
+        buyer.id,
+        store.id.toString(),
+      );
+
+      expect(result.storeName).toBe('해즈 케이크');
+      // 매장 인사말 미설정 → 기본 문구에 닉네임·매장명 치환
+      expect(result.greetingMessage).toContain('김현진 고객님');
+      expect(result.greetingMessage).toContain('해즈 케이크');
+      expect(result.greetingMessage).not.toContain('{nickname}');
+      // 활성 FAQ만 sort_order 순으로
+      expect(result.faqTopics.map((t) => t.title)).toEqual([
+        '케이크 보관 방법',
+        '날짜 변경',
+      ]);
+      // 요일 오름차순 + 휴무일은 시각 null
+      expect(result.businessHours).toEqual([
+        { dayOfWeek: 0, isClosed: true, openTime: null, closeTime: null },
+        {
+          dayOfWeek: 1,
+          isClosed: false,
+          openTime: '10:00',
+          closeTime: '18:00',
+        },
+      ]);
+      expect(result.conversationId).toBeNull();
+    });
+
+    it('커스텀 인사말 템플릿을 치환해 반환하고, 기존 대화 ID를 채운다', async () => {
+      const buyer = await setupBuyer('현진');
+      const store = await createStore(prisma, {
+        store_name: '달콤 케이크',
+        greeting_message: '{storeName}에 오신 {nickname}님 환영!',
+      });
+      const conv = await prisma.storeConversation.create({
+        data: { account_id: buyer.id, store_id: store.id },
+      });
+
+      const result = await service.storeInquiryContext(
+        buyer.id,
+        store.id.toString(),
+      );
+
+      expect(result.greetingMessage).toBe('달콤 케이크에 오신 현진님 환영!');
+      expect(result.conversationId).toBe(conv.id.toString());
+    });
+
+    it('비활성/삭제 매장은 NotFoundException', async () => {
+      const buyer = await setupBuyer();
+      const inactive = await createStore(prisma, { is_active: false });
+      const deleted = await createStore(prisma, { deleted_at: new Date() });
+
+      await expect(
+        service.storeInquiryContext(buyer.id, inactive.id.toString()),
+      ).rejects.toThrow(NotFoundException);
+      await expect(
+        service.storeInquiryContext(buyer.id, deleted.id.toString()),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('없는 계정은 Unauthorized, SELLER 계정은 Forbidden', async () => {
+      const store = await createStore(prisma);
+      const seller = await createAccount(prisma, { account_type: 'SELLER' });
+
+      await expect(
+        service.storeInquiryContext(BigInt(999999), store.id.toString()),
+      ).rejects.toThrow(UnauthorizedException);
+      await expect(
+        service.storeInquiryContext(seller.id, store.id.toString()),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ─── sendConversationMessage ───
+  describe('sendConversationMessage', () => {
+    it('첫 전송이면 대화를 생성하고 인사말(STORE) → 유저 메시지 순으로 저장한다', async () => {
+      const buyer = await setupBuyer('김현진');
+      const store = await createStore(prisma, { store_name: '해즈 케이크' });
+
+      const result = await service.sendConversationMessage(buyer.id, {
+        storeId: store.id.toString(),
+        bodyText: '  픽업 시간 변경 가능한가요?  ',
+      });
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0].senderType).toBe('STORE');
+      expect(result.messages[0].bodyText).toContain('김현진 고객님');
+      expect(result.messages[1].senderType).toBe('USER');
+      // 앞뒤 공백은 정리해 저장한다
+      expect(result.messages[1].bodyText).toBe('픽업 시간 변경 가능한가요?');
+
+      const conversation = await prisma.storeConversation.findFirstOrThrow({
+        where: { account_id: buyer.id, store_id: store.id },
+      });
+      expect(result.conversationId).toBe(conversation.id.toString());
+      expect(conversation.last_message_at).not.toBeNull();
+      expect(await messagesOf(conversation.id)).toHaveLength(2);
+    });
+
+    it('대화가 이미 있으면 인사말 없이 유저 메시지 1건만 저장한다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      await service.sendConversationMessage(buyer.id, {
+        storeId: store.id.toString(),
+        bodyText: '첫 메시지',
+      });
+
+      const second = await service.sendConversationMessage(buyer.id, {
+        storeId: store.id.toString(),
+        bodyText: '두 번째 메시지',
+      });
+
+      expect(second.messages).toHaveLength(1);
+      expect(second.messages[0].senderType).toBe('USER');
+
+      const conversations = await prisma.storeConversation.findMany({
+        where: { account_id: buyer.id, store_id: store.id },
+      });
+      // 계정당 매장당 대화 1개 유지(중복 생성 없음)
+      expect(conversations).toHaveLength(1);
+      expect(await messagesOf(conversations[0].id)).toHaveLength(3);
+    });
+
+    it('soft-delete된 대화가 있으면 유니크 충돌 없이 그 대화를 재사용한다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const softDeleted = await prisma.storeConversation.create({
+        data: {
+          account_id: buyer.id,
+          store_id: store.id,
+          deleted_at: new Date(),
+        },
+      });
+
+      const result = await service.sendConversationMessage(buyer.id, {
+        storeId: store.id.toString(),
+        bodyText: '다시 문의드립니다',
+      });
+
+      // 유니크 제약 범위(삭제 포함)와 동일하게 기존 row를 찾아 이어간다
+      expect(result.conversationId).toBe(softDeleted.id.toString());
+      // 기존 대화 재사용이므로 인사말은 다시 저장하지 않는다
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].senderType).toBe('USER');
+    });
+
+    it('공백뿐인 본문·2000자 초과 본문은 거절한다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+
+      await expect(
+        service.sendConversationMessage(buyer.id, {
+          storeId: store.id.toString(),
+          bodyText: '   ',
+        }),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.sendConversationMessage(buyer.id, {
+          storeId: store.id.toString(),
+          bodyText: 'a'.repeat(2001),
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('비활성 매장에는 전송할 수 없다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma, { is_active: false });
+
+      await expect(
+        service.sendConversationMessage(buyer.id, {
+          storeId: store.id.toString(),
+          bodyText: '안녕하세요',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ─── sendConversationFaqMessage ───
+  describe('sendConversationFaqMessage', () => {
+    it('첫 전송이면 인사말 → 유저 질문(TEXT) → 자동응답(HTML) 3건을 저장한다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const faq = await createFaq(store.id, {
+        title: '케이크 보관 방법',
+        answer_html: '<p>냉장보관시 최대 3일</p>',
+      });
+
+      const result = await service.sendConversationFaqMessage(buyer.id, {
+        storeId: store.id.toString(),
+        faqTopicId: faq.id.toString(),
+      });
+
+      expect(result.messages).toHaveLength(3);
+      expect(result.messages[0].senderType).toBe('STORE');
+      expect(result.messages[0].bodyFormat).toBe('TEXT');
+      expect(result.messages[1]).toMatchObject({
+        senderType: 'USER',
+        bodyFormat: 'TEXT',
+        bodyText: '케이크 보관 방법',
+      });
+      expect(result.messages[2]).toMatchObject({
+        senderType: 'STORE',
+        bodyFormat: 'HTML',
+        bodyHtml: '<p>냉장보관시 최대 3일</p>',
+      });
+    });
+
+    it('기존 대화가 있으면 질문+자동응답 2건만 저장한다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const faq = await createFaq(store.id);
+      await service.sendConversationMessage(buyer.id, {
+        storeId: store.id.toString(),
+        bodyText: '먼저 보낸 메시지',
+      });
+
+      const result = await service.sendConversationFaqMessage(buyer.id, {
+        storeId: store.id.toString(),
+        faqTopicId: faq.id.toString(),
+      });
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages.map((m) => m.senderType)).toEqual([
+        'USER',
+        'STORE',
+      ]);
+    });
+
+    it('비활성 FAQ·다른 매장 FAQ는 NotFoundException', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const otherStore = await createStore(prisma);
+      const inactiveFaq = await createFaq(store.id, { is_active: false });
+      const othersFaq = await createFaq(otherStore.id);
+
+      await expect(
+        service.sendConversationFaqMessage(buyer.id, {
+          storeId: store.id.toString(),
+          faqTopicId: inactiveFaq.id.toString(),
+        }),
+      ).rejects.toThrow(NotFoundException);
+      await expect(
+        service.sendConversationFaqMessage(buyer.id, {
+          storeId: store.id.toString(),
+          faqTopicId: othersFaq.id.toString(),
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/features/conversation/services/conversation-inquiry.service.spec.ts
+++ b/src/features/conversation/services/conversation-inquiry.service.spec.ts
@@ -233,9 +233,12 @@ describe('ConversationInquiryService (real DB)', () => {
 
       // 유니크 제약 범위(삭제 포함)와 동일하게 기존 row를 찾아 이어간다
       expect(result.conversationId).toBe(softDeleted.id.toString());
-      // 기존 대화 재사용이므로 인사말은 다시 저장하지 않는다
-      expect(result.messages).toHaveLength(1);
-      expect(result.messages[0].senderType).toBe('USER');
+      // 인사말 여부는 "메시지 0건" 기준 — 빈 대화 재사용이면 인사말부터 저장한다
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages.map((m) => m.senderType)).toEqual([
+        'STORE',
+        'USER',
+      ]);
       // 재사용 시 복구 — 삭제 상태로 두면 어느 조회에도 잡히지 않는다
       const restored = await prisma.storeConversation.findUniqueOrThrow({
         where: { id: softDeleted.id },

--- a/src/features/conversation/services/conversation-inquiry.service.ts
+++ b/src/features/conversation/services/conversation-inquiry.service.ts
@@ -1,0 +1,192 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConversationBodyFormat, ConversationSenderType } from '@prisma/client';
+
+import { parseId } from '@/common/utils/id-parser';
+import { cleanRequiredText } from '@/common/utils/text-cleaner';
+import { CONVERSATION_ERRORS } from '@/features/conversation/constants/conversation-error-messages';
+import { MAX_INQUIRY_BODY_TEXT_LENGTH } from '@/features/conversation/constants/conversation.constants';
+import type { SendConversationFaqMessageInput } from '@/features/conversation/dto/inputs/send-conversation-faq-message.input';
+import type { SendConversationMessageInput } from '@/features/conversation/dto/inputs/send-conversation-message.input';
+import {
+  ConversationRepository,
+  type ConversationMessageEntry,
+} from '@/features/conversation/repositories/conversation.repository';
+import {
+  renderGreeting,
+  toConversationMessageOutput,
+  toInquiryBusinessHour,
+} from '@/features/conversation/services/conversation-inquiry-mappers.helper';
+import type {
+  ConversationMessagesPayload,
+  StoreInquiryContextOutput,
+} from '@/features/conversation/types/conversation-output.type';
+import { evaluateActiveUserAccount } from '@/features/user';
+
+@Injectable()
+export class ConversationInquiryService {
+  constructor(private readonly repo: ConversationRepository) {}
+
+  async storeInquiryContext(
+    accountId: bigint,
+    storeIdRaw: string,
+  ): Promise<StoreInquiryContextOutput> {
+    const { nickname } = await this.requireActiveUser(accountId);
+    const storeId = parseId(storeIdRaw);
+
+    const store = await this.requireInquiryStore(storeId);
+    const [faqTopics, conversation] = await Promise.all([
+      this.repo.listActiveFaqTopics(storeId),
+      this.repo.findConversationByAccountAndStore({ accountId, storeId }),
+    ]);
+
+    return {
+      storeId: store.id.toString(),
+      storeName: store.store_name,
+      profileImageUrl: store.profile_image_url,
+      businessHours: store.business_hours.map(toInquiryBusinessHour),
+      greetingMessage: renderGreeting(store.greeting_message, {
+        nickname,
+        storeName: store.store_name,
+      }),
+      faqTopics: faqTopics.map((t) => ({
+        id: t.id.toString(),
+        title: t.title,
+      })),
+      conversationId: conversation?.id.toString() ?? null,
+    };
+  }
+
+  async sendConversationMessage(
+    accountId: bigint,
+    input: SendConversationMessageInput,
+  ): Promise<ConversationMessagesPayload> {
+    const { nickname } = await this.requireActiveUser(accountId);
+    const storeId = parseId(input.storeId);
+    const store = await this.requireInquiryStore(storeId);
+
+    const bodyText = cleanRequiredText(
+      input.bodyText,
+      MAX_INQUIRY_BODY_TEXT_LENGTH,
+    );
+
+    return this.saveBuyerMessages({
+      accountId,
+      storeId,
+      nickname,
+      storeName: store.store_name,
+      greetingTemplate: store.greeting_message,
+      entries: [
+        {
+          senderType: ConversationSenderType.USER,
+          senderAccountId: accountId,
+          bodyFormat: ConversationBodyFormat.TEXT,
+          bodyText,
+          bodyHtml: null,
+        },
+      ],
+    });
+  }
+
+  async sendConversationFaqMessage(
+    accountId: bigint,
+    input: SendConversationFaqMessageInput,
+  ): Promise<ConversationMessagesPayload> {
+    const { nickname } = await this.requireActiveUser(accountId);
+    const storeId = parseId(input.storeId);
+    const store = await this.requireInquiryStore(storeId);
+
+    const topic = await this.repo.findActiveFaqTopic({
+      storeId,
+      faqTopicId: parseId(input.faqTopicId),
+    });
+    if (!topic) {
+      throw new NotFoundException(CONVERSATION_ERRORS.FAQ_TOPIC_NOT_FOUND);
+    }
+
+    // 칩 탭 = 유저 질문(칩 제목) + 매장 자동응답(FAQ 답변 스냅샷) 한 쌍 저장.
+    // 이후 FAQ가 수정돼도 저장된 대화 이력은 당시 답변을 유지한다.
+    return this.saveBuyerMessages({
+      accountId,
+      storeId,
+      nickname,
+      storeName: store.store_name,
+      greetingTemplate: store.greeting_message,
+      entries: [
+        {
+          senderType: ConversationSenderType.USER,
+          senderAccountId: accountId,
+          bodyFormat: ConversationBodyFormat.TEXT,
+          bodyText: topic.title,
+          bodyHtml: null,
+        },
+        {
+          senderType: ConversationSenderType.STORE,
+          senderAccountId: null,
+          bodyFormat: ConversationBodyFormat.HTML,
+          bodyText: null,
+          bodyHtml: topic.answer_html,
+        },
+      ],
+    });
+  }
+
+  private async saveBuyerMessages(args: {
+    accountId: bigint;
+    storeId: bigint;
+    nickname: string;
+    storeName: string;
+    greetingTemplate: string | null;
+    entries: ConversationMessageEntry[];
+  }): Promise<ConversationMessagesPayload> {
+    const result = await this.repo.createBuyerMessages({
+      accountId: args.accountId,
+      storeId: args.storeId,
+      // 첫 전송으로 대화가 생성될 때만 repository가 사용한다(치환 완료본 저장)
+      greetingBodyText: renderGreeting(args.greetingTemplate, {
+        nickname: args.nickname,
+        storeName: args.storeName,
+      }),
+      entries: args.entries,
+      now: new Date(),
+    });
+
+    return {
+      conversationId: result.conversationId.toString(),
+      messages: result.messages.map(toConversationMessageOutput),
+    };
+  }
+
+  /** user feature의 활성 USER 판정 정책을 공유한다(메시지 매핑만 도메인별). */
+  private async requireActiveUser(
+    accountId: bigint,
+  ): Promise<{ nickname: string }> {
+    const account = await this.repo.findUserAccountForInquiry(accountId);
+    switch (evaluateActiveUserAccount(account)) {
+      case 'ACCOUNT_NOT_FOUND':
+        throw new UnauthorizedException(CONVERSATION_ERRORS.ACCOUNT_NOT_FOUND);
+      case 'ACCOUNT_DELETED':
+        throw new UnauthorizedException(CONVERSATION_ERRORS.ACCOUNT_DELETED);
+      case 'NOT_USER':
+        throw new ForbiddenException(CONVERSATION_ERRORS.NOT_USER);
+      case 'PROFILE_INACTIVE':
+        throw new UnauthorizedException(CONVERSATION_ERRORS.PROFILE_INACTIVE);
+      case null:
+        break;
+    }
+    // evaluate 통과 시 user_profile 존재가 보장된다
+    return { nickname: account!.user_profile!.nickname };
+  }
+
+  private async requireInquiryStore(storeId: bigint) {
+    const store = await this.repo.findInquiryStore(storeId);
+    if (!store) {
+      throw new NotFoundException(CONVERSATION_ERRORS.STORE_NOT_FOUND);
+    }
+    return store;
+  }
+}

--- a/src/features/conversation/types/conversation-output.type.ts
+++ b/src/features/conversation/types/conversation-output.type.ts
@@ -1,0 +1,41 @@
+import type {
+  ConversationBodyFormat,
+  ConversationSenderType,
+} from '@prisma/client';
+
+export interface InquiryBusinessHourOutput {
+  dayOfWeek: number;
+  isClosed: boolean;
+  openTime: string | null;
+  closeTime: string | null;
+}
+
+export interface InquiryFaqTopicOutput {
+  id: string;
+  title: string;
+}
+
+export interface StoreInquiryContextOutput {
+  storeId: string;
+  storeName: string;
+  profileImageUrl: string | null;
+  businessHours: InquiryBusinessHourOutput[];
+  greetingMessage: string;
+  faqTopics: InquiryFaqTopicOutput[];
+  conversationId: string | null;
+}
+
+export interface ConversationMessageOutput {
+  id: string;
+  conversationId: string;
+  senderType: ConversationSenderType;
+  bodyFormat: ConversationBodyFormat;
+  bodyText: string | null;
+  bodyHtml: string | null;
+  createdAt: Date;
+}
+
+export interface ConversationMessagesPayload {
+  conversationId: string;
+  messages: ConversationMessageOutput[];
+}

--- a/src/features/seller/constants/seller.constants.ts
+++ b/src/features/seller/constants/seller.constants.ts
@@ -60,4 +60,6 @@ export const MAX_BANNER_TITLE_LENGTH = 200;
 // ── 대화 ──
 
 export const MAX_CONVERSATION_BODY_TEXT_LENGTH = 2000;
+// 문의 채팅 인사말 템플릿(store.greeting_message VARCHAR(500)과 동일 상한)
+export const MAX_GREETING_MESSAGE_LENGTH = 500;
 export const MAX_CONVERSATION_BODY_HTML_LENGTH = 100000;

--- a/src/features/seller/dto/inputs/seller-update-store-basic-info.input.ts
+++ b/src/features/seller/dto/inputs/seller-update-store-basic-info.input.ts
@@ -51,4 +51,8 @@ export class SellerUpdateStoreBasicInfoInput {
   @IsOptional()
   @IsString()
   profileImageUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  greetingMessage?: string;
 }

--- a/src/features/seller/seller-store.graphql
+++ b/src/features/seller/seller-store.graphql
@@ -58,6 +58,8 @@ type SellerStore {
   businessHoursText: String
   """매장 프로필(로고) 이미지 URL. 미등록 시 null."""
   profileImageUrl: String
+  """문의 채팅 인사말 템플릿({nickname}/{storeName} 치환). null이면 기본 문구."""
+  greetingMessage: String
   pickupSlotIntervalMinutes: Int!
   minLeadTimeMinutes: Int!
   maxDaysAhead: Int!

--- a/src/features/seller/seller-store.graphql
+++ b/src/features/seller/seller-store.graphql
@@ -122,6 +122,8 @@ input SellerUpdateStoreBasicInfoInput {
   businessHoursText: String
   """매장 프로필(로고) 이미지 URL. null 전달 시 제거."""
   profileImageUrl: String
+  """문의 채팅 인사말 템플릿. 빈 문자열이면 기본 문구로 되돌린다(null 저장)."""
+  greetingMessage: String
 }
 
 """SellerUpsertStoreBusinessHourInput 입력 타입"""

--- a/src/features/seller/services/seller-store-mappers.helper.ts
+++ b/src/features/seller/services/seller-store-mappers.helper.ts
@@ -28,6 +28,7 @@ export interface StoreRow {
   website_url: string | null;
   business_hours_text: string | null;
   profile_image_url: string | null;
+  greeting_message: string | null;
   pickup_slot_interval_minutes: number;
   min_lead_time_minutes: number;
   max_days_ahead: number;
@@ -78,6 +79,7 @@ export function toStoreOutput(row: StoreRow): SellerStoreOutput {
     websiteUrl: row.website_url,
     businessHoursText: row.business_hours_text,
     profileImageUrl: row.profile_image_url,
+    greetingMessage: row.greeting_message,
     pickupSlotIntervalMinutes: row.pickup_slot_interval_minutes,
     minLeadTimeMinutes: row.min_lead_time_minutes,
     maxDaysAhead: row.max_days_ahead,

--- a/src/features/seller/services/seller-store-profile.service.spec.ts
+++ b/src/features/seller/services/seller-store-profile.service.spec.ts
@@ -188,5 +188,28 @@ describe('SellerStoreProfileService (real DB)', () => {
       } as unknown as SellerUpdateStoreBasicInfoInput);
       expect(removed.profileImageUrl).toBeNull();
     });
+
+    it('greetingMessage를 설정하고, 빈 문자열이면 null로 되돌린다(기본 인사말 사용)', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+
+      const set = await service.sellerUpdateStoreBasicInfo(account.id, {
+        greetingMessage: '{nickname}님 반가워요! {storeName}입니다.',
+      });
+      expect(set.greetingMessage).toBe(
+        '{nickname}님 반가워요! {storeName}입니다.',
+      );
+      const dbStore = await prisma.store.findUniqueOrThrow({
+        where: { id: store.id },
+      });
+      expect(dbStore.greeting_message).toBe(
+        '{nickname}님 반가워요! {storeName}입니다.',
+      );
+
+      // 빈 문자열 → null 저장(문의 채팅은 서버 기본 문구로 동작)
+      const cleared = await service.sellerUpdateStoreBasicInfo(account.id, {
+        greetingMessage: '   ',
+      });
+      expect(cleared.greetingMessage).toBeNull();
+    });
   });
 });

--- a/src/features/seller/services/seller-store-profile.service.ts
+++ b/src/features/seller/services/seller-store-profile.service.ts
@@ -12,6 +12,7 @@ import {
 import { STORE_NOT_FOUND } from '@/features/seller/constants/seller-error-messages';
 import {
   MAX_ADDRESS_CITY_LENGTH,
+  MAX_GREETING_MESSAGE_LENGTH,
   MAX_ADDRESS_DISTRICT_LENGTH,
   MAX_ADDRESS_FULL_LENGTH,
   MAX_ADDRESS_NEIGHBORHOOD_LENGTH,
@@ -160,6 +161,15 @@ export class SellerStoreProfileService
             profile_image_url: cleanNullableText(
               input.profileImageUrl,
               MAX_URL_LENGTH,
+            ),
+          }
+        : {}),
+      // 빈 문자열은 null 저장 → 문의 채팅에서 서버 기본 인사말로 되돌아간다
+      ...(input.greetingMessage !== undefined
+        ? {
+            greeting_message: cleanNullableText(
+              input.greetingMessage,
+              MAX_GREETING_MESSAGE_LENGTH,
             ),
           }
         : {}),

--- a/src/features/seller/types/seller-output.type.ts
+++ b/src/features/seller/types/seller-output.type.ts
@@ -13,6 +13,7 @@ export interface SellerStoreOutput {
   websiteUrl: string | null;
   businessHoursText: string | null;
   profileImageUrl: string | null;
+  greetingMessage: string | null;
   pickupSlotIntervalMinutes: number;
   minLeadTimeMinutes: number;
   maxDaysAhead: number;

--- a/src/test/factories/store.factory.ts
+++ b/src/test/factories/store.factory.ts
@@ -18,6 +18,8 @@ export interface StoreOverrides {
   map_provider?: 'NAVER' | 'KAKAO' | 'NONE';
   business_hours_text?: string | null;
   profile_image_url?: string | null;
+  greeting_message?: string | null;
+  deleted_at?: Date | null;
   access_guide_text?: string | null;
   regular_closure_text?: string | null;
   pickup_slot_interval_minutes?: number;
@@ -51,6 +53,8 @@ export async function createStore(
       map_provider: overrides.map_provider ?? 'NONE',
       business_hours_text: overrides.business_hours_text ?? null,
       profile_image_url: overrides.profile_image_url ?? null,
+      greeting_message: overrides.greeting_message ?? null,
+      deleted_at: overrides.deleted_at ?? null,
       access_guide_text: overrides.access_guide_text ?? null,
       regular_closure_text: overrides.regular_closure_text ?? null,
       pickup_slot_interval_minutes:


### PR DESCRIPTION
## 배경

figma 알림센터(문의 채팅) 화면 대응 2/4. conversation feature에는 DB 모델과 판매자 측 API만 있었고, 구매자 측(대화 생성·전송)은 전무했다.

## 변경점

- **Prisma**: `store.greeting_message VARCHAR(500)` 추가(마이그레이션) — 인사말 템플릿(`{nickname}`/`{storeName}` 치환, null이면 서버 기본 문구).
- **`storeInquiryContext(storeId)`**: 채팅 진입 화면 데이터 — 매장 프로필, 요일별 상담시간("HH:mm"), 치환 완료 인사말, 질문 칩(활성 StoreFaqTopic 정렬순), 기존 대화 ID.
- **`sendConversationMessage`**: 텍스트 전송. 첫 전송 시 대화 생성 + 인사말 STORE 메시지 선저장(대화당 1회, 이력 보존 — 판매자 화면에도 보임).
- **`sendConversationFaqMessage`**: 칩 탭 → 유저 질문(TEXT) + 자동응답(FAQ answer_html, HTML) 트랜잭션 저장. 답변은 저장 시점 스냅샷.
- **동시성/soft-delete**: 대화 조회를 유니크 제약과 같은 범위(삭제 포함)로 맞춰 P2002 예방, 잔여 레이스는 P2002 복구로 방어.
- **판매자**: `sellerUpdateStoreBasicInfo`에 `greetingMessage` 확장(빈 문자열 → null = 기본 문구 복귀), `SellerStore`에 노출.
- **시드**: FAQ 칩 5종 + 대화 2건(칩 문답, 판매자 답장 3건 안읽음 재현), `resetSeedScope` 정리 범위 갱신(재시드 멱등 확인 완료).

## 테스트

- service 12케이스 / 매퍼 helper 6케이스 / resolver 통합 2케이스 / input 6케이스 / seller greeting 케이스
- `yarn validate` 전체 통과 (215 suites / 1825 tests), 시드 2회 연속 실행 멱등 확인