### PR TITLE
feat(conversation): 알림센터 대화 탭 — 대화 목록·채팅 상세 조회·읽음 처리

### DIFF
--- a/src/common/utils/id-parser.spec.ts
+++ b/src/common/utils/id-parser.spec.ts
@@ -24,6 +24,12 @@ describe('id-parser', () => {
     expect(() => parseId('   ')).toThrow(BadRequestException);
   });
 
+  it('UNSIGNED BIGINT 상한(2^64-1)을 넘으면 BadRequestException을 던진다', () => {
+    expect(parseId('18446744073709551615')).toBe(18446744073709551615n);
+    expect(() => parseId('18446744073709551616')).toThrow(BadRequestException);
+    expect(() => parseId('9'.repeat(30))).toThrow(BadRequestException);
+  });
+
   it('음수이면 BadRequestException을 던진다', () => {
     expect(() => parseId('-1')).toThrow(BadRequestException);
   });

--- a/src/common/utils/id-parser.ts
+++ b/src/common/utils/id-parser.ts
@@ -1,5 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 
+import { MAX_UNSIGNED_BIGINT } from '@/common/utils/keyset-cursor';
+
 export function parseId(raw: string): bigint {
   const trimmed = raw.trim();
   if (trimmed === '') {
@@ -11,7 +13,9 @@ export function parseId(raw: string): bigint {
   } catch {
     throw new BadRequestException('Invalid id.');
   }
-  if (id < 0n) {
+  // DB UNSIGNED BIGINT 범위 밖 값은 커넥터 범위 오류(내부 오류)로 번진다 —
+  // 클라이언트 입력 단계에서 형식 오류로 거부한다.
+  if (id < 0n || id > MAX_UNSIGNED_BIGINT) {
     throw new BadRequestException('Invalid id.');
   }
   return id;

--- a/src/common/utils/keyset-cursor.spec.ts
+++ b/src/common/utils/keyset-cursor.spec.ts
@@ -39,6 +39,17 @@ describe('keyset-cursor', () => {
     );
   });
 
+  it('MySQL DATETIME 상한(9999년)을 넘는 timestamp를 거부한다', () => {
+    // 연도 10000 — JS Date로는 유효하지만 MySQL DATETIME 범위 밖
+    expect(() => parseTimestampIdCursor('253402300800000:1', ERR)).toThrow(
+      BadRequestException,
+    );
+    // 상한 자체는 허용
+    expect(
+      parseTimestampIdCursor('253402300799999:1', ERR).timestamp.getTime(),
+    ).toBe(253402300799999);
+  });
+
   it('UNSIGNED BIGINT 상한을 넘는 id를 거부한다', () => {
     expect(() =>
       parseTimestampIdCursor(`1700000000000:${'9'.repeat(30)}`, ERR),

--- a/src/common/utils/keyset-cursor.spec.ts
+++ b/src/common/utils/keyset-cursor.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 
 import {
   buildTimestampIdCursor,
+  parseIdCursor,
   parseTimestampIdCursor,
 } from '@/common/utils/keyset-cursor';
 
@@ -46,5 +47,20 @@ describe('keyset-cursor', () => {
     expect(
       parseTimestampIdCursor('1700000000000:18446744073709551615', ERR).id,
     ).toBe(18446744073709551615n);
+  });
+
+  describe('parseIdCursor', () => {
+    it('정상 id는 bigint로 파싱하고 상한 자체는 허용한다', () => {
+      expect(parseIdCursor('42', ERR)).toBe(42n);
+      expect(parseIdCursor('18446744073709551615', ERR)).toBe(
+        18446744073709551615n,
+      );
+    });
+
+    it('형식 불일치·UNSIGNED BIGINT 상한 초과를 거부한다', () => {
+      for (const raw of ['abc', '-1', '', '1.5', '9'.repeat(30)]) {
+        expect(() => parseIdCursor(raw, ERR)).toThrow(BadRequestException);
+      }
+    });
   });
 });

--- a/src/common/utils/keyset-cursor.spec.ts
+++ b/src/common/utils/keyset-cursor.spec.ts
@@ -1,0 +1,50 @@
+import { BadRequestException } from '@nestjs/common';
+
+import {
+  buildTimestampIdCursor,
+  parseTimestampIdCursor,
+} from '@/common/utils/keyset-cursor';
+
+describe('keyset-cursor', () => {
+  const ERR = 'Invalid cursor.';
+
+  it('build → parse 왕복이 값을 보존한다', () => {
+    const ts = new Date('2026-08-01T12:34:56.789Z');
+    const raw = buildTimestampIdCursor(ts, BigInt(42));
+
+    expect(parseTimestampIdCursor(raw, ERR)).toEqual({
+      timestamp: ts,
+      id: BigInt(42),
+    });
+  });
+
+  it('형식이 다르면 거부한다', () => {
+    for (const raw of ['abc', '123', '1:2:3', '-1:2', '1:-2', '']) {
+      expect(() => parseTimestampIdCursor(raw, ERR)).toThrow(
+        BadRequestException,
+      );
+    }
+  });
+
+  it('안전 정수 밖 timestamp(자릿수 폭탄)를 거부한다', () => {
+    expect(() => parseTimestampIdCursor(`${'9'.repeat(30)}:1`, ERR)).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('Date 지원 범위 밖 timestamp를 거부한다', () => {
+    expect(() => parseTimestampIdCursor('9000000000000000:1', ERR)).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('UNSIGNED BIGINT 상한을 넘는 id를 거부한다', () => {
+    expect(() =>
+      parseTimestampIdCursor(`1700000000000:${'9'.repeat(30)}`, ERR),
+    ).toThrow(BadRequestException);
+    // 상한 자체는 허용
+    expect(
+      parseTimestampIdCursor('1700000000000:18446744073709551615', ERR).id,
+    ).toBe(18446744073709551615n);
+  });
+});

--- a/src/common/utils/keyset-cursor.ts
+++ b/src/common/utils/keyset-cursor.ts
@@ -13,6 +13,10 @@ import { BadRequestException } from '@nestjs/common';
 // DB UNSIGNED BIGINT 상한(2^64-1). 외부 입력 id의 범위 방어에 쓴다.
 export const MAX_UNSIGNED_BIGINT = 18446744073709551615n;
 
+// MySQL DATETIME 상한(9999-12-31 23:59:59.999 UTC). JS Date는 ±275760년까지
+// 허용해 그 사이 값이 커넥터 변환 오류로 번진다 — 커서 timestamp 상한.
+export const MAX_MYSQL_DATETIME_MS = Date.UTC(9999, 11, 31, 23, 59, 59, 999);
+
 export interface TimestampIdCursor {
   timestamp: Date;
   id: bigint;
@@ -31,7 +35,10 @@ export function parseTimestampIdCursor(
     throw new BadRequestException(errorMessage);
   }
   const timestamp = new Date(timestampMs);
-  if (Number.isNaN(timestamp.getTime())) {
+  if (
+    Number.isNaN(timestamp.getTime()) ||
+    timestampMs > MAX_MYSQL_DATETIME_MS
+  ) {
     throw new BadRequestException(errorMessage);
   }
   const id = BigInt(match[2]);

--- a/src/common/utils/keyset-cursor.ts
+++ b/src/common/utils/keyset-cursor.ts
@@ -1,0 +1,47 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * "<timestampMs>:<id>" 형식 키셋 커서 파싱 공용 유틸.
+ * 커서 토큰은 (시각, id) desc 정렬과 결합돼 있어 정렬이 바뀌면 무효다.
+ *
+ * 방어(전부 형식 오류로 거부):
+ * - 형식 불일치, 안전 정수 밖 timestamp(자릿수 폭탄 → Infinity)
+ * - Date 지원 범위(±8.64e15ms) 밖 timestamp → Invalid Date로 Prisma 내부 오류
+ * - DB UNSIGNED BIGINT 상한을 넘는 id → 커넥터 범위 오류
+ */
+
+// DB UNSIGNED BIGINT 상한(2^64-1). 외부 입력 id의 범위 방어에 쓴다.
+export const MAX_UNSIGNED_BIGINT = 18446744073709551615n;
+
+export interface TimestampIdCursor {
+  timestamp: Date;
+  id: bigint;
+}
+
+export function parseTimestampIdCursor(
+  raw: string,
+  errorMessage: string,
+): TimestampIdCursor {
+  const match = /^(\d+):(\d+)$/.exec(raw);
+  if (!match) {
+    throw new BadRequestException(errorMessage);
+  }
+  const timestampMs = Number(match[1]);
+  if (!Number.isSafeInteger(timestampMs)) {
+    throw new BadRequestException(errorMessage);
+  }
+  const timestamp = new Date(timestampMs);
+  if (Number.isNaN(timestamp.getTime())) {
+    throw new BadRequestException(errorMessage);
+  }
+  const id = BigInt(match[2]);
+  if (id > MAX_UNSIGNED_BIGINT) {
+    throw new BadRequestException(errorMessage);
+  }
+  return { timestamp, id };
+}
+
+/** (시각, id) desc 페이지의 다음 커서 문자열. */
+export function buildTimestampIdCursor(timestamp: Date, id: bigint): string {
+  return `${timestamp.getTime()}:${id.toString()}`;
+}

--- a/src/common/utils/keyset-cursor.ts
+++ b/src/common/utils/keyset-cursor.ts
@@ -45,3 +45,19 @@ export function parseTimestampIdCursor(
 export function buildTimestampIdCursor(timestamp: Date, id: bigint): string {
   return `${timestamp.getTime()}:${id.toString()}`;
 }
+
+/**
+ * 숫자 id 단독 커서 파싱. parseId와 달리 DB UNSIGNED BIGINT 상한까지
+ * 검증한다 — 상한 초과 값이 커넥터 범위 오류로 번지는 것을 형식 오류로
+ * 선제 거부한다.
+ */
+export function parseIdCursor(raw: string, errorMessage: string): bigint {
+  if (!/^\d+$/.test(raw)) {
+    throw new BadRequestException(errorMessage);
+  }
+  const id = BigInt(raw);
+  if (id > MAX_UNSIGNED_BIGINT) {
+    throw new BadRequestException(errorMessage);
+  }
+  return id;
+}

--- a/src/features/conversation/constants/conversation-error-messages.ts
+++ b/src/features/conversation/constants/conversation-error-messages.ts
@@ -1,6 +1,9 @@
 export const CONVERSATION_ERRORS = {
   STORE_NOT_FOUND: 'Store not found.',
   FAQ_TOPIC_NOT_FOUND: 'FAQ topic not found.',
+  CONVERSATION_NOT_FOUND: 'Conversation not found.',
+  // 커서는 "<lastMessageAtMs>:<id>" 불투명 토큰 — 형식이 다르면 클라이언트 버그다.
+  INVALID_CURSOR: 'Invalid conversation cursor.',
   // 활성 USER 판정 실패 메시지 — user feature와 동일 의미론(판정은 정책 헬퍼 공유)
   ACCOUNT_NOT_FOUND: 'Account not found.',
   ACCOUNT_DELETED: 'Account is deleted.',

--- a/src/features/conversation/constants/conversation.constants.ts
+++ b/src/features/conversation/constants/conversation.constants.ts
@@ -9,3 +9,8 @@ export const DEFAULT_GREETING_TEMPLATE =
 
 // 구매자 텍스트 메시지 상한. 판매자 측 MAX_CONVERSATION_BODY_TEXT_LENGTH와 동일 정책.
 export const MAX_INQUIRY_BODY_TEXT_LENGTH = 2000;
+
+// 대화 목록/채팅 상세 페이지네이션 기본값(상한 50은 DTO가 검증)
+export const DEFAULT_CONVERSATION_LIST_LIMIT = 20;
+export const DEFAULT_CONVERSATION_MESSAGES_LIMIT = 30;
+export const MAX_CONVERSATION_PAGE_LIMIT = 50;

--- a/src/features/conversation/conversation-center.graphql
+++ b/src/features/conversation/conversation-center.graphql
@@ -1,0 +1,60 @@
+extend type Query {
+  """알림센터 대화 탭 목록(구매자). 마지막 메시지 최신순."""
+  myConversations(input: MyConversationsInput): MyConversationConnection!
+  """
+  채팅 상세 메시지 목록(최신순 키셋 커서). 구매자 본인 대화만 조회 가능하며,
+  조회 시 last_read_at을 현재 시각으로 갱신한다(안읽음 배지 해소 부수효과).
+  """
+  conversationMessages(conversationId: ID!, input: ConversationMessagesInput): ConversationMessageConnection!
+}
+
+"""대화 목록 조회 입력"""
+input MyConversationsInput {
+  """이전 응답의 nextCursor(불투명 토큰). 미지정 시 첫 페이지"""
+  cursor: String
+  """조회 개수(최대 50)"""
+  limit: Int = 20
+}
+
+"""대화 목록 응답"""
+type MyConversationConnection {
+  items: [MyConversationItem!]!
+  """전체 대화 수"""
+  totalCount: Int!
+  hasMore: Boolean!
+  """다음 페이지 커서. 없으면 null"""
+  nextCursor: String
+}
+
+"""대화 목록 아이템"""
+type MyConversationItem {
+  """대화 ID"""
+  id: ID!
+  storeId: ID!
+  storeName: String!
+  """매장 프로필(로고) 이미지 URL. 미등록 시 null"""
+  storeProfileImageUrl: String
+  """마지막 메시지 미리보기(HTML 메시지는 태그 제거 plain text)"""
+  lastMessagePreview: String
+  lastMessageAt: DateTime!
+  """읽지 않은 수신 메시지 수(매장명 옆 "(3)" 표기용)"""
+  unreadCount: Int!
+}
+
+"""채팅 상세 메시지 조회 입력"""
+input ConversationMessagesInput {
+  """이전 응답의 nextCursor(마지막 메시지 ID). 미지정 시 최신 페이지"""
+  cursor: String
+  """조회 개수(최대 50)"""
+  limit: Int = 30
+}
+
+"""채팅 상세 메시지 응답(최신순)"""
+type ConversationMessageConnection {
+  items: [ConversationMessage!]!
+  """대화 전체 메시지 수"""
+  totalCount: Int!
+  hasMore: Boolean!
+  """다음(더 과거) 페이지 커서. 없으면 null"""
+  nextCursor: String
+}

--- a/src/features/conversation/conversation.module.ts
+++ b/src/features/conversation/conversation.module.ts
@@ -1,16 +1,20 @@
 import { Module } from '@nestjs/common';
 
 import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { ConversationCenterQueryResolver } from '@/features/conversation/resolvers/conversation-center-query.resolver';
 import { ConversationInquiryMutationResolver } from '@/features/conversation/resolvers/conversation-inquiry-mutation.resolver';
 import { ConversationInquiryQueryResolver } from '@/features/conversation/resolvers/conversation-inquiry-query.resolver';
+import { ConversationCenterService } from '@/features/conversation/services/conversation-center.service';
 import { ConversationInquiryService } from '@/features/conversation/services/conversation-inquiry.service';
 
 @Module({
   providers: [
     ConversationRepository,
     ConversationInquiryService,
+    ConversationCenterService,
     ConversationInquiryQueryResolver,
     ConversationInquiryMutationResolver,
+    ConversationCenterQueryResolver,
   ],
   exports: [ConversationRepository],
 })

--- a/src/features/conversation/dto/inputs/conversation-messages.input.spec.ts
+++ b/src/features/conversation/dto/inputs/conversation-messages.input.spec.ts
@@ -1,0 +1,26 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { ConversationMessagesInput } from '@/features/conversation/dto/inputs/conversation-messages.input';
+
+function build(plain: object): ConversationMessagesInput {
+  return plainToInstance(ConversationMessagesInput, plain);
+}
+
+describe('ConversationMessagesInput', () => {
+  it('cursor·limit 정상 조합 허용', async () => {
+    expect(await validate(build({ cursor: '10', limit: 30 }))).toHaveLength(0);
+  });
+
+  it('limit 0 거절', async () => {
+    const errors = await validate(build({ limit: 0 }));
+    expect(errors.map((e) => e.property)).toEqual(['limit']);
+  });
+
+  it('limit 상한(50) 초과 거절', async () => {
+    const errors = await validate(build({ limit: 51 }));
+    expect(errors.map((e) => e.property)).toEqual(['limit']);
+  });
+});

--- a/src/features/conversation/dto/inputs/conversation-messages.input.ts
+++ b/src/features/conversation/dto/inputs/conversation-messages.input.ts
@@ -1,0 +1,23 @@
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+import { MAX_CONVERSATION_PAGE_LIMIT } from '@/features/conversation/constants/conversation.constants';
+
+export class ConversationMessagesInput {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  cursor?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(MAX_CONVERSATION_PAGE_LIMIT)
+  limit?: number;
+}

--- a/src/features/conversation/dto/inputs/my-conversations.input.spec.ts
+++ b/src/features/conversation/dto/inputs/my-conversations.input.spec.ts
@@ -1,0 +1,26 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { MyConversationsInput } from '@/features/conversation/dto/inputs/my-conversations.input';
+
+function build(plain: object): MyConversationsInput {
+  return plainToInstance(MyConversationsInput, plain);
+}
+
+describe('MyConversationsInput', () => {
+  it('모든 필드 누락 허용(기본값은 서비스가 처리)', async () => {
+    expect(await validate(build({}))).toHaveLength(0);
+  });
+
+  it('빈 문자열 커서 거절', async () => {
+    const errors = await validate(build({ cursor: '' }));
+    expect(errors.map((e) => e.property)).toEqual(['cursor']);
+  });
+
+  it('limit 상한(50) 초과 거절', async () => {
+    const errors = await validate(build({ limit: 51 }));
+    expect(errors.map((e) => e.property)).toEqual(['limit']);
+  });
+});

--- a/src/features/conversation/dto/inputs/my-conversations.input.ts
+++ b/src/features/conversation/dto/inputs/my-conversations.input.ts
@@ -1,0 +1,23 @@
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+import { MAX_CONVERSATION_PAGE_LIMIT } from '@/features/conversation/constants/conversation.constants';
+
+export class MyConversationsInput {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  cursor?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(MAX_CONVERSATION_PAGE_LIMIT)
+  limit?: number;
+}

--- a/src/features/conversation/repositories/conversation.repository.spec.ts
+++ b/src/features/conversation/repositories/conversation.repository.spec.ts
@@ -125,7 +125,6 @@ describe('ConversationRepository (real DB)', () => {
     it('메시지 생성 시 conversation.last_message_at/updated_at을 트랜잭션 안에서 갱신한다', async () => {
       const { store, conversation } = await setupConversation();
       const seller = await createAccount(prisma, { account_type: 'SELLER' });
-      const now = new Date('2026-04-22T12:00:00Z');
 
       const message = await repo.createSellerConversationMessage({
         conversationId: conversation.id,
@@ -133,7 +132,6 @@ describe('ConversationRepository (real DB)', () => {
         bodyFormat: 'TEXT',
         bodyText: '판매자 응답',
         bodyHtml: null,
-        now,
       });
 
       expect(message.sender_type).toBe('STORE');
@@ -143,8 +141,9 @@ describe('ConversationRepository (real DB)', () => {
       const updatedConv = await prisma.storeConversation.findUniqueOrThrow({
         where: { id: conversation.id },
       });
-      expect(updatedConv.last_message_at?.toISOString()).toBe(
-        now.toISOString(),
+      // 시각은 대화 잠금 아래에서 repository가 채번한다 — 메시지와 동일해야 함
+      expect(updatedConv.last_message_at?.getTime()).toBe(
+        message.created_at.getTime(),
       );
       expect(updatedConv.store_id).toBe(store.id);
     });

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -365,6 +365,11 @@ export class ConversationRepository {
         data: {
           last_message_at: now,
           updated_at: now,
+          // 이번 mutation 응답으로 인사말·FAQ 자동응답까지 구매자에게 즉시
+          // 표시되므로, 여기까지를 읽음으로 전진시킨다 — 방금 받은 자동응답이
+          // 목록 미읽음 배지로 잡히는 불일치 방지(리뷰 반영). 항상 최신
+          // 시각이라 단조 증가 조건이 필요 없다.
+          last_read_at: now,
           // soft-delete된 대화를 재사용한 경우 복구한다 — 삭제 상태로 두면
           // 구매자·판매자 어느 조회에도 잡히지 않아 메시지가 유실돼 보인다
           // (리뷰 반영). 평상시엔 이미 null이라 no-op.

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -311,7 +311,8 @@ export class ConversationRepository {
     entries: ConversationMessageEntry[];
   }) {
     return this.prisma.$transaction(async (tx) => {
-      const conversationId = await this.lockOrCreateConversation(tx, args);
+      const conversation = await this.lockOrCreateConversation(tx, args);
+      const conversationId = conversation.id;
       // 메시지 시각은 대화 잠금 획득 "이후"에 채번한다 — 잠금 밖에서 미리
       // 받은 시각은 커밋 순서와 어긋나, 늦게 커밋된 과거 시각 메시지가
       // 읽음 마커(last_read_at)를 건너뛰는 레이스를 만든다(리뷰 반영).
@@ -320,26 +321,32 @@ export class ConversationRepository {
 
       // 인사말 필요 여부는 실제 메시지 수로 판정한다 — "생성 여부" 플래그는
       // 동시 첫 전송·실패 재시도에서 인사말 계약(항상 첫 메시지)을 깨뜨린다.
-      // 위에서 row를 잠갔거나(기존 대화) 본 트랜잭션이 만들었으므로(신규)
-      // count 판정은 직렬화된다.
-      const messageCount = await tx.storeConversationMessage.count({
-        where: { conversation_id: conversationId },
-      });
+      // 잠금 조회(FOR SHARE)로 최신 커밋 기준으로 센다(스냅샷 우회).
+      const messageCountRows = await tx.$queryRaw<{ c: bigint }[]>`
+        SELECT COUNT(*) AS c FROM store_conversation_message
+        WHERE conversation_id = ${conversationId} AND deleted_at IS NULL
+        FOR SHARE`;
+      const messageCount = Number(messageCountRows[0]?.c ?? 0n);
 
       // 이번 전송 "이전"의 미읽음 수신 메시지 — 읽음 마커 전진 가능 여부 판정용.
-      const current = await tx.storeConversation.findFirst({
-        where: { id: conversationId, deleted_at: undefined },
-        select: { last_read_at: true },
-      });
-      const pendingUnread = await tx.storeConversationMessage.count({
-        where: {
-          conversation_id: conversationId,
-          sender_type: { not: ConversationSenderType.USER },
-          ...(current?.last_read_at
-            ? { created_at: { gt: current.last_read_at } }
-            : {}),
-        },
-      });
+      // 잠금 조회(FOR SHARE)로 최신 커밋을 읽는다 — 트랜잭션 초입의 일반
+      // 조회가 만든 REPEATABLE READ 스냅샷은 잠금 대기 중 커밋된 판매자
+      // 답장을 못 본다(리뷰 반영). raw라 soft-delete 필터를 수동 명시.
+      const unreadRows = conversation.lastReadAt
+        ? await tx.$queryRaw<{ c: bigint }[]>`
+            SELECT COUNT(*) AS c FROM store_conversation_message
+            WHERE conversation_id = ${conversationId}
+              AND sender_type <> 'USER'
+              AND deleted_at IS NULL
+              AND created_at > ${conversation.lastReadAt}
+            FOR SHARE`
+        : await tx.$queryRaw<{ c: bigint }[]>`
+            SELECT COUNT(*) AS c FROM store_conversation_message
+            WHERE conversation_id = ${conversationId}
+              AND sender_type <> 'USER'
+              AND deleted_at IS NULL
+            FOR SHARE`;
+      const pendingUnread = Number(unreadRows[0]?.c ?? 0n);
 
       const toCreate: ConversationMessageEntry[] = [
         ...(messageCount === 0
@@ -409,13 +416,21 @@ export class ConversationRepository {
   private async lockOrCreateConversation(
     tx: Prisma.TransactionClient,
     args: { accountId: bigint; storeId: bigint },
-  ): Promise<bigint> {
-    const lockExisting = async (): Promise<bigint | null> => {
-      const rows = await tx.$queryRaw<{ id: bigint }[]>`
-        SELECT id FROM store_conversation
+  ): Promise<{ id: bigint; lastReadAt: Date | null }> {
+    // 잠금 조회가 돌려준 last_read_at을 그대로 쓴다 — 잠금 대기 중 커밋된
+    // 변경까지 반영된 최신 값이다(일반 조회의 스냅샷과 달리).
+    const lockExisting = async (): Promise<{
+      id: bigint;
+      lastReadAt: Date | null;
+    } | null> => {
+      const rows = await tx.$queryRaw<
+        { id: bigint; last_read_at: Date | null }[]
+      >`
+        SELECT id, last_read_at FROM store_conversation
         WHERE account_id = ${args.accountId} AND store_id = ${args.storeId}
         FOR UPDATE`;
-      return rows[0]?.id ?? null;
+      const row = rows[0];
+      return row ? { id: row.id, lastReadAt: row.last_read_at } : null;
     };
 
     // 사전 조회도 tx 경유 — 트랜잭션 안에서 루트 클라이언트를 쓰면 풀
@@ -444,7 +459,7 @@ export class ConversationRepository {
         },
         select: { id: true },
       });
-      return created.id;
+      return { id: created.id, lastReadAt: null };
     } catch (e) {
       if (
         e instanceof Prisma.PrismaClientKnownRequestError &&

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -326,6 +326,21 @@ export class ConversationRepository {
         where: { conversation_id: conversationId },
       });
 
+      // 이번 전송 "이전"의 미읽음 수신 메시지 — 읽음 마커 전진 가능 여부 판정용.
+      const current = await tx.storeConversation.findFirst({
+        where: { id: conversationId, deleted_at: undefined },
+        select: { last_read_at: true },
+      });
+      const pendingUnread = await tx.storeConversationMessage.count({
+        where: {
+          conversation_id: conversationId,
+          sender_type: { not: ConversationSenderType.USER },
+          ...(current?.last_read_at
+            ? { created_at: { gt: current.last_read_at } }
+            : {}),
+        },
+      });
+
       const toCreate: ConversationMessageEntry[] = [
         ...(messageCount === 0
           ? [
@@ -366,10 +381,11 @@ export class ConversationRepository {
           last_message_at: now,
           updated_at: now,
           // 이번 mutation 응답으로 인사말·FAQ 자동응답까지 구매자에게 즉시
-          // 표시되므로, 여기까지를 읽음으로 전진시킨다 — 방금 받은 자동응답이
-          // 목록 미읽음 배지로 잡히는 불일치 방지(리뷰 반영). 항상 최신
-          // 시각이라 단조 증가 조건이 필요 없다.
-          last_read_at: now,
+          // 표시되므로 여기까지 읽음으로 전진시키되, 이전에 쌓인 미읽음
+          // 답장이 있으면 전진하지 않는다 — 단일 워터마크라 함께 읽음
+          // 처리돼 버리기 때문(리뷰 반영). 그 경우 방금 받은 자동응답도
+          // 미읽음에 포함되지만, 채팅 상세를 열면 함께 해소된다.
+          ...(pendingUnread === 0 ? { last_read_at: now } : {}),
           // soft-delete된 대화를 재사용한 경우 복구한다 — 삭제 상태로 두면
           // 구매자·판매자 어느 조회에도 잡히지 않아 메시지가 유실돼 보인다
           // (리뷰 반영). 평상시엔 이미 null이라 no-op.

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -246,29 +246,52 @@ export class ConversationRepository {
     });
   }
 
-  async countConversationMessages(conversationId: bigint): Promise<number> {
-    return this.prisma.storeConversationMessage.count({
-      where: { conversation_id: conversationId },
-    });
-  }
-
   /**
-   * 구매자 읽음 처리 — 메시지 조회의 부수효과로 호출된다.
-   * 마커는 벽시계가 아니라 "실제로 내려준 최신 메시지의 created_at"까지만
-   * 전진시킨다(리뷰 반영) — 조회 후 커밋된 메시지가 응답에 없는데도 읽음
-   * 처리되는 레이스 방지. 과거 페이지 조회로 마커가 후퇴하지 않도록
-   * 단조 증가 조건을 건다.
+   * 구매자 채팅 상세 조회 + 읽음 마커 전진(한 트랜잭션).
+   *
+   * 전송 경로와 같은 대화 row 잠금을 잡는다 — 미커밋 전송이 있으면 커밋을
+   * 기다린 뒤 조회하므로, "아직 안 보이는 메시지"를 건너뛰고 마커가
+   * 전진하는 레이스가 없다(리뷰 반영). 마커는 실제 내려준 최신 메시지의
+   * created_at까지만, 과거 페이지 조회로 후퇴하지 않게 단조 증가 조건으로
+   * 갱신한다.
    */
-  async markConversationRead(args: {
+  async listBuyerMessagesAndMarkRead(args: {
     conversationId: bigint;
-    readAt: Date;
-  }): Promise<void> {
-    await this.prisma.storeConversation.updateMany({
-      where: {
-        id: args.conversationId,
-        OR: [{ last_read_at: null }, { last_read_at: { lt: args.readAt } }],
-      },
-      data: { last_read_at: args.readAt },
+    limit: number;
+    cursor?: bigint;
+  }) {
+    return this.prisma.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT id FROM store_conversation WHERE id = ${args.conversationId} FOR UPDATE`;
+
+      const [rows, totalCount] = await Promise.all([
+        tx.storeConversationMessage.findMany({
+          where: {
+            conversation_id: args.conversationId,
+            ...(args.cursor ? { id: { lt: args.cursor } } : {}),
+          },
+          orderBy: { id: 'desc' },
+          take: args.limit + 1,
+        }),
+        tx.storeConversationMessage.count({
+          where: { conversation_id: args.conversationId },
+        }),
+      ]);
+
+      const newest = rows[0];
+      if (newest) {
+        await tx.storeConversation.updateMany({
+          where: {
+            id: args.conversationId,
+            OR: [
+              { last_read_at: null },
+              { last_read_at: { lt: newest.created_at } },
+            ],
+          },
+          data: { last_read_at: newest.created_at },
+        });
+      }
+
+      return { rows, totalCount };
     });
   }
 
@@ -286,10 +309,14 @@ export class ConversationRepository {
     storeId: bigint;
     greetingBodyText: string;
     entries: ConversationMessageEntry[];
-    now: Date;
   }) {
     return this.prisma.$transaction(async (tx) => {
       const conversationId = await this.lockOrCreateConversation(tx, args);
+      // 메시지 시각은 대화 잠금 획득 "이후"에 채번한다 — 잠금 밖에서 미리
+      // 받은 시각은 커밋 순서와 어긋나, 늦게 커밋된 과거 시각 메시지가
+      // 읽음 마커(last_read_at)를 건너뛰는 레이스를 만든다(리뷰 반영).
+      // 잠금 순서 = 시각 순서 = 커밋 순서가 대화 단위로 보장된다(NTP 전제).
+      const now = new Date();
 
       // 인사말 필요 여부는 실제 메시지 수로 판정한다 — "생성 여부" 플래그는
       // 동시 첫 전송·실패 재시도에서 인사말 계약(항상 첫 메시지)을 깨뜨린다.
@@ -327,7 +354,7 @@ export class ConversationRepository {
               body_format: entry.bodyFormat,
               body_text: entry.bodyText,
               body_html: entry.bodyHtml,
-              created_at: args.now,
+              created_at: now,
             },
           }),
         );
@@ -336,8 +363,8 @@ export class ConversationRepository {
       await tx.storeConversation.update({
         where: { id: conversationId },
         data: {
-          last_message_at: args.now,
-          updated_at: args.now,
+          last_message_at: now,
+          updated_at: now,
           // soft-delete된 대화를 재사용한 경우 복구한다 — 삭제 상태로 두면
           // 구매자·판매자 어느 조회에도 잡히지 않아 메시지가 유실돼 보인다
           // (리뷰 반영). 평상시엔 이미 null이라 no-op.
@@ -360,7 +387,7 @@ export class ConversationRepository {
    */
   private async lockOrCreateConversation(
     tx: Prisma.TransactionClient,
-    args: { accountId: bigint; storeId: bigint; now: Date },
+    args: { accountId: bigint; storeId: bigint },
   ): Promise<bigint> {
     const lockExisting = async (): Promise<bigint | null> => {
       const rows = await tx.$queryRaw<{ id: bigint }[]>`
@@ -393,7 +420,6 @@ export class ConversationRepository {
         data: {
           account_id: args.accountId,
           store_id: args.storeId,
-          created_at: args.now,
         },
         select: { id: true },
       });
@@ -416,9 +442,13 @@ export class ConversationRepository {
     bodyFormat: ConversationBodyFormat;
     bodyText: string | null;
     bodyHtml: string | null;
-    now: Date;
   }) {
     return this.prisma.$transaction(async (tx) => {
+      // 구매자 전송·읽음 처리와 같은 대화 잠금 아래에서 시각을 채번해
+      // 커밋 순서와 시각 순서를 대화 단위로 일치시킨다(읽음 마커 정합).
+      await tx.$queryRaw`SELECT id FROM store_conversation WHERE id = ${args.conversationId} FOR UPDATE`;
+      const now = new Date();
+
       const message = await tx.storeConversationMessage.create({
         data: {
           conversation_id: args.conversationId,
@@ -427,15 +457,15 @@ export class ConversationRepository {
           body_format: args.bodyFormat,
           body_text: args.bodyText,
           body_html: args.bodyHtml,
-          created_at: args.now,
+          created_at: now,
         },
       });
 
       await tx.storeConversation.update({
         where: { id: args.conversationId },
         data: {
-          last_message_at: args.now,
-          updated_at: args.now,
+          last_message_at: now,
+          updated_at: now,
         },
       });
 

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -176,32 +176,65 @@ export class ConversationRepository {
   /**
    * 목록 아이템 부가 정보 — 대화별 마지막 메시지와 안읽은 수신 메시지 수.
    * 안읽음 = last_read_at 이후 도착한, 내가 보낸 것이 아닌 메시지.
-   * 페이지 크기(≤50) 만큼의 소규모 병렬 조회라 per-row 쿼리로 충분하다.
+   * per-row 쿼리는 페이지 50건 기준 100쿼리로 풀을 압박한다(리뷰 반영) —
+   * 최신 메시지 id 집계 → 본문 일괄 조회 → 안읽음 OR-분기 groupBy의
+   * 고정 3쿼리로 배치한다.
    */
   async getConversationListExtras(
     rows: { id: bigint; last_read_at: Date | null }[],
   ) {
-    return Promise.all(
-      rows.map(async (row) => {
-        const [lastMessage, unreadCount] = await Promise.all([
-          this.prisma.storeConversationMessage.findFirst({
-            where: { conversation_id: row.id },
-            orderBy: { id: 'desc' },
-            select: { body_format: true, body_text: true, body_html: true },
-          }),
-          this.prisma.storeConversationMessage.count({
-            where: {
-              conversation_id: row.id,
-              sender_type: { not: ConversationSenderType.USER },
-              ...(row.last_read_at
-                ? { created_at: { gt: row.last_read_at } }
-                : {}),
+    if (rows.length === 0) return [];
+    const ids = rows.map((row) => row.id);
+
+    const latestIdRows = await this.prisma.storeConversationMessage.groupBy({
+      by: ['conversation_id'],
+      where: { conversation_id: { in: ids } },
+      _max: { id: true },
+    });
+    const latestIds = latestIdRows
+      .map((row) => row._max.id)
+      .filter((id): id is bigint => id !== null);
+
+    const [latestMessages, unreadGroups] = await Promise.all([
+      latestIds.length > 0
+        ? this.prisma.storeConversationMessage.findMany({
+            where: { id: { in: latestIds } },
+            select: {
+              conversation_id: true,
+              body_format: true,
+              body_text: true,
+              body_html: true,
             },
-          }),
-        ]);
-        return { conversationId: row.id, lastMessage, unreadCount };
+          })
+        : Promise.resolve([]),
+      this.prisma.storeConversationMessage.groupBy({
+        by: ['conversation_id'],
+        where: {
+          sender_type: { not: ConversationSenderType.USER },
+          // 대화별 last_read_at이 달라 조건을 OR 분기로 배치한다(페이지 ≤50)
+          OR: rows.map((row) => ({
+            conversation_id: row.id,
+            ...(row.last_read_at
+              ? { created_at: { gt: row.last_read_at } }
+              : {}),
+          })),
+        },
+        _count: { _all: true },
       }),
+    ]);
+
+    const lastMessageById = new Map(
+      latestMessages.map((m) => [m.conversation_id.toString(), m]),
     );
+    const unreadById = new Map(
+      unreadGroups.map((g) => [g.conversation_id.toString(), g._count._all]),
+    );
+
+    return rows.map((row) => ({
+      conversationId: row.id,
+      lastMessage: lastMessageById.get(row.id.toString()) ?? null,
+      unreadCount: unreadById.get(row.id.toString()) ?? 0,
+    }));
   }
 
   async findConversationByIdAndAccount(args: {
@@ -219,14 +252,23 @@ export class ConversationRepository {
     });
   }
 
-  /** 구매자 읽음 처리 — last_read_at 갱신(메시지 조회의 부수효과로 호출된다). */
+  /**
+   * 구매자 읽음 처리 — 메시지 조회의 부수효과로 호출된다.
+   * 마커는 벽시계가 아니라 "실제로 내려준 최신 메시지의 created_at"까지만
+   * 전진시킨다(리뷰 반영) — 조회 후 커밋된 메시지가 응답에 없는데도 읽음
+   * 처리되는 레이스 방지. 과거 페이지 조회로 마커가 후퇴하지 않도록
+   * 단조 증가 조건을 건다.
+   */
   async markConversationRead(args: {
     conversationId: bigint;
-    now: Date;
+    readAt: Date;
   }): Promise<void> {
-    await this.prisma.storeConversation.update({
-      where: { id: args.conversationId },
-      data: { last_read_at: args.now },
+    await this.prisma.storeConversation.updateMany({
+      where: {
+        id: args.conversationId,
+        OR: [{ last_read_at: null }, { last_read_at: { lt: args.readAt } }],
+      },
+      data: { last_read_at: args.readAt },
     });
   }
 

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -129,6 +129,108 @@ export class ConversationRepository {
   }
 
   /**
+   * 구매자 대화 목록 페이지. (last_message_at, id) desc 키셋.
+   * 대화는 첫 메시지 전송 시에만 생성되지만, 방어적으로 메시지 없는
+   * 대화(last_message_at null)는 목록에서 제외한다 — 커서 정렬 키가 없다.
+   */
+  async listConversationsByAccount(args: {
+    accountId: bigint;
+    limit: number;
+    cursor?: { lastMessageAt: Date; id: bigint };
+  }) {
+    const where: Prisma.StoreConversationWhereInput = {
+      account_id: args.accountId,
+      last_message_at: { not: null },
+    };
+    return this.prisma.storeConversation.findMany({
+      where: args.cursor
+        ? {
+            AND: [
+              where,
+              {
+                OR: [
+                  { last_message_at: { lt: args.cursor.lastMessageAt } },
+                  {
+                    last_message_at: args.cursor.lastMessageAt,
+                    id: { lt: args.cursor.id },
+                  },
+                ],
+              },
+            ],
+          }
+        : where,
+      orderBy: [{ last_message_at: 'desc' }, { id: 'desc' }],
+      take: args.limit + 1,
+      include: {
+        store: { select: { store_name: true, profile_image_url: true } },
+      },
+    });
+  }
+
+  async countConversationsByAccount(accountId: bigint): Promise<number> {
+    return this.prisma.storeConversation.count({
+      where: { account_id: accountId, last_message_at: { not: null } },
+    });
+  }
+
+  /**
+   * 목록 아이템 부가 정보 — 대화별 마지막 메시지와 안읽은 수신 메시지 수.
+   * 안읽음 = last_read_at 이후 도착한, 내가 보낸 것이 아닌 메시지.
+   * 페이지 크기(≤50) 만큼의 소규모 병렬 조회라 per-row 쿼리로 충분하다.
+   */
+  async getConversationListExtras(
+    rows: { id: bigint; last_read_at: Date | null }[],
+  ) {
+    return Promise.all(
+      rows.map(async (row) => {
+        const [lastMessage, unreadCount] = await Promise.all([
+          this.prisma.storeConversationMessage.findFirst({
+            where: { conversation_id: row.id },
+            orderBy: { id: 'desc' },
+            select: { body_format: true, body_text: true, body_html: true },
+          }),
+          this.prisma.storeConversationMessage.count({
+            where: {
+              conversation_id: row.id,
+              sender_type: { not: ConversationSenderType.USER },
+              ...(row.last_read_at
+                ? { created_at: { gt: row.last_read_at } }
+                : {}),
+            },
+          }),
+        ]);
+        return { conversationId: row.id, lastMessage, unreadCount };
+      }),
+    );
+  }
+
+  async findConversationByIdAndAccount(args: {
+    conversationId: bigint;
+    accountId: bigint;
+  }) {
+    return this.prisma.storeConversation.findFirst({
+      where: { id: args.conversationId, account_id: args.accountId },
+    });
+  }
+
+  async countConversationMessages(conversationId: bigint): Promise<number> {
+    return this.prisma.storeConversationMessage.count({
+      where: { conversation_id: conversationId },
+    });
+  }
+
+  /** 구매자 읽음 처리 — last_read_at 갱신(메시지 조회의 부수효과로 호출된다). */
+  async markConversationRead(args: {
+    conversationId: bigint;
+    now: Date;
+  }): Promise<void> {
+    await this.prisma.storeConversation.update({
+      where: { id: args.conversationId },
+      data: { last_read_at: args.now },
+    });
+  }
+
+  /**
    * 구매자 메시지 저장. 대화가 없으면 같은 트랜잭션에서 생성하고, 인사말은
    * "대화의 첫 메시지"일 때만(메시지 0건) 유저 메시지보다 앞서 저장한다.
    *

--- a/src/features/conversation/resolvers/conversation-center-query.resolver.ts
+++ b/src/features/conversation/resolvers/conversation-center-query.resolver.ts
@@ -1,0 +1,45 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { ConversationMessagesInput } from '@/features/conversation/dto/inputs/conversation-messages.input';
+import { MyConversationsInput } from '@/features/conversation/dto/inputs/my-conversations.input';
+import { ConversationCenterService } from '@/features/conversation/services/conversation-center.service';
+import type {
+  ConversationMessageConnection,
+  MyConversationConnection,
+} from '@/features/conversation/types/conversation-output.type';
+import {
+  CurrentUser,
+  JwtAuthGuard,
+  parseAccountId,
+  type JwtUser,
+} from '@/global/auth';
+
+@Resolver('Query')
+@UseGuards(JwtAuthGuard)
+export class ConversationCenterQueryResolver {
+  constructor(private readonly centerService: ConversationCenterService) {}
+
+  @Query('myConversations')
+  myConversations(
+    @CurrentUser() user: JwtUser,
+    @Args('input', { nullable: true }) input?: MyConversationsInput,
+  ): Promise<MyConversationConnection> {
+    const accountId = parseAccountId(user);
+    return this.centerService.myConversations(accountId, input);
+  }
+
+  @Query('conversationMessages')
+  conversationMessages(
+    @CurrentUser() user: JwtUser,
+    @Args('conversationId') conversationId: string,
+    @Args('input', { nullable: true }) input?: ConversationMessagesInput,
+  ): Promise<ConversationMessageConnection> {
+    const accountId = parseAccountId(user);
+    return this.centerService.conversationMessages(
+      accountId,
+      conversationId,
+      input,
+    );
+  }
+}

--- a/src/features/conversation/resolvers/conversation-center.resolver.spec.ts
+++ b/src/features/conversation/resolvers/conversation-center.resolver.spec.ts
@@ -1,0 +1,74 @@
+// 전체 경로(리졸버→서비스→레포→DB) 통합 검증만 담당. 분기/집계 세부 검증은 service.spec.ts에서 담당
+import type { PrismaClient } from '@prisma/client';
+
+import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { ConversationCenterQueryResolver } from '@/features/conversation/resolvers/conversation-center-query.resolver';
+import { ConversationInquiryMutationResolver } from '@/features/conversation/resolvers/conversation-inquiry-mutation.resolver';
+import { ConversationCenterService } from '@/features/conversation/services/conversation-center.service';
+import { ConversationInquiryService } from '@/features/conversation/services/conversation-inquiry.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createStore,
+  createUserProfile,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('Conversation Center Resolvers (real DB)', () => {
+  let centerResolver: ConversationCenterQueryResolver;
+  let inquiryMutationResolver: ConversationInquiryMutationResolver;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [
+        ConversationCenterQueryResolver,
+        ConversationInquiryMutationResolver,
+        ConversationCenterService,
+        ConversationInquiryService,
+        ConversationRepository,
+      ],
+    });
+    centerResolver = module.get(ConversationCenterQueryResolver);
+    inquiryMutationResolver = module.get(ConversationInquiryMutationResolver);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('전송 → 목록 → 상세 조회 전체 경로가 안읽음 수까지 일관된다', async () => {
+    const buyer = await createAccount(prisma, { account_type: 'USER' });
+    await createUserProfile(prisma, { account_id: buyer.id });
+    const store = await createStore(prisma, { store_name: '해즈 케이크' });
+    const jwtUser = { accountId: buyer.id.toString() };
+
+    const sent = await inquiryMutationResolver.sendConversationMessage(
+      jwtUser,
+      { storeId: store.id.toString(), bodyText: '픽업 문의드립니다' },
+    );
+
+    const list = await centerResolver.myConversations(jwtUser);
+    expect(list.totalCount).toBe(1);
+    expect(list.items[0]).toMatchObject({
+      id: sent.conversationId,
+      storeName: '해즈 케이크',
+      lastMessagePreview: '픽업 문의드립니다',
+    });
+
+    const messages = await centerResolver.conversationMessages(
+      jwtUser,
+      sent.conversationId,
+    );
+    // 인사말 + 유저 메시지 (최신순)
+    expect(messages.totalCount).toBe(2);
+    expect(messages.items.map((m) => m.senderType)).toEqual(['USER', 'STORE']);
+  });
+});

--- a/src/features/conversation/services/conversation-base.service.ts
+++ b/src/features/conversation/services/conversation-base.service.ts
@@ -1,0 +1,30 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+
+import { CONVERSATION_ERRORS } from '@/features/conversation/constants/conversation-error-messages';
+import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { evaluateActiveUserAccount } from '@/features/user';
+
+/** 구매자 대화 서비스 공통 — 활성 USER 판정(user feature 정책 헬퍼 공유). */
+export abstract class ConversationBaseService {
+  protected constructor(protected readonly repo: ConversationRepository) {}
+
+  protected async requireActiveUser(
+    accountId: bigint,
+  ): Promise<{ nickname: string }> {
+    const account = await this.repo.findUserAccountForInquiry(accountId);
+    switch (evaluateActiveUserAccount(account)) {
+      case 'ACCOUNT_NOT_FOUND':
+        throw new UnauthorizedException(CONVERSATION_ERRORS.ACCOUNT_NOT_FOUND);
+      case 'ACCOUNT_DELETED':
+        throw new UnauthorizedException(CONVERSATION_ERRORS.ACCOUNT_DELETED);
+      case 'NOT_USER':
+        throw new ForbiddenException(CONVERSATION_ERRORS.NOT_USER);
+      case 'PROFILE_INACTIVE':
+        throw new UnauthorizedException(CONVERSATION_ERRORS.PROFILE_INACTIVE);
+      case null:
+        break;
+    }
+    // evaluate 통과 시 user_profile 존재가 보장된다
+    return { nickname: account!.user_profile!.nickname };
+  }
+}

--- a/src/features/conversation/services/conversation-center-mappers.helper.spec.ts
+++ b/src/features/conversation/services/conversation-center-mappers.helper.spec.ts
@@ -1,0 +1,36 @@
+import {
+  stripHtmlToPreview,
+  toLastMessagePreview,
+} from '@/features/conversation/services/conversation-center-mappers.helper';
+
+describe('conversation-center-mappers.helper', () => {
+  describe('stripHtmlToPreview', () => {
+    it('태그를 제거하고 공백을 정리한다', () => {
+      expect(
+        stripHtmlToPreview('<p>🎂 <strong>케이크 보관 방법</strong></p><ul><li>냉장 3일</li></ul>'),
+      ).toBe('🎂 케이크 보관 방법 냉장 3일');
+    });
+
+    it('기본 HTML 엔티티를 복원한다', () => {
+      expect(stripHtmlToPreview('A&nbsp;&amp;&nbsp;B &lt;3&gt;')).toBe('A & B <3>');
+    });
+  });
+
+  describe('toLastMessagePreview', () => {
+    it('TEXT 메시지는 원문, HTML 메시지는 태그 제거 텍스트를 반환한다', () => {
+      expect(
+        toLastMessagePreview({ body_format: 'TEXT', body_text: '안녕하세요', body_html: null }),
+      ).toBe('안녕하세요');
+      expect(
+        toLastMessagePreview({ body_format: 'HTML', body_text: null, body_html: '<p>답변</p>' }),
+      ).toBe('답변');
+    });
+
+    it('메시지가 없거나 본문이 비면 null', () => {
+      expect(toLastMessagePreview(null)).toBeNull();
+      expect(
+        toLastMessagePreview({ body_format: 'HTML', body_text: null, body_html: null }),
+      ).toBeNull();
+    });
+  });
+});

--- a/src/features/conversation/services/conversation-center-mappers.helper.spec.ts
+++ b/src/features/conversation/services/conversation-center-mappers.helper.spec.ts
@@ -7,29 +7,45 @@ describe('conversation-center-mappers.helper', () => {
   describe('stripHtmlToPreview', () => {
     it('태그를 제거하고 공백을 정리한다', () => {
       expect(
-        stripHtmlToPreview('<p>🎂 <strong>케이크 보관 방법</strong></p><ul><li>냉장 3일</li></ul>'),
+        stripHtmlToPreview(
+          '<p>🎂 <strong>케이크 보관 방법</strong></p><ul><li>냉장 3일</li></ul>',
+        ),
       ).toBe('🎂 케이크 보관 방법 냉장 3일');
     });
 
     it('기본 HTML 엔티티를 복원한다', () => {
-      expect(stripHtmlToPreview('A&nbsp;&amp;&nbsp;B &lt;3&gt;')).toBe('A & B <3>');
+      expect(stripHtmlToPreview('A&nbsp;&amp;&nbsp;B &lt;3&gt;')).toBe(
+        'A & B <3>',
+      );
     });
   });
 
   describe('toLastMessagePreview', () => {
     it('TEXT 메시지는 원문, HTML 메시지는 태그 제거 텍스트를 반환한다', () => {
       expect(
-        toLastMessagePreview({ body_format: 'TEXT', body_text: '안녕하세요', body_html: null }),
+        toLastMessagePreview({
+          body_format: 'TEXT',
+          body_text: '안녕하세요',
+          body_html: null,
+        }),
       ).toBe('안녕하세요');
       expect(
-        toLastMessagePreview({ body_format: 'HTML', body_text: null, body_html: '<p>답변</p>' }),
+        toLastMessagePreview({
+          body_format: 'HTML',
+          body_text: null,
+          body_html: '<p>답변</p>',
+        }),
       ).toBe('답변');
     });
 
     it('메시지가 없거나 본문이 비면 null', () => {
       expect(toLastMessagePreview(null)).toBeNull();
       expect(
-        toLastMessagePreview({ body_format: 'HTML', body_text: null, body_html: null }),
+        toLastMessagePreview({
+          body_format: 'HTML',
+          body_text: null,
+          body_html: null,
+        }),
       ).toBeNull();
     });
   });

--- a/src/features/conversation/services/conversation-center-mappers.helper.ts
+++ b/src/features/conversation/services/conversation-center-mappers.helper.ts
@@ -1,0 +1,32 @@
+/** DI-free 순수 함수만 둔다 — 대화 목록 미리보기 텍스트 가공. */
+
+/**
+ * HTML 본문 → 목록 미리보기 plain text.
+ * 표시용 한 줄 미리보기가 목적이라 완전한 HTML 파싱 대신 태그 제거 +
+ * 공백 정리로 충분하다(저장 원문은 그대로 유지).
+ */
+export function stripHtmlToPreview(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** 마지막 메시지 row → 미리보기 텍스트. TEXT는 원문, HTML은 태그 제거. */
+export function toLastMessagePreview(
+  message: {
+    body_format: 'TEXT' | 'HTML';
+    body_text: string | null;
+    body_html: string | null;
+  } | null,
+): string | null {
+  if (!message) return null;
+  if (message.body_format === 'HTML') {
+    return message.body_html ? stripHtmlToPreview(message.body_html) : null;
+  }
+  return message.body_text;
+}

--- a/src/features/conversation/services/conversation-center.service.spec.ts
+++ b/src/features/conversation/services/conversation-center.service.spec.ts
@@ -75,8 +75,7 @@ describe('ConversationCenterService (real DB)', () => {
         sender_type: args.senderType ?? 'STORE',
         sender_account_id: args.senderAccountId ?? null,
         body_format: args.bodyFormat ?? 'TEXT',
-        body_text:
-          args.bodyText === undefined ? '메시지' : args.bodyText,
+        body_text: args.bodyText === undefined ? '메시지' : args.bodyText,
         body_html: args.bodyHtml ?? null,
         created_at: args.createdAt ?? new Date(),
       },
@@ -266,6 +265,58 @@ describe('ConversationCenterService (real DB)', () => {
       expect(saved.last_read_at).not.toBeNull();
       const list = await service.myConversations(buyer.id);
       expect(list.items[0].unreadCount).toBe(0);
+    });
+
+    it('과거 페이지 조회로는 읽음 마커가 후퇴하지 않는다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const conv = await makeConversation({
+        accountId: buyer.id,
+        storeId: store.id,
+        lastReadAt: null,
+      });
+      await addMessage({ conversationId: conv.id, createdAt: hoursAgo(2) });
+      await addMessage({ conversationId: conv.id, createdAt: hoursAgo(1) });
+
+      // 첫 페이지(최신) → 마커 = 최신 메시지 시각
+      const page1 = await service.conversationMessages(
+        buyer.id,
+        conv.id.toString(),
+        { limit: 1 },
+      );
+      const afterFirst = await prisma.storeConversation.findUniqueOrThrow({
+        where: { id: conv.id },
+      });
+      expect(afterFirst.last_read_at?.getTime()).toBe(
+        new Date(page1.items[0].createdAt).getTime(),
+      );
+
+      // 과거 페이지 조회 — 더 오래된 메시지 시각으로 후퇴하면 안 된다
+      await service.conversationMessages(buyer.id, conv.id.toString(), {
+        limit: 1,
+        cursor: page1.nextCursor!,
+      });
+      const afterSecond = await prisma.storeConversation.findUniqueOrThrow({
+        where: { id: conv.id },
+      });
+      expect(afterSecond.last_read_at?.getTime()).toBe(
+        afterFirst.last_read_at?.getTime(),
+      );
+    });
+
+    it('UNSIGNED BIGINT 상한을 넘는 메시지 커서는 거절한다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const conv = await makeConversation({
+        accountId: buyer.id,
+        storeId: store.id,
+      });
+
+      await expect(
+        service.conversationMessages(buyer.id, conv.id.toString(), {
+          cursor: '9'.repeat(30),
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('남의 대화·없는 대화는 NotFoundException', async () => {

--- a/src/features/conversation/services/conversation-center.service.spec.ts
+++ b/src/features/conversation/services/conversation-center.service.spec.ts
@@ -1,0 +1,288 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import type { PrismaClient } from '@prisma/client';
+
+import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { ConversationCenterService } from '@/features/conversation/services/conversation-center.service';
+import { disconnectTestPrismaClient } from '@/test/db/prisma-test-client';
+import { closeTruncateConnection, truncateAll } from '@/test/db/truncate';
+import {
+  createAccount,
+  createStore,
+  createUserProfile,
+} from '@/test/factories';
+import { createTestingModuleWithRealDb } from '@/test/modules/testing-module.builder';
+
+describe('ConversationCenterService (real DB)', () => {
+  let service: ConversationCenterService;
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    const { module, prisma: p } = await createTestingModuleWithRealDb({
+      providers: [ConversationCenterService, ConversationRepository],
+    });
+    service = module.get(ConversationCenterService);
+    prisma = p;
+  });
+
+  afterAll(async () => {
+    await closeTruncateConnection();
+    await disconnectTestPrismaClient();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  async function setupBuyer() {
+    const account = await createAccount(prisma, { account_type: 'USER' });
+    await createUserProfile(prisma, { account_id: account.id });
+    return account;
+  }
+
+  function hoursAgo(hours: number): Date {
+    return new Date(Date.now() - hours * 60 * 60 * 1000);
+  }
+
+  async function makeConversation(args: {
+    accountId: bigint;
+    storeId: bigint;
+    lastMessageAt?: Date | null;
+    lastReadAt?: Date | null;
+  }) {
+    return prisma.storeConversation.create({
+      data: {
+        account_id: args.accountId,
+        store_id: args.storeId,
+        last_message_at:
+          args.lastMessageAt === undefined ? new Date() : args.lastMessageAt,
+        last_read_at: args.lastReadAt ?? null,
+      },
+    });
+  }
+
+  async function addMessage(args: {
+    conversationId: bigint;
+    senderType?: 'USER' | 'STORE' | 'SYSTEM';
+    bodyFormat?: 'TEXT' | 'HTML';
+    bodyText?: string | null;
+    bodyHtml?: string | null;
+    createdAt?: Date;
+    senderAccountId?: bigint;
+  }) {
+    return prisma.storeConversationMessage.create({
+      data: {
+        conversation_id: args.conversationId,
+        sender_type: args.senderType ?? 'STORE',
+        sender_account_id: args.senderAccountId ?? null,
+        body_format: args.bodyFormat ?? 'TEXT',
+        body_text:
+          args.bodyText === undefined ? '메시지' : args.bodyText,
+        body_html: args.bodyHtml ?? null,
+        created_at: args.createdAt ?? new Date(),
+      },
+    });
+  }
+
+  // ─── myConversations ───
+  describe('myConversations', () => {
+    it('마지막 메시지 최신순으로 매장 정보·미리보기·안읽음 수를 반환한다', async () => {
+      const buyer = await setupBuyer();
+      const storeA = await createStore(prisma, {
+        store_name: '해즈 케이크',
+        profile_image_url: 'https://cdn.example.com/hs.png',
+      });
+      const storeB = await createStore(prisma, { store_name: '달콤 케이크' });
+
+      // storeA: 최근 대화, 안읽은 STORE 메시지 3건
+      const convA = await makeConversation({
+        accountId: buyer.id,
+        storeId: storeA.id,
+        lastMessageAt: hoursAgo(1),
+        lastReadAt: hoursAgo(5),
+      });
+      await addMessage({
+        conversationId: convA.id,
+        senderType: 'USER',
+        bodyText: '문의합니다',
+        createdAt: hoursAgo(6),
+        senderAccountId: buyer.id,
+      });
+      for (let i = 0; i < 3; i++) {
+        await addMessage({
+          conversationId: convA.id,
+          bodyText: `답변 ${i + 1}`,
+          createdAt: hoursAgo(4 - i),
+        });
+      }
+
+      // storeB: 오래된 대화, 전부 읽음. 마지막 메시지는 HTML
+      const convB = await makeConversation({
+        accountId: buyer.id,
+        storeId: storeB.id,
+        lastMessageAt: hoursAgo(24),
+        lastReadAt: hoursAgo(23),
+      });
+      await addMessage({
+        conversationId: convB.id,
+        bodyFormat: 'HTML',
+        bodyText: null,
+        bodyHtml: '<p>🎂 <strong>케이크 보관 방법</strong></p><p>냉장 3일</p>',
+        createdAt: hoursAgo(24),
+      });
+
+      const result = await service.myConversations(buyer.id);
+
+      expect(result.totalCount).toBe(2);
+      expect(result.items.map((i) => i.storeName)).toEqual([
+        '해즈 케이크',
+        '달콤 케이크',
+      ]);
+      expect(result.items[0]).toMatchObject({
+        id: convA.id.toString(),
+        storeId: storeA.id.toString(),
+        storeProfileImageUrl: 'https://cdn.example.com/hs.png',
+        lastMessagePreview: '답변 3',
+        unreadCount: 3,
+      });
+      // HTML 마지막 메시지는 태그를 제거한 미리보기
+      expect(result.items[1]).toMatchObject({
+        lastMessagePreview: '🎂 케이크 보관 방법 냉장 3일',
+        unreadCount: 0,
+      });
+    });
+
+    it('내가 보낸 메시지는 안읽음 수에 세지 않는다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const conv = await makeConversation({
+        accountId: buyer.id,
+        storeId: store.id,
+        lastReadAt: null,
+      });
+      await addMessage({
+        conversationId: conv.id,
+        senderType: 'USER',
+        senderAccountId: buyer.id,
+      });
+      await addMessage({ conversationId: conv.id, senderType: 'STORE' });
+
+      const result = await service.myConversations(buyer.id);
+
+      // last_read_at이 null이면 수신 메시지 전부가 안읽음
+      expect(result.items[0].unreadCount).toBe(1);
+    });
+
+    it('커서로 다음 페이지를 이어가고, 메시지 없는 대화는 제외한다', async () => {
+      const buyer = await setupBuyer();
+      const convIds: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const store = await createStore(prisma);
+        const conv = await makeConversation({
+          accountId: buyer.id,
+          storeId: store.id,
+          lastMessageAt: hoursAgo(i + 1),
+        });
+        convIds.push(conv.id.toString());
+      }
+      // 메시지 없는(빈) 대화 — 목록 비노출
+      const emptyStore = await createStore(prisma);
+      await makeConversation({
+        accountId: buyer.id,
+        storeId: emptyStore.id,
+        lastMessageAt: null,
+      });
+
+      const page1 = await service.myConversations(buyer.id, { limit: 2 });
+      expect(page1.totalCount).toBe(3);
+      expect(page1.hasMore).toBe(true);
+      expect(page1.items.map((i) => i.id)).toEqual([convIds[0], convIds[1]]);
+
+      const page2 = await service.myConversations(buyer.id, {
+        limit: 2,
+        cursor: page1.nextCursor!,
+      });
+      expect(page2.items.map((i) => i.id)).toEqual([convIds[2]]);
+      expect(page2.hasMore).toBe(false);
+      expect(page2.nextCursor).toBeNull();
+    });
+
+    it('형식이 잘못된 커서는 거절하고, 다른 계정 대화는 노출하지 않는다', async () => {
+      const buyer = await setupBuyer();
+      const other = await setupBuyer();
+      const store = await createStore(prisma);
+      await makeConversation({ accountId: other.id, storeId: store.id });
+
+      await expect(
+        service.myConversations(buyer.id, { cursor: 'abc' }),
+      ).rejects.toThrow(BadRequestException);
+
+      const result = await service.myConversations(buyer.id);
+      expect(result.totalCount).toBe(0);
+      expect(result.items).toHaveLength(0);
+    });
+  });
+
+  // ─── conversationMessages ───
+  describe('conversationMessages', () => {
+    it('메시지를 최신순 키셋 커서로 반환하고, 조회 시 last_read_at을 갱신한다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      const conv = await makeConversation({
+        accountId: buyer.id,
+        storeId: store.id,
+        lastReadAt: null,
+      });
+      const msgIds: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const m = await addMessage({
+          conversationId: conv.id,
+          bodyText: `메시지 ${i + 1}`,
+        });
+        msgIds.push(m.id.toString());
+      }
+
+      const page1 = await service.conversationMessages(
+        buyer.id,
+        conv.id.toString(),
+        { limit: 2 },
+      );
+      expect(page1.totalCount).toBe(3);
+      expect(page1.hasMore).toBe(true);
+      // 최신(id desc)부터
+      expect(page1.items.map((m) => m.id)).toEqual([msgIds[2], msgIds[1]]);
+
+      const page2 = await service.conversationMessages(
+        buyer.id,
+        conv.id.toString(),
+        { limit: 2, cursor: page1.nextCursor! },
+      );
+      expect(page2.items.map((m) => m.id)).toEqual([msgIds[0]]);
+      expect(page2.hasMore).toBe(false);
+
+      // 조회 부수효과로 읽음 처리 → 목록 안읽음 수 0
+      const saved = await prisma.storeConversation.findUniqueOrThrow({
+        where: { id: conv.id },
+      });
+      expect(saved.last_read_at).not.toBeNull();
+      const list = await service.myConversations(buyer.id);
+      expect(list.items[0].unreadCount).toBe(0);
+    });
+
+    it('남의 대화·없는 대화는 NotFoundException', async () => {
+      const buyer = await setupBuyer();
+      const other = await setupBuyer();
+      const store = await createStore(prisma);
+      const othersConv = await makeConversation({
+        accountId: other.id,
+        storeId: store.id,
+      });
+
+      await expect(
+        service.conversationMessages(buyer.id, othersConv.id.toString()),
+      ).rejects.toThrow(NotFoundException);
+      await expect(
+        service.conversationMessages(buyer.id, '999999'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/features/conversation/services/conversation-center.service.ts
+++ b/src/features/conversation/services/conversation-center.service.ts
@@ -3,6 +3,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { parseId } from '@/common/utils/id-parser';
 import {
   buildTimestampIdCursor,
+  parseIdCursor,
   parseTimestampIdCursor,
 } from '@/common/utils/keyset-cursor';
 import { sliceCursorPage } from '@/common/utils/pagination';
@@ -100,7 +101,11 @@ export class ConversationCenterService extends ConversationBaseService {
     }
 
     const limit = input?.limit ?? DEFAULT_CONVERSATION_MESSAGES_LIMIT;
-    const cursor = input?.cursor ? parseId(input.cursor) : undefined;
+    // parseId는 음수만 거르므로 UNSIGNED BIGINT 상한 초과가 커넥터 오류로
+    // 번진다 — 상한까지 검증하는 커서 전용 파서를 쓴다(리뷰 반영)
+    const cursor = input?.cursor
+      ? parseIdCursor(input.cursor, CONVERSATION_ERRORS.INVALID_CURSOR)
+      : undefined;
 
     const [rows, totalCount] = await Promise.all([
       this.repo.listConversationMessages({ conversationId, limit, cursor }),
@@ -109,7 +114,16 @@ export class ConversationCenterService extends ConversationBaseService {
 
     // 채팅 상세 진입/조회 = 읽음으로 간주 — 별도 mutation 없이 여기서
     // last_read_at을 갱신한다(조회의 의도적 쓰기 부수효과, 사용자 확정 정책).
-    await this.repo.markConversationRead({ conversationId, now: new Date() });
+    // 마커는 벽시계가 아니라 실제 내려준 최신 메시지 시각까지만 전진 —
+    // 조회 직후 커밋된(응답에 없는) 메시지가 읽음 처리되는 레이스 방지.
+    // created_at 밀리초 동률 메시지는 다음 조회에서 함께 내려가므로 허용.
+    const newestFetched = rows[0];
+    if (newestFetched) {
+      await this.repo.markConversationRead({
+        conversationId,
+        readAt: newestFetched.created_at,
+      });
+    }
 
     const page = sliceCursorPage(rows, limit, (last) => last.id.toString());
 

--- a/src/features/conversation/services/conversation-center.service.ts
+++ b/src/features/conversation/services/conversation-center.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { parseId } from '@/common/utils/id-parser';
+import {
+  buildTimestampIdCursor,
+  parseTimestampIdCursor,
+} from '@/common/utils/keyset-cursor';
+import { sliceCursorPage } from '@/common/utils/pagination';
+import { CONVERSATION_ERRORS } from '@/features/conversation/constants/conversation-error-messages';
+import {
+  DEFAULT_CONVERSATION_LIST_LIMIT,
+  DEFAULT_CONVERSATION_MESSAGES_LIMIT,
+} from '@/features/conversation/constants/conversation.constants';
+import type { ConversationMessagesInput } from '@/features/conversation/dto/inputs/conversation-messages.input';
+import type { MyConversationsInput } from '@/features/conversation/dto/inputs/my-conversations.input';
+import { ConversationRepository } from '@/features/conversation/repositories/conversation.repository';
+import { ConversationBaseService } from '@/features/conversation/services/conversation-base.service';
+import { toLastMessagePreview } from '@/features/conversation/services/conversation-center-mappers.helper';
+import { toConversationMessageOutput } from '@/features/conversation/services/conversation-inquiry-mappers.helper';
+import type {
+  ConversationMessageConnection,
+  MyConversationConnection,
+} from '@/features/conversation/types/conversation-output.type';
+
+@Injectable()
+export class ConversationCenterService extends ConversationBaseService {
+  constructor(repo: ConversationRepository) {
+    super(repo);
+  }
+
+  async myConversations(
+    accountId: bigint,
+    input?: MyConversationsInput,
+  ): Promise<MyConversationConnection> {
+    await this.requireActiveUser(accountId);
+
+    const limit = input?.limit ?? DEFAULT_CONVERSATION_LIST_LIMIT;
+    const cursor = input?.cursor
+      ? parseTimestampIdCursor(input.cursor, CONVERSATION_ERRORS.INVALID_CURSOR)
+      : undefined;
+
+    const [rows, totalCount] = await Promise.all([
+      this.repo.listConversationsByAccount({
+        accountId,
+        limit,
+        cursor: cursor
+          ? { lastMessageAt: cursor.timestamp, id: cursor.id }
+          : undefined,
+      }),
+      this.repo.countConversationsByAccount(accountId),
+    ]);
+
+    // last_message_at desc 정렬과 결합된 커서 — 새 메시지 도착으로 대화가
+    // 위로 떠오르면 다음 페이지에 다시 나타날 수 있다(목록 새로고침 전제).
+    const page = sliceCursorPage(rows, limit, (last) =>
+      // listConversationsByAccount가 last_message_at null을 제외하므로 항상 존재
+      buildTimestampIdCursor(last.last_message_at!, last.id),
+    );
+
+    const extras = await this.repo.getConversationListExtras(
+      page.items.map((row) => ({ id: row.id, last_read_at: row.last_read_at })),
+    );
+    const extraById = new Map(
+      extras.map((e) => [e.conversationId.toString(), e]),
+    );
+
+    return {
+      items: page.items.map((row) => {
+        const extra = extraById.get(row.id.toString());
+        return {
+          id: row.id.toString(),
+          storeId: row.store_id.toString(),
+          storeName: row.store.store_name,
+          storeProfileImageUrl: row.store.profile_image_url,
+          lastMessagePreview: toLastMessagePreview(extra?.lastMessage ?? null),
+          lastMessageAt: row.last_message_at!,
+          unreadCount: extra?.unreadCount ?? 0,
+        };
+      }),
+      totalCount,
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
+    };
+  }
+
+  async conversationMessages(
+    accountId: bigint,
+    conversationIdRaw: string,
+    input?: ConversationMessagesInput,
+  ): Promise<ConversationMessageConnection> {
+    await this.requireActiveUser(accountId);
+    const conversationId = parseId(conversationIdRaw);
+
+    const conversation = await this.repo.findConversationByIdAndAccount({
+      conversationId,
+      accountId,
+    });
+    if (!conversation) {
+      throw new NotFoundException(CONVERSATION_ERRORS.CONVERSATION_NOT_FOUND);
+    }
+
+    const limit = input?.limit ?? DEFAULT_CONVERSATION_MESSAGES_LIMIT;
+    const cursor = input?.cursor ? parseId(input.cursor) : undefined;
+
+    const [rows, totalCount] = await Promise.all([
+      this.repo.listConversationMessages({ conversationId, limit, cursor }),
+      this.repo.countConversationMessages(conversationId),
+    ]);
+
+    // 채팅 상세 진입/조회 = 읽음으로 간주 — 별도 mutation 없이 여기서
+    // last_read_at을 갱신한다(조회의 의도적 쓰기 부수효과, 사용자 확정 정책).
+    await this.repo.markConversationRead({ conversationId, now: new Date() });
+
+    const page = sliceCursorPage(rows, limit, (last) => last.id.toString());
+
+    return {
+      items: page.items.map(toConversationMessageOutput),
+      totalCount,
+      hasMore: page.hasMore,
+      nextCursor: page.nextCursor,
+    };
+  }
+}

--- a/src/features/conversation/services/conversation-center.service.ts
+++ b/src/features/conversation/services/conversation-center.service.ts
@@ -107,23 +107,14 @@ export class ConversationCenterService extends ConversationBaseService {
       ? parseIdCursor(input.cursor, CONVERSATION_ERRORS.INVALID_CURSOR)
       : undefined;
 
-    const [rows, totalCount] = await Promise.all([
-      this.repo.listConversationMessages({ conversationId, limit, cursor }),
-      this.repo.countConversationMessages(conversationId),
-    ]);
-
-    // 채팅 상세 진입/조회 = 읽음으로 간주 — 별도 mutation 없이 여기서
-    // last_read_at을 갱신한다(조회의 의도적 쓰기 부수효과, 사용자 확정 정책).
-    // 마커는 벽시계가 아니라 실제 내려준 최신 메시지 시각까지만 전진 —
-    // 조회 직후 커밋된(응답에 없는) 메시지가 읽음 처리되는 레이스 방지.
-    // created_at 밀리초 동률 메시지는 다음 조회에서 함께 내려가므로 허용.
-    const newestFetched = rows[0];
-    if (newestFetched) {
-      await this.repo.markConversationRead({
-        conversationId,
-        readAt: newestFetched.created_at,
-      });
-    }
+    // 채팅 상세 진입/조회 = 읽음으로 간주 — 별도 mutation 없이 조회
+    // 트랜잭션이 last_read_at을 갱신한다(의도적 쓰기 부수효과, 사용자 확정
+    // 정책). 전송 경로와 같은 잠금·마커 정합은 repository가 담당한다.
+    const { rows, totalCount } = await this.repo.listBuyerMessagesAndMarkRead({
+      conversationId,
+      limit,
+      cursor,
+    });
 
     const page = sliceCursorPage(rows, limit, (last) => last.id.toString());
 

--- a/src/features/conversation/services/conversation-inquiry.service.spec.ts
+++ b/src/features/conversation/services/conversation-inquiry.service.spec.ts
@@ -188,6 +188,10 @@ describe('ConversationInquiryService (real DB)', () => {
       });
       expect(result.conversationId).toBe(conversation.id.toString());
       expect(conversation.last_message_at).not.toBeNull();
+      // 응답으로 인사말까지 즉시 표시되므로 여기까지 읽음 처리돼야 한다
+      expect(conversation.last_read_at?.getTime()).toBe(
+        conversation.last_message_at?.getTime(),
+      );
       expect(await messagesOf(conversation.id)).toHaveLength(2);
     });
 

--- a/src/features/conversation/services/conversation-inquiry.service.spec.ts
+++ b/src/features/conversation/services/conversation-inquiry.service.spec.ts
@@ -219,6 +219,40 @@ describe('ConversationInquiryService (real DB)', () => {
       expect(await messagesOf(conversations[0].id)).toHaveLength(3);
     });
 
+    it('미읽음 판매자 답장이 있는 대화에 전송해도 읽음 마커를 전진시키지 않는다', async () => {
+      const buyer = await setupBuyer();
+      const store = await createStore(prisma);
+      await service.sendConversationMessage(buyer.id, {
+        storeId: store.id.toString(),
+        bodyText: '첫 문의',
+      });
+      const conversation = await prisma.storeConversation.findFirstOrThrow({
+        where: { account_id: buyer.id, store_id: store.id },
+      });
+      // 판매자 답장(미읽음) 도착 재현
+      await prisma.storeConversationMessage.create({
+        data: {
+          conversation_id: conversation.id,
+          sender_type: 'STORE',
+          body_format: 'TEXT',
+          body_text: '아직 안 읽은 답장',
+          created_at: new Date(Date.now() + 1000),
+        },
+      });
+      const markerBefore = conversation.last_read_at;
+
+      await service.sendConversationMessage(buyer.id, {
+        storeId: store.id.toString(),
+        bodyText: '추가 문의',
+      });
+
+      // 백로그가 있으면 마커 유지 — 안 본 답장이 읽음 처리되면 안 된다
+      const after = await prisma.storeConversation.findUniqueOrThrow({
+        where: { id: conversation.id },
+      });
+      expect(after.last_read_at?.getTime()).toBe(markerBefore?.getTime());
+    });
+
     it('soft-delete된 대화가 있으면 유니크 충돌 없이 그 대화를 재사용한다', async () => {
       const buyer = await setupBuyer();
       const store = await createStore(prisma);

--- a/src/features/conversation/services/conversation-inquiry.service.ts
+++ b/src/features/conversation/services/conversation-inquiry.service.ts
@@ -149,7 +149,6 @@ export class ConversationInquiryService extends ConversationBaseService {
         storeName: args.storeName,
       }),
       entries: args.entries,
-      now: new Date(),
     });
 
     return {

--- a/src/features/conversation/services/conversation-inquiry.service.ts
+++ b/src/features/conversation/services/conversation-inquiry.service.ts
@@ -1,9 +1,4 @@
-import {
-  ForbiddenException,
-  Injectable,
-  NotFoundException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { ConversationBodyFormat, ConversationSenderType } from '@prisma/client';
 
 import { parseId } from '@/common/utils/id-parser';
@@ -16,6 +11,7 @@ import {
   ConversationRepository,
   type ConversationMessageEntry,
 } from '@/features/conversation/repositories/conversation.repository';
+import { ConversationBaseService } from '@/features/conversation/services/conversation-base.service';
 import {
   renderGreeting,
   toConversationMessageOutput,
@@ -25,11 +21,12 @@ import type {
   ConversationMessagesPayload,
   StoreInquiryContextOutput,
 } from '@/features/conversation/types/conversation-output.type';
-import { evaluateActiveUserAccount } from '@/features/user';
 
 @Injectable()
-export class ConversationInquiryService {
-  constructor(private readonly repo: ConversationRepository) {}
+export class ConversationInquiryService extends ConversationBaseService {
+  constructor(repo: ConversationRepository) {
+    super(repo);
+  }
 
   async storeInquiryContext(
     accountId: bigint,
@@ -159,27 +156,6 @@ export class ConversationInquiryService {
       conversationId: result.conversationId.toString(),
       messages: result.messages.map(toConversationMessageOutput),
     };
-  }
-
-  /** user feature의 활성 USER 판정 정책을 공유한다(메시지 매핑만 도메인별). */
-  private async requireActiveUser(
-    accountId: bigint,
-  ): Promise<{ nickname: string }> {
-    const account = await this.repo.findUserAccountForInquiry(accountId);
-    switch (evaluateActiveUserAccount(account)) {
-      case 'ACCOUNT_NOT_FOUND':
-        throw new UnauthorizedException(CONVERSATION_ERRORS.ACCOUNT_NOT_FOUND);
-      case 'ACCOUNT_DELETED':
-        throw new UnauthorizedException(CONVERSATION_ERRORS.ACCOUNT_DELETED);
-      case 'NOT_USER':
-        throw new ForbiddenException(CONVERSATION_ERRORS.NOT_USER);
-      case 'PROFILE_INACTIVE':
-        throw new UnauthorizedException(CONVERSATION_ERRORS.PROFILE_INACTIVE);
-      case null:
-        break;
-    }
-    // evaluate 통과 시 user_profile 존재가 보장된다
-    return { nickname: account!.user_profile!.nickname };
   }
 
   private async requireInquiryStore(storeId: bigint) {

--- a/src/features/conversation/types/conversation-output.type.ts
+++ b/src/features/conversation/types/conversation-output.type.ts
@@ -39,3 +39,27 @@ export interface ConversationMessagesPayload {
   conversationId: string;
   messages: ConversationMessageOutput[];
 }
+
+export interface MyConversationItemOutput {
+  id: string;
+  storeId: string;
+  storeName: string;
+  storeProfileImageUrl: string | null;
+  lastMessagePreview: string | null;
+  lastMessageAt: Date;
+  unreadCount: number;
+}
+
+export interface MyConversationConnection {
+  items: MyConversationItemOutput[];
+  totalCount: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export interface ConversationMessageConnection {
+  items: ConversationMessageOutput[];
+  totalCount: number;
+  hasMore: boolean;
+  nextCursor: string | null;
+}

--- a/src/features/seller/services/seller-conversation.service.ts
+++ b/src/features/seller/services/seller-conversation.service.ts
@@ -143,7 +143,6 @@ export class SellerConversationService extends SellerBaseService {
         bodyFormat,
         bodyText,
         bodyHtml,
-        now: new Date(),
       });
 
     await this.auditLogs.createAuditLog({

--- a/src/features/user/constants/user.constants.ts
+++ b/src/features/user/constants/user.constants.ts
@@ -30,6 +30,3 @@ export const MAX_REVIEW_COMMENT_LENGTH = 500;
 // figma notification-center: "최근 3개월 내의 알림만 확인할 수 있어요."
 // 삭제가 아니라 조회 필터로만 강제한다(사용자 확정 정책).
 export const NOTIFICATION_VISIBLE_MONTHS = 3;
-
-// DB UNSIGNED BIGINT 상한(2^64-1). 커서 등 외부 입력 id의 범위 방어에 쓴다.
-export const MAX_UNSIGNED_BIGINT = 18446744073709551615n;

--- a/src/features/user/services/user-notification.service.ts
+++ b/src/features/user/services/user-notification.service.ts
@@ -1,14 +1,13 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 
+import {
+  buildTimestampIdCursor,
+  parseTimestampIdCursor,
+} from '@/common/utils/keyset-cursor';
 import { sliceCursorPage } from '@/common/utils/pagination';
 import { USER_NOTIFICATION_ERRORS } from '@/features/user/constants/user-notification-error-messages';
 import {
   DEFAULT_PAGINATION_LIMIT,
-  MAX_UNSIGNED_BIGINT,
   NOTIFICATION_VISIBLE_MONTHS,
 } from '@/features/user/constants/user.constants';
 import type { MyNotificationsInput } from '@/features/user/dto/inputs/my-notifications.input';
@@ -55,10 +54,8 @@ export class UserNotificationService extends UserBaseService {
     });
 
     // (created_at, id) desc 정렬과 결합된 커서 — 정렬이 바뀌면 무효다.
-    const page = sliceCursorPage(
-      result.items,
-      limit,
-      (last) => `${last.created_at.getTime()}:${last.id.toString()}`,
+    const page = sliceCursorPage(result.items, limit, (last) =>
+      buildTimestampIdCursor(last.created_at, last.id),
     );
 
     return {
@@ -106,31 +103,15 @@ export class UserNotificationService extends UserBaseService {
     return since;
   }
 
-  /** 커서 파싱: "<createdAtMs>:<id>". 형식·안전 정수 범위를 벗어나면 거부. */
+  /** 커서 파싱: "<createdAtMs>:<id>". 형식·범위 방어는 공용 유틸이 담당. */
   private parseNotificationCursor(raw: string): {
     createdAt: Date;
     id: bigint;
   } {
-    const match = /^(\d+):(\d+)$/.exec(raw);
-    if (!match) {
-      throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
-    }
-    const createdAtMs = Number(match[1]);
-    if (!Number.isSafeInteger(createdAtMs)) {
-      throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
-    }
-    const createdAt = new Date(createdAtMs);
-    // 안전 정수여도 Date 지원 범위(±8.64e15ms) 밖이면 Invalid Date가 되어
-    // Prisma 필터에서 내부 오류로 번진다 — 형식 오류로 선제 거부한다.
-    if (Number.isNaN(createdAt.getTime())) {
-      throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
-    }
-    const id = BigInt(match[2]);
-    // id 컬럼은 UNSIGNED BIGINT — 그 최댓값을 넘는 값도 커넥터 범위 오류로
-    // 번지기 전에 형식 오류로 거부한다.
-    if (id > MAX_UNSIGNED_BIGINT) {
-      throw new BadRequestException(USER_NOTIFICATION_ERRORS.INVALID_CURSOR);
-    }
-    return { createdAt, id };
+    const cursor = parseTimestampIdCursor(
+      raw,
+      USER_NOTIFICATION_ERRORS.INVALID_CURSOR,
+    );
+    return { createdAt: cursor.timestamp, id: cursor.id };
   }
 }


### PR DESCRIPTION
## 배경

figma 알림센터(대화 탭) 화면 대응 3/4. PR #268의 대화 기반 위에 구매자 조회 경로를 얹는다.

## 변경점

- **`myConversations`**: 마지막 메시지 최신순 키셋 커서 목록 — 매장 프로필·마지막 메시지 미리보기(HTML은 태그 제거 plain text)·**안읽은 수신 메시지 수**(`unreadCount`, 목록의 "(3)" 표기용). 메시지 없는 대화는 제외.
- **`conversationMessages`**: 본인 대화 검증 후 최신순(id desc) 키셋 커서 메시지 목록. **조회 시 `last_read_at` 자동 갱신** — 별도 읽음 mutation 없는 정책(사용자 확정), 의도적 쓰기 부수효과로 주석 명시.
- **커서 유틸 공용화**: `"<timestampMs>:<id>"` 파싱·조립을 `common/utils/keyset-cursor`로 이동(형식·안전 정수·Date 범위·UNSIGNED BIGINT 상한 방어 일원화). user 알림 커서도 동일 유틸로 리팩토링.
- **`ConversationBaseService`**: 활성 USER 판정 공유(inquiry/center 공통).

## 테스트

- center service 6케이스(정렬·미리보기·unreadCount·본인 메시지 제외·커서·빈 대화 제외·읽음 부수효과·소유권)
- 커서 유틸 5케이스 / 미리보기 매퍼 4케이스 / resolver 통합 1케이스 / input 6케이스