### PR TITLE
fix: 릴리즈 리뷰 반영 (3개월 하한 월말 롤오버 클램프, 시드 포맷)

### DIFF
--- a/prisma/seed/conversations.ts
+++ b/prisma/seed/conversations.ts
@@ -37,15 +37,30 @@ export async function seedConversations(
   });
 
   const faqRows = [
-    { title: '날짜 변경', answer_html: '<p>픽업 1일 전까지 채팅으로 요청해 주시면 일정 확인 후 변경해 드려요.</p>' },
+    {
+      title: '날짜 변경',
+      answer_html:
+        '<p>픽업 1일 전까지 채팅으로 요청해 주시면 일정 확인 후 변경해 드려요.</p>',
+    },
     {
       title: '케이크 보관 방법',
       answer_html:
         '<p>🎂 <strong>케이크 보관 방법</strong></p><ul><li>냉장보관시 최대 3일</li><li>생크림 케이크는 당일 드시는 걸 권장해요</li></ul>',
     },
-    { title: '가게 위치 정보', answer_html: '<p>매장 상세의 찾아오는 길 안내를 확인해 주세요.</p>' },
-    { title: '제일 많이 물어보는 질문', answer_html: '<p>레터링 문구는 주문 시 요청사항에 남겨 주시면 반영돼요.</p>' },
-    { title: '예약 가능 일정', answer_html: '<p>캘린더에서 픽업 가능 날짜·시간대를 확인할 수 있어요.</p>' },
+    {
+      title: '가게 위치 정보',
+      answer_html: '<p>매장 상세의 찾아오는 길 안내를 확인해 주세요.</p>',
+    },
+    {
+      title: '제일 많이 물어보는 질문',
+      answer_html:
+        '<p>레터링 문구는 주문 시 요청사항에 남겨 주시면 반영돼요.</p>',
+    },
+    {
+      title: '예약 가능 일정',
+      answer_html:
+        '<p>캘린더에서 픽업 가능 날짜·시간대를 확인할 수 있어요.</p>',
+    },
   ];
   const faqs = [] as { id: bigint; title: string; answer_html: string }[];
   for (const [i, row] of faqRows.entries()) {

--- a/src/features/user/services/user-notification.service.ts
+++ b/src/features/user/services/user-notification.service.ts
@@ -94,12 +94,18 @@ export class UserNotificationService extends UserBaseService {
   }
 
   /**
-   * "최근 3개월" 노출 하한. setMonth 롤오버(예: 5/31 → 3/1 아님, 3/3)로
-   * 말일 경계가 며칠 어긋날 수 있으나 안내 문구 수준의 정밀도로 충분하다.
+   * "최근 3개월" 노출 하한. setMonth는 대상 월에 없는 날짜를 다음 달로
+   * 롤오버시키므로(예: 5/31 → 3/3) 하한이 며칠 늦어져 알림이 일찍 숨는다 —
+   * 롤오버가 감지되면 대상 월의 말일로 클램프한다(릴리즈 리뷰 반영).
    */
   private notificationVisibleSince(): Date {
     const since = new Date();
+    const dayOfMonth = since.getDate();
     since.setMonth(since.getMonth() - NOTIFICATION_VISIBLE_MONTHS);
+    if (since.getDate() !== dayOfMonth) {
+      // 롤오버 발생 — setDate(0)은 이전 달(=대상 월)의 말일로 되돌린다
+      since.setDate(0);
+    }
     return since;
   }
 


### PR DESCRIPTION
릴리즈 PR #272 CodeRabbit 지적 반영 — 알림 3개월 하한의 setMonth 월말 롤오버를 대상 월 말일로 클램프, 시드 파일 Prettier 포맷. API 표면 변경 없음.