### PR TITLE
fix(conversation): 미리보기 엔티티 복원 순서 수정 (CodeQL js/double-escaping)

### DIFF
--- a/src/features/conversation/services/conversation-center-mappers.helper.spec.ts
+++ b/src/features/conversation/services/conversation-center-mappers.helper.spec.ts
@@ -18,6 +18,10 @@ describe('conversation-center-mappers.helper', () => {
         'A & B <3>',
       );
     });
+
+    it('이중 이스케이프는 한 번만 복원한다(&amp;lt; → &lt;)', () => {
+      expect(stripHtmlToPreview('&amp;lt;b&amp;gt;')).toBe('&lt;b&gt;');
+    });
   });
 
   describe('toLastMessagePreview', () => {

--- a/src/features/conversation/services/conversation-center-mappers.helper.ts
+++ b/src/features/conversation/services/conversation-center-mappers.helper.ts
@@ -6,14 +6,18 @@
  * 공백 정리로 충분하다(저장 원문은 그대로 유지).
  */
 export function stripHtmlToPreview(html: string): string {
-  return html
-    .replace(/<[^>]*>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/\s+/g, ' ')
-    .trim();
+  return (
+    html
+      .replace(/<[^>]*>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      // &amp; 복원은 반드시 마지막 — 먼저 풀면 "&amp;lt;" 같은 이중
+      // 이스케이프가 두 번 풀려 "<"가 된다 (CodeQL js/double-escaping)
+      .replace(/&amp;/g, '&')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
 }
 
 /** 마지막 메시지 row → 미리보기 텍스트. TEXT는 원문, HTML은 태그 제거. */


### PR DESCRIPTION
CodeQL 오픈 알럿 #7(js/double-escaping) 해소 — stripHtmlToPreview의 &amp; 복원을 마지막으로 이동해 이중 이스케이프의 과복원 차단. 회귀 spec 추가. API 표면 변경 없음.