### PR TITLE
ci: SDL description 커버리지 게이트 추가 (docs:check)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -47,6 +47,14 @@ jobs:
       - name: DTO ↔ SDL sync check (warning during migration)
         run: yarn dto:check --warning
 
+      # SDL description 커버리지 게이트. 임계치는 현재 달성치로 고정돼 있어
+      # 회귀만 차단한다 — 설명 없는 필드를 새로 추가하면 여기서 걸린다.
+      - name: SDL description coverage check
+        run: yarn docs:check
+
+      - name: Script unit tests
+        run: yarn test:scripts
+
       # 아키텍처 의존 규칙 게이트(순환·Prisma-ban·레이어). 로컬 validate(pre-push)뿐 아니라
       # 보호된 check status에서도 강제해야 --no-verify/Husky 미설치 환경의 우회를 막는다.
       - name: Architecture check (dependency-cruiser)

--- a/jest.scripts.config.js
+++ b/jest.scripts.config.js
@@ -1,0 +1,15 @@
+// scripts/ 전용 jest 설정.
+//
+// 왜 별도인가: package.json의 jest는 rootDir이 src라 scripts/ 아래 spec을 아예
+// 수집하지 않는다. 앱 커버리지 임계치(statements 96 등)에 빌드 도구를 섞고 싶지도
+// 않아서, 실행만 분리하고 커버리지 집계에서는 제외한다.
+module.exports = {
+  rootDir: 'scripts',
+  testRegex: '.*\\.spec\\.ts$',
+  // TS 6부터 출력 레이아웃 기준 디렉터리 명시가 필수(TS5011)라 rootDir을 준다.
+  // emit하지 않는 검사 전용이지만 ts-jest도 같은 진단을 탄다.
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: { rootDir: './scripts' } }],
+  },
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "graphql:codegen": "graphql-codegen --config codegen.yml",
     "graphql:docs": "spectaql -c spectaql.yml",
     "dto:check": "ts-node -r tsconfig-paths/register scripts/check-graphql-dto-sync.ts",
+    "docs:check": "ts-node -r tsconfig-paths/register scripts/check-sdl-description-coverage.ts",
+    "test:scripts": "jest --config jest.scripts.config.js",
     "arch:check": "depcruise --config .dependency-cruiser.cjs src",
     "knip": "knip --no-config-hints",
-    "validate": "yarn lint && npx tsc --noEmit && yarn dto:check && yarn arch:check && yarn test:cov",
+    "validate": "yarn lint && npx tsc --noEmit && yarn dto:check && yarn docs:check && yarn arch:check && yarn test:scripts && yarn test:cov",
     "prepare": "husky"
   },
   "prisma": {

--- a/scripts/check-sdl-description-coverage.ts
+++ b/scripts/check-sdl-description-coverage.ts
@@ -49,7 +49,7 @@ const BASELINE: Record<Category, Baseline> = {
   rootArgScalar: { documented: 0, total: 6 },
   inputType: { documented: 13, total: 72 },
   inputField: { documented: 49, total: 227 },
-  outputType: { documented: 66, total: 133 },
+  outputType: { documented: 67, total: 134 },
   outputField: { documented: 185, total: 603 },
   enumType: { documented: 12, total: 23 },
   enumValue: { documented: 10, total: 81 },

--- a/scripts/check-sdl-description-coverage.ts
+++ b/scripts/check-sdl-description-coverage.ts
@@ -31,21 +31,36 @@ const SDL_FILE_EXT = '.graphql';
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.yarn']);
 
 /**
- * 요소별 최소 커버리지(%).
+ * 회귀 차단 기준선. 2026-09-10 실측 스냅샷을 {문서화된 수, 전체 수} 그대로 둔다.
  *
- * 2026-09-10 기준 실측치로 고정했다. 자명한 필드(id·createdAt·*Id)는 분모에서
- * 빠지고, 타입 이름만 되풀이하는 플레이스홀더 설명은 미기재로 센다.
+ * 왜 정수 %가 아닌 분수인가: 임계치를 내림하면 그만큼 여유분이 생겨 회귀가 통과한다.
+ * 예컨대 출력 필드 185/603(30.68%)에 임계 30%를 걸면 미기재 13건을 더 넣어도
+ * 185/616 = 30.03%라 게이트를 빠져나간다. 분수를 그대로 기준으로 삼아야
+ * "커버리지 비율이 내려가면 실패"가 성립한다.
+ *
+ * 자명한 필드(id·createdAt·*Id)는 분모에서 빠지고, 타입 이름만 되풀이하는
+ * 플레이스홀더 설명은 미기재로 센다.
+ *
+ * 커버리지를 올렸다면 `yarn docs:check --report`가 찍어 주는 수치로 갱신한다.
  */
-const THRESHOLDS: Record<Category, number> = {
-  rootField: 100,
-  rootArgScalar: 0,
-  inputType: 18,
-  inputField: 21,
-  outputType: 49,
-  outputField: 30,
-  enumType: 52,
-  enumValue: 12,
+const BASELINE: Record<Category, { documented: number; total: number }> = {
+  rootField: { documented: 130, total: 130 },
+  rootArgScalar: { documented: 0, total: 6 },
+  inputType: { documented: 13, total: 72 },
+  inputField: { documented: 49, total: 227 },
+  outputType: { documented: 66, total: 133 },
+  outputField: { documented: 185, total: 603 },
+  enumType: { documented: 12, total: 23 },
+  enumValue: { documented: 10, total: 81 },
 };
+
+const THRESHOLDS: Record<Category, number> = CATEGORIES.reduce(
+  (acc, category) => {
+    acc[category] = percentOf({ ...BASELINE[category], missing: [] });
+    return acc;
+  },
+  {} as Record<Category, number>,
+);
 
 const args = new Set(process.argv.slice(2));
 const REPORT_ONLY = args.has('--report');
@@ -94,7 +109,7 @@ function main(): void {
     const label = CATEGORY_LABELS[category].padEnd(22, ' ');
     const ratio = `${String(stat.documented)}/${String(stat.total)}`.padStart(9);
     console.log(
-      `  ${label}${ratio}  ${actual.toFixed(1).padStart(5)}%  (임계 ${String(threshold)}%)`,
+      `  ${label}${ratio}  ${actual.toFixed(1).padStart(5)}%  (기준 ${String(BASELINE[category].documented)}/${String(BASELINE[category].total)} = ${threshold.toFixed(1)}%)`,
     );
   }
   console.log('');
@@ -113,7 +128,7 @@ function main(): void {
   for (const violation of violations) {
     console.error(
       `\n[COVERAGE_BELOW_THRESHOLD] ${CATEGORY_LABELS[violation.category]}: ` +
-        `${violation.actual.toFixed(1)}% < ${String(violation.threshold)}%`,
+        `${violation.actual.toFixed(1)}% < ${violation.threshold.toFixed(1)}%`,
     );
     console.error(`  설명이 없는 요소 ${String(violation.missing.length)}건:`);
     for (const item of violation.missing) {

--- a/scripts/check-sdl-description-coverage.ts
+++ b/scripts/check-sdl-description-coverage.ts
@@ -16,12 +16,13 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { extname, join, relative, resolve } from 'node:path';
 
-import type { Category, SdlFile } from './sdl-description-coverage';
+import type { Baseline, Category, SdlFile } from './sdl-description-coverage';
 import {
   CATEGORIES,
   CATEGORY_LABELS,
   collectCoverage,
   findViolations,
+  missingCountOf,
   percentOf,
 } from './sdl-description-coverage';
 
@@ -43,7 +44,7 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.yarn']);
  *
  * 커버리지를 올렸다면 `yarn docs:check --report`가 찍어 주는 수치로 갱신한다.
  */
-const BASELINE: Record<Category, { documented: number; total: number }> = {
+const BASELINE: Record<Category, Baseline> = {
   rootField: { documented: 130, total: 130 },
   rootArgScalar: { documented: 0, total: 6 },
   inputType: { documented: 13, total: 72 },
@@ -53,14 +54,6 @@ const BASELINE: Record<Category, { documented: number; total: number }> = {
   enumType: { documented: 12, total: 23 },
   enumValue: { documented: 10, total: 81 },
 };
-
-const THRESHOLDS: Record<Category, number> = CATEGORIES.reduce(
-  (acc, category) => {
-    acc[category] = percentOf({ ...BASELINE[category], missing: [] });
-    return acc;
-  },
-  {} as Record<Category, number>,
-);
 
 const args = new Set(process.argv.slice(2));
 const REPORT_ONLY = args.has('--report');
@@ -104,12 +97,15 @@ function main(): void {
   console.log('');
   for (const category of CATEGORIES) {
     const stat = coverage[category];
+    const baseline = BASELINE[category];
     const actual = percentOf(stat);
-    const threshold = THRESHOLDS[category];
+    const threshold = percentOf({ ...baseline, missing: [] });
     const label = CATEGORY_LABELS[category].padEnd(22, ' ');
     const ratio = `${String(stat.documented)}/${String(stat.total)}`.padStart(9);
     console.log(
-      `  ${label}${ratio}  ${actual.toFixed(1).padStart(5)}%  (기준 ${String(BASELINE[category].documented)}/${String(BASELINE[category].total)} = ${threshold.toFixed(1)}%)`,
+      `  ${label}${ratio}  ${actual.toFixed(1).padStart(5)}%  ` +
+        `(기준 ${String(baseline.documented)}/${String(baseline.total)} = ${threshold.toFixed(1)}%, ` +
+        `미기재 ${String(stat.missing.length)}/${String(missingCountOf(baseline))})`,
     );
   }
   console.log('');
@@ -119,16 +115,19 @@ function main(): void {
     return;
   }
 
-  const violations = findViolations(coverage, THRESHOLDS);
+  const violations = findViolations(coverage, BASELINE);
   if (violations.length === 0) {
     console.log('[docs:check] 통과');
     return;
   }
 
   for (const violation of violations) {
+    const detail =
+      violation.reason === 'count'
+        ? `미기재 ${String(violation.actualMissing)}건 > 기준선 ${String(violation.baselineMissing)}건`
+        : `커버리지 ${violation.actual.toFixed(1)}% < 기준선 ${violation.threshold.toFixed(1)}%`;
     console.error(
-      `\n[COVERAGE_BELOW_THRESHOLD] ${CATEGORY_LABELS[violation.category]}: ` +
-        `${violation.actual.toFixed(1)}% < ${violation.threshold.toFixed(1)}%`,
+      `\n[DOC_COVERAGE_REGRESSION] ${CATEGORY_LABELS[violation.category]}: ${detail}`,
     );
     console.error(`  설명이 없는 요소 ${String(violation.missing.length)}건:`);
     for (const item of violation.missing) {

--- a/scripts/check-sdl-description-coverage.ts
+++ b/scripts/check-sdl-description-coverage.ts
@@ -1,0 +1,130 @@
+/**
+ * SDL description 커버리지 게이트.
+ *
+ * 왜: 설명 없는 필드를 추가해도 CI가 통과한다. dto:check가 SDL↔DTO 동기화를
+ * 도구로 강제하듯, 문서 커버리지도 게이트로 받친다. (이슈 #250)
+ *
+ * 운용 방침: 요소별 임계치를 **현재 달성치로 고정**해 회귀만 차단한다. 신규 API에는
+ * 문서화를 강제하고, 남은 부채는 임계치를 올려가며 갚는다. 커버리지를 올렸다면
+ * THRESHOLDS도 함께 올린다 — `--report`가 현재 수치를 그대로 뽑아 준다.
+ *
+ * 사용: yarn docs:check [--report] [--warning]
+ *   --report   임계치 검사 없이 현재 커버리지만 출력 (임계치 갱신용)
+ *   --warning  미달이어도 종료코드 0 (CI 경고용)
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { extname, join, relative, resolve } from 'node:path';
+
+import type { Category, SdlFile } from './sdl-description-coverage';
+import {
+  CATEGORIES,
+  CATEGORY_LABELS,
+  collectCoverage,
+  findViolations,
+  percentOf,
+} from './sdl-description-coverage';
+
+const REPO_ROOT = resolve(__dirname, '..');
+const SDL_ROOT = join(REPO_ROOT, 'src');
+const SDL_FILE_EXT = '.graphql';
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.yarn']);
+
+/**
+ * 요소별 최소 커버리지(%).
+ *
+ * 2026-09-10 기준 실측치로 고정했다. 자명한 필드(id·createdAt·*Id)는 분모에서
+ * 빠지고, 타입 이름만 되풀이하는 플레이스홀더 설명은 미기재로 센다.
+ */
+const THRESHOLDS: Record<Category, number> = {
+  rootField: 100,
+  rootArgScalar: 0,
+  inputType: 18,
+  inputField: 21,
+  outputType: 49,
+  outputField: 30,
+  enumType: 52,
+  enumValue: 12,
+};
+
+const args = new Set(process.argv.slice(2));
+const REPORT_ONLY = args.has('--report');
+const WARNING_ONLY = args.has('--warning');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (extname(full) === SDL_FILE_EXT) out.push(full);
+  }
+  return out;
+}
+
+function loadSdlFiles(): SdlFile[] {
+  if (!safeIsDir(SDL_ROOT)) return [];
+  return walk(SDL_ROOT)
+    .sort()
+    .map((file) => ({
+      path: relative(SDL_ROOT, file),
+      sdl: readFileSync(file, 'utf8'),
+    }));
+}
+
+function safeIsDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function main(): void {
+  const files = loadSdlFiles();
+  const coverage = collectCoverage(files);
+
+  console.log(`[docs:check] SDL 파일 ${files.length}개`);
+  console.log('');
+  for (const category of CATEGORIES) {
+    const stat = coverage[category];
+    const actual = percentOf(stat);
+    const threshold = THRESHOLDS[category];
+    const label = CATEGORY_LABELS[category].padEnd(22, ' ');
+    const ratio = `${String(stat.documented)}/${String(stat.total)}`.padStart(9);
+    console.log(
+      `  ${label}${ratio}  ${actual.toFixed(1).padStart(5)}%  (임계 ${String(threshold)}%)`,
+    );
+  }
+  console.log('');
+
+  if (REPORT_ONLY) {
+    console.log('[docs:check] --report 모드: 임계치 검사를 건너뜁니다.');
+    return;
+  }
+
+  const violations = findViolations(coverage, THRESHOLDS);
+  if (violations.length === 0) {
+    console.log('[docs:check] 통과');
+    return;
+  }
+
+  for (const violation of violations) {
+    console.error(
+      `\n[COVERAGE_BELOW_THRESHOLD] ${CATEGORY_LABELS[violation.category]}: ` +
+        `${violation.actual.toFixed(1)}% < ${String(violation.threshold)}%`,
+    );
+    console.error(`  설명이 없는 요소 ${String(violation.missing.length)}건:`);
+    for (const item of violation.missing) {
+      console.error(`    - ${item}`);
+    }
+  }
+
+  console.error(
+    `\n[docs:check] ${String(violations.length)}개 항목이 임계치 미달입니다.`,
+  );
+  if (!WARNING_ONLY) process.exitCode = 1;
+}
+
+main();

--- a/scripts/sdl-description-coverage.spec.ts
+++ b/scripts/sdl-description-coverage.spec.ts
@@ -8,6 +8,7 @@ import {
   percentOf,
 } from './sdl-description-coverage';
 import type { Baseline, Category, Coverage } from './sdl-description-coverage';
+import { IGNORED_KINDS } from './sdl-description-coverage';
 
 // DB 불필요한 순수 단위 테스트. SDL 문자열만으로 검증한다.
 describe('sdl-description-coverage', () => {
@@ -240,6 +241,43 @@ describe('sdl-description-coverage', () => {
       expect(() =>
         collectDefinition(alien, 't.graphql', () => undefined, new Set()),
       ).toThrow('처리하지 않은 SDL 정의 종류: AlienDefinition');
+    });
+
+    // 분류 목록을 손으로 적으면 반드시 빠진다 — directive를 그렇게 놓쳤고
+    // extend scalar/union도 같은 이유로 예외를 터뜨렸다. 그래서 목록을 내가 적지 않고
+    // graphql 패키지의 Kind에서 파생해, 모든 kind가 "집계됨" 또는 "의도적 제외" 중
+    // 하나로 분류돼 있는지 확인한다. graphql 버전이 올라 새 kind가 생기면 여기서 걸린다.
+    it('SDL에 올 수 있는 모든 정의 kind가 집계 또는 제외로 분류돼 있다', () => {
+      const { Kind } = jest.requireActual<typeof import('graphql')>('graphql');
+      const definitionKinds = Object.values(Kind).filter((k) =>
+        /(?:Definition|Extension)$/.test(k),
+      );
+      // 상위 노드 안에서만 등장해 최상위 분류 대상이 아닌 것들
+      const nested = new Set<string>([
+        Kind.FIELD_DEFINITION,
+        Kind.INPUT_VALUE_DEFINITION,
+        Kind.ENUM_VALUE_DEFINITION,
+        Kind.VARIABLE_DEFINITION,
+        Kind.OPERATION_TYPE_DEFINITION,
+      ]);
+
+      const unclassified = definitionKinds
+        .filter((k) => !nested.has(k))
+        .filter((kind) => {
+          if (IGNORED_KINDS.has(kind)) return false;
+          const node = {
+            kind,
+            name: { kind: 'Name', value: 'X' },
+          } as unknown as Parameters<typeof collectDefinition>[0];
+          try {
+            collectDefinition(node, 't.graphql', () => undefined, new Set());
+            return false;
+          } catch {
+            return true;
+          }
+        });
+
+      expect(unclassified).toEqual([]);
     });
 
     it('schema 선언은 의도적으로 집계하지 않는다', () => {

--- a/scripts/sdl-description-coverage.spec.ts
+++ b/scripts/sdl-description-coverage.spec.ts
@@ -150,6 +150,31 @@ describe('sdl-description-coverage', () => {
       ]);
     });
 
+    it('확장 문법으로 추가된 필드·값도 집계한다', () => {
+      // extend를 건너뛰면 확장으로 들어온 신규 요소가 게이트를 그냥 통과한다
+      const coverage = coverageOf(`
+        """목록 입력."""
+        input MyListInput { """개수.""" limit: Int }
+        extend input MyListInput { cursor: String }
+
+        """정렬."""
+        enum Sort { """최신순.""" LATEST }
+        extend enum Sort { OLDEST }
+
+        """카드."""
+        type Card { """제목.""" title: String }
+        extend type Card { subtitle: String }
+      `);
+      expect(coverage.inputField).toMatchObject({ documented: 1, total: 2 });
+      expect(coverage.inputField.missing).toEqual(['test.graphql: MyListInput.cursor']);
+      expect(coverage.enumValue).toMatchObject({ documented: 1, total: 2 });
+      expect(coverage.outputField).toMatchObject({ documented: 1, total: 2 });
+      // 선언 설명은 확장에 붙일 수 없으므로 정의 1건씩만 센다
+      expect(coverage.inputType).toMatchObject({ documented: 1, total: 1 });
+      expect(coverage.enumType).toMatchObject({ documented: 1, total: 1 });
+      expect(coverage.outputType).toMatchObject({ documented: 1, total: 1 });
+    });
+
     it('input 타입 선언과 필드를 집계한다', () => {
       const coverage = coverageOf(`
         """목록 입력."""

--- a/scripts/sdl-description-coverage.spec.ts
+++ b/scripts/sdl-description-coverage.spec.ts
@@ -189,6 +189,42 @@ describe('sdl-description-coverage', () => {
     });
   });
 
+
+  // 게이트 전수 점검. 설명을 붙일 수 있는 SDL 자리를 빠짐없이 나열하고, 각 자리에
+  // 설명 없는 요소를 하나씩 넣어 게이트가 실제로 잡아내는지 본다.
+  //
+  // 왜 이 형태인가: "현재 스키마에서 통과한다"는 오탐이 없다는 뜻일 뿐, 막아야 할 것을
+  // 막는다는 증거가 아니다. 실제로 이 표를 만들고서야 필드 인자·union·scalar 자리가
+  // 집계에서 통째로 빠져 있던 걸 찾았다. 새 자리가 생기면 여기에 줄을 추가한다.
+  describe('설명을 붙일 수 있는 모든 자리를 빠짐없이 집계한다', () => {
+    const SITES: [name: string, sdl: string, expected: string][] = [
+      ['object type 선언', 'type A { """f.""" f: String }', 'A'],
+      ['object type 필드', '"""A.""" type A { f: String }', 'A.f'],
+      ['object type 필드의 인자', '"""A.""" type A { """f.""" f(bad: String): String }', 'A.f(bad)'],
+      ['root 필드', 'extend type Query { q: String }', 'Query.q'],
+      ['root 필드의 인자', 'extend type Query { """q.""" q(bad: String): String }', 'Query.q(bad)'],
+      ['object 확장 필드', '"""A.""" type A { """f.""" f: String } extend type A { g: String }', 'A.g'],
+      ['object 확장 필드의 인자', '"""A.""" type A { """f.""" f: String } extend type A { """g.""" g(bad: String): String }', 'A.g(bad)'],
+      ['input 선언', 'input I { """v.""" v: String }', 'I'],
+      ['input 필드', '"""I.""" input I { v: String }', 'I.v'],
+      ['input 확장 필드', '"""I.""" input I { """v.""" v: String } extend input I { w: String }', 'I.w'],
+      ['enum 선언', 'enum E { """A.""" A }', 'E'],
+      ['enum 값', '"""E.""" enum E { A }', 'E.A'],
+      ['enum 확장 값', '"""E.""" enum E { """A.""" A } extend enum E { B }', 'E.B'],
+      ['interface 선언', 'interface N { """f.""" f: String }', 'N'],
+      ['interface 필드', '"""N.""" interface N { f: String }', 'N.f'],
+      ['interface 확장 필드', '"""N.""" interface N { """f.""" f: String } extend interface N { g: String }', 'N.g'],
+      ['union 선언', '"""A.""" type A { """f.""" f: String } union U = A', 'U'],
+      ['scalar 선언', 'scalar S', 'S'],
+    ];
+
+    it.each(SITES)('%s', (_site, sdl, expected) => {
+      const coverage = coverageOf(sdl);
+      const missing = CATEGORIES.flatMap((c) => coverage[c].missing);
+      expect(missing).toContain(`test.graphql: ${expected}`);
+    });
+  });
+
   describe('percentOf', () => {
     it('분모가 0이면 100%로 본다', () => {
       expect(percentOf({ documented: 0, total: 0, missing: [] })).toBe(100);

--- a/scripts/sdl-description-coverage.spec.ts
+++ b/scripts/sdl-description-coverage.spec.ts
@@ -1,6 +1,7 @@
 import {
   CATEGORIES,
   collectCoverage,
+  collectDefinition,
   findViolations,
   isExemptFieldName,
   isPlaceholderDescription,
@@ -216,12 +217,38 @@ describe('sdl-description-coverage', () => {
       ['interface 확장 필드', '"""N.""" interface N { """f.""" f: String } extend interface N { g: String }', 'N.g'],
       ['union 선언', '"""A.""" type A { """f.""" f: String } union U = A', 'U'],
       ['scalar 선언', 'scalar S', 'S'],
+      ['directive 선언', 'directive @d on FIELD_DEFINITION', '@d'],
+      ['directive 인자', '"""d.""" directive @d(bad: String) on FIELD_DEFINITION', '@d(bad)'],
     ];
 
     it.each(SITES)('%s', (_site, sdl, expected) => {
       const coverage = coverageOf(sdl);
       const missing = CATEGORIES.flatMap((c) => coverage[c].missing);
       expect(missing).toContain(`test.graphql: ${expected}`);
+    });
+  });
+
+  describe('처리하지 않은 SDL 구문', () => {
+    it('모르는 정의 종류를 만나면 조용히 넘기지 않고 예외를 던진다', () => {
+      // 손으로 적은 자리 목록은 반드시 빠지는 게 생긴다(directive를 그렇게 놓쳤다).
+      // 새 구문이 들어오면 집계에서 통째로 빠지는 대신 여기서 터져야 한다.
+      const alien = {
+        kind: 'AlienDefinition',
+        name: { kind: 'Name', value: 'X' },
+      } as unknown as Parameters<typeof collectDefinition>[0];
+
+      expect(() =>
+        collectDefinition(alien, 't.graphql', () => undefined, new Set()),
+      ).toThrow('처리하지 않은 SDL 정의 종류: AlienDefinition');
+    });
+
+    it('schema 선언은 의도적으로 집계하지 않는다', () => {
+      const coverage = coverageOf(`
+        schema { query: Query }
+        extend type Query { """q.""" q: String }
+      `);
+      const missing = CATEGORIES.flatMap((c) => coverage[c].missing);
+      expect(missing).toEqual([]);
     });
   });
 

--- a/scripts/sdl-description-coverage.spec.ts
+++ b/scripts/sdl-description-coverage.spec.ts
@@ -1,0 +1,183 @@
+import {
+  collectCoverage,
+  findViolations,
+  isExemptFieldName,
+  isPlaceholderDescription,
+  percentOf,
+} from './sdl-description-coverage';
+import type { Category, Coverage } from './sdl-description-coverage';
+
+// DB 불필요한 순수 단위 테스트. SDL 문자열만으로 검증한다.
+describe('sdl-description-coverage', () => {
+  function coverageOf(sdl: string): Coverage {
+    return collectCoverage([{ path: 'test.graphql', sdl }]);
+  }
+
+  describe('isPlaceholderDescription', () => {
+    it('타입 이름을 되풀이하기만 하면 플레이스홀더로 본다', () => {
+      expect(isPlaceholderDescription('SellerOrder', 'SellerOrder 타입')).toBe(
+        true,
+      );
+      expect(
+        isPlaceholderDescription('SellerOrderListInput', 'SellerOrderListInput 입력 타입'),
+      ).toBe(true);
+      expect(
+        isPlaceholderDescription('SellerStoreMapProvider', 'SellerStoreMapProvider 열거형'),
+      ).toBe(true);
+      expect(isPlaceholderDescription('SellerOrder', 'SellerOrder')).toBe(true);
+    });
+
+    it('빈 설명도 플레이스홀더로 본다', () => {
+      expect(isPlaceholderDescription('SellerOrder', '')).toBe(true);
+      expect(isPlaceholderDescription('SellerOrder', '   ')).toBe(true);
+    });
+
+    it('실제 의미가 담긴 설명은 플레이스홀더가 아니다', () => {
+      expect(
+        isPlaceholderDescription('CreateOrderInput', '주문 생성 입력. 옵션을 서버가 재검증한다.'),
+      ).toBe(false);
+      // 이름으로 시작하더라도 뒤에 내용이 붙으면 정보가 있다
+      expect(
+        isPlaceholderDescription('SellerOrder', 'SellerOrder 타입. 판매자 화면 주문 카드.'),
+      ).toBe(false);
+    });
+  });
+
+  describe('isExemptFieldName', () => {
+    it('자명한 필드와 식별자 접미사는 제외한다', () => {
+      expect(isExemptFieldName('id')).toBe(true);
+      expect(isExemptFieldName('createdAt')).toBe(true);
+      expect(isExemptFieldName('productId')).toBe(true);
+      expect(isExemptFieldName('optionItemIds')).toBe(true);
+    });
+
+    it('비자명 필드는 제외하지 않는다', () => {
+      expect(isExemptFieldName('pickupAt')).toBe(false);
+      expect(isExemptFieldName('nextCursor')).toBe(false);
+      expect(isExemptFieldName('idempotencyKey')).toBe(false);
+      // 'Id'로 끝나지 않는 이름이 우연히 걸리지 않아야 한다
+      expect(isExemptFieldName('valid')).toBe(false);
+    });
+  });
+
+  describe('collectCoverage', () => {
+    it('루트 필드 설명 유무를 집계한다', () => {
+      const coverage = coverageOf(`
+        extend type Query {
+          """상품 상세를 조회한다."""
+          productDetail(productId: ID!): String!
+          storeDetail(storeId: ID!): String!
+        }
+      `);
+      expect(coverage.rootField).toMatchObject({ documented: 1, total: 2 });
+      expect(coverage.rootField.missing).toEqual(['test.graphql: Query.storeDetail']);
+    });
+
+    it('스칼라 루트 인자만 집계하고 식별자 인자는 제외한다', () => {
+      const coverage = coverageOf(`
+        extend type Query {
+          """픽업 달력."""
+          pickupCalendar(yearMonth: String!, storeId: ID!, input: SomeInput): String!
+        }
+        input SomeInput { """값.""" value: String }
+      `);
+      // yearMonth만 대상 — storeId는 식별자, input은 input 객체
+      expect(coverage.rootArgScalar).toMatchObject({ documented: 0, total: 1 });
+      expect(coverage.rootArgScalar.missing).toEqual([
+        'test.graphql: Query.pickupCalendar(yearMonth)',
+      ]);
+    });
+
+    it('플레이스홀더 설명이 붙은 타입은 미기재로 센다', () => {
+      const coverage = coverageOf(`
+        """SellerOrder 타입"""
+        type SellerOrder {
+          """주문번호."""
+          orderNumber: String!
+        }
+      `);
+      expect(coverage.outputType).toMatchObject({ documented: 0, total: 1 });
+      expect(coverage.outputField).toMatchObject({ documented: 1, total: 1 });
+    });
+
+    it('자명한 필드는 분모에서 뺀다', () => {
+      const coverage = coverageOf(`
+        """주문 카드."""
+        type Order {
+          id: ID!
+          createdAt: DateTime!
+          storeId: ID!
+          pickupAt: DateTime!
+        }
+      `);
+      // id·createdAt·storeId 제외, pickupAt만 남는다
+      expect(coverage.outputField).toMatchObject({ documented: 0, total: 1 });
+      expect(coverage.outputField.missing).toEqual(['test.graphql: Order.pickupAt']);
+    });
+
+    it('enum 선언과 값을 따로 집계한다', () => {
+      const coverage = coverageOf(`
+        """주문 상태."""
+        enum OrderStatusType {
+          """접수됨."""
+          SUBMITTED
+          CONFIRMED
+        }
+      `);
+      expect(coverage.enumType).toMatchObject({ documented: 1, total: 1 });
+      expect(coverage.enumValue).toMatchObject({ documented: 1, total: 2 });
+      expect(coverage.enumValue.missing).toEqual([
+        'test.graphql: OrderStatusType.CONFIRMED',
+      ]);
+    });
+
+    it('input 타입 선언과 필드를 집계한다', () => {
+      const coverage = coverageOf(`
+        """목록 입력."""
+        input MyListInput {
+          """한 번에 가져올 개수."""
+          limit: Int
+          cursor: ID
+        }
+      `);
+      expect(coverage.inputType).toMatchObject({ documented: 1, total: 1 });
+      expect(coverage.inputField).toMatchObject({ documented: 1, total: 2 });
+    });
+  });
+
+  describe('percentOf', () => {
+    it('분모가 0이면 100%로 본다', () => {
+      expect(percentOf({ documented: 0, total: 0, missing: [] })).toBe(100);
+    });
+  });
+
+  describe('findViolations', () => {
+    const thresholds = Object.fromEntries(
+      ['rootField', 'rootArgScalar', 'inputType', 'inputField', 'outputType', 'outputField', 'enumType', 'enumValue'].map(
+        (c) => [c, 0],
+      ),
+    ) as Record<Category, number>;
+
+    it('임계치 미달 항목만 돌려준다', () => {
+      const coverage = coverageOf(`
+        extend type Query {
+          productDetail(productId: ID!): String!
+        }
+      `);
+      expect(findViolations(coverage, { ...thresholds, rootField: 100 })).toMatchObject([
+        { category: 'rootField', actual: 0, threshold: 100 },
+      ]);
+      expect(findViolations(coverage, thresholds)).toEqual([]);
+    });
+
+    it('실측치를 그대로 임계치로 박아도 자기 자신에게 걸리지 않는다', () => {
+      // 임계치를 달성치로 고정하는 운용이라 부동소수 오차 방어가 필요하다
+      const coverage = coverageOf(`
+        """설명 있음."""
+        type A { """값.""" one: String, two: String, three: String }
+      `);
+      const actual = percentOf(coverage.outputField); // 1/3 = 33.33...
+      expect(findViolations(coverage, { ...thresholds, outputField: actual })).toEqual([]);
+    });
+  });
+});

--- a/scripts/sdl-description-coverage.spec.ts
+++ b/scripts/sdl-description-coverage.spec.ts
@@ -170,6 +170,24 @@ describe('sdl-description-coverage', () => {
       expect(findViolations(coverage, thresholds)).toEqual([]);
     });
 
+    it('기준선을 분수로 잡으면 미기재 1건 추가도 잡아낸다', () => {
+      // 정수 %로 내림하면 그만큼 여유분이 생겨 회귀가 통과한다.
+      // 예: 185/603=30.68%에 임계 30을 걸면 185/616=30.03%도 통과.
+      const baseline = (100 * 185) / 603;
+      const regressed = { documented: 185, total: 604, missing: [] };
+      expect(percentOf(regressed)).toBeLessThan(baseline);
+
+      const coverage = coverageOf(`
+        """설명 있음."""
+        type A { """값.""" one: String, two: String, three: String, four: String }
+      `);
+      // 1/4 = 25% < 1/3 = 33.33%
+      const previous = (100 * 1) / 3;
+      expect(
+        findViolations(coverage, { ...thresholds, outputField: previous }),
+      ).toMatchObject([{ category: 'outputField' }]);
+    });
+
     it('실측치를 그대로 임계치로 박아도 자기 자신에게 걸리지 않는다', () => {
       // 임계치를 달성치로 고정하는 운용이라 부동소수 오차 방어가 필요하다
       const coverage = coverageOf(`

--- a/scripts/sdl-description-coverage.spec.ts
+++ b/scripts/sdl-description-coverage.spec.ts
@@ -74,7 +74,7 @@ describe('sdl-description-coverage', () => {
       expect(coverage.rootField.missing).toEqual(['test.graphql: Query.storeDetail']);
     });
 
-    it('스칼라 루트 인자만 집계하고 식별자 인자는 제외한다', () => {
+    it('input 객체가 아닌 루트 인자만 집계하고 식별자 인자는 제외한다', () => {
       const coverage = coverageOf(`
         extend type Query {
           """픽업 달력."""
@@ -86,6 +86,24 @@ describe('sdl-description-coverage', () => {
       expect(coverage.rootArgScalar).toMatchObject({ documented: 0, total: 1 });
       expect(coverage.rootArgScalar.missing).toEqual([
         'test.graphql: Query.pickupCalendar(yearMonth)',
+      ]);
+    });
+
+    it('커스텀 스칼라·enum 인자도 대상에 넣는다', () => {
+      // 하드코딩 allowlist였다면 URL·Sort 인자가 통째로 빠졌을 자리
+      const coverage = coverageOf(`
+        scalar URL
+        enum Sort { LATEST }
+        extend type Query {
+          """검색."""
+          search(url: URL!, sort: Sort, input: SearchInput): String!
+        }
+        input SearchInput { """값.""" value: String }
+      `);
+      expect(coverage.rootArgScalar).toMatchObject({ documented: 0, total: 2 });
+      expect(coverage.rootArgScalar.missing).toEqual([
+        'test.graphql: Query.search(url)',
+        'test.graphql: Query.search(sort)',
       ]);
     });
 

--- a/scripts/sdl-description-coverage.spec.ts
+++ b/scripts/sdl-description-coverage.spec.ts
@@ -1,11 +1,12 @@
 import {
+  CATEGORIES,
   collectCoverage,
   findViolations,
   isExemptFieldName,
   isPlaceholderDescription,
   percentOf,
 } from './sdl-description-coverage';
-import type { Category, Coverage } from './sdl-description-coverage';
+import type { Baseline, Category, Coverage } from './sdl-description-coverage';
 
 // DB 불필요한 순수 단위 테스트. SDL 문자열만으로 검증한다.
 describe('sdl-description-coverage', () => {
@@ -152,50 +153,81 @@ describe('sdl-description-coverage', () => {
   });
 
   describe('findViolations', () => {
-    const thresholds = Object.fromEntries(
-      ['rootField', 'rootArgScalar', 'inputType', 'inputField', 'outputType', 'outputField', 'enumType', 'enumValue'].map(
-        (c) => [c, 0],
-      ),
-    ) as Record<Category, number>;
+    /** 모든 카테고리를 "회귀 없음"으로 두고, 검사할 카테고리만 덮어쓴다. */
+    function baselineOf(
+      overrides: Partial<Record<Category, Baseline>> = {},
+    ): Record<Category, Baseline> {
+      const base = CATEGORIES.reduce(
+        (acc, category) => {
+          acc[category] = { documented: 0, total: 0 };
+          return acc;
+        },
+        {} as Record<Category, Baseline>,
+      );
+      return { ...base, ...overrides };
+    }
 
-    it('임계치 미달 항목만 돌려준다', () => {
-      const coverage = coverageOf(`
-        extend type Query {
-          productDetail(productId: ID!): String!
-        }
-      `);
-      expect(findViolations(coverage, { ...thresholds, rootField: 100 })).toMatchObject([
-        { category: 'rootField', actual: 0, threshold: 100 },
-      ]);
-      expect(findViolations(coverage, thresholds)).toEqual([]);
-    });
+    const oneRootField = `
+      extend type Query {
+        productDetail(productId: ID!): String!
+      }
+    `;
 
-    it('기준선을 분수로 잡으면 미기재 1건 추가도 잡아낸다', () => {
-      // 정수 %로 내림하면 그만큼 여유분이 생겨 회귀가 통과한다.
-      // 예: 185/603=30.68%에 임계 30을 걸면 185/616=30.03%도 통과.
-      const baseline = (100 * 185) / 603;
-      const regressed = { documented: 185, total: 604, missing: [] };
-      expect(percentOf(regressed)).toBeLessThan(baseline);
-
-      const coverage = coverageOf(`
-        """설명 있음."""
-        type A { """값.""" one: String, two: String, three: String, four: String }
-      `);
-      // 1/4 = 25% < 1/3 = 33.33%
-      const previous = (100 * 1) / 3;
+    it('기준선을 만족하면 위반이 없다', () => {
+      const coverage = coverageOf(oneRootField);
       expect(
-        findViolations(coverage, { ...thresholds, outputField: previous }),
-      ).toMatchObject([{ category: 'outputField' }]);
+        findViolations(coverage, baselineOf({ rootField: { documented: 0, total: 1 } })),
+      ).toEqual([]);
     });
 
-    it('실측치를 그대로 임계치로 박아도 자기 자신에게 걸리지 않는다', () => {
-      // 임계치를 달성치로 고정하는 운용이라 부동소수 오차 방어가 필요하다
+    it('커버리지 비율이 떨어지면 ratio 위반으로 잡는다', () => {
+      // 설명이 있던 필드가 사라져 비율만 내려가는 경우 (미기재 건수는 그대로)
+      const coverage = coverageOf(oneRootField);
+      const violations = findViolations(
+        coverage,
+        baselineOf({ rootField: { documented: 1, total: 2 } }),
+      );
+      expect(violations).toMatchObject([{ category: 'rootField', reason: 'ratio' }]);
+    });
+
+    it('미기재 건수가 늘면 count 위반으로 잡는다', () => {
       const coverage = coverageOf(`
         """설명 있음."""
         type A { """값.""" one: String, two: String, three: String }
       `);
-      const actual = percentOf(coverage.outputField); // 1/3 = 33.33...
-      expect(findViolations(coverage, { ...thresholds, outputField: actual })).toEqual([]);
+      // 기준선 1/2(미기재 1) → 실제 1/3(미기재 2)
+      expect(
+        findViolations(coverage, baselineOf({ outputField: { documented: 1, total: 2 } })),
+      ).toMatchObject([{ category: 'outputField', reason: 'count' }]);
+    });
+
+    it('기준선이 0%인 카테고리도 미기재 추가를 막는다', () => {
+      // 비율만 보면 0/6 → 0/7도 0% >= 0%라 통과해 게이트가 성립하지 않는다
+      const coverage = coverageOf(`
+        extend type Query {
+          """검색."""
+          search(keyword: String!, cursor: String): String!
+        }
+      `);
+      expect(percentOf(coverage.rootArgScalar)).toBe(0);
+      expect(
+        findViolations(coverage, baselineOf({ rootArgScalar: { documented: 0, total: 1 } })),
+      ).toMatchObject([{ category: 'rootArgScalar', reason: 'count' }]);
+      // 기준선이 같은 미기재 2건이면 통과
+      expect(
+        findViolations(coverage, baselineOf({ rootArgScalar: { documented: 0, total: 2 } })),
+      ).toEqual([]);
+    });
+
+    it('실측치를 그대로 기준선으로 박아도 자기 자신에게 걸리지 않는다', () => {
+      // 기준선을 실측 분수로 고정하는 운용이라 부동소수 오차 방어가 필요하다
+      const coverage = coverageOf(`
+        """설명 있음."""
+        type A { """값.""" one: String, two: String, three: String }
+      `);
+      expect(
+        findViolations(coverage, baselineOf({ outputField: { documented: 1, total: 3 } })),
+      ).toEqual([]);
     });
   });
 });

--- a/scripts/sdl-description-coverage.ts
+++ b/scripts/sdl-description-coverage.ts
@@ -64,11 +64,15 @@ const ROOT_TYPES = new Set(['Query', 'Mutation', 'Subscription']);
  * 의도적으로 집계하지 않는 정의 종류.
  *
  * schema 선언은 루트 타입을 이름짓는 배선일 뿐 프론트가 소비하는 API 요소가 아니다.
+ * scalar·union·directive 확장은 설명을 붙일 자리가 없다(각각 directive·멤버·인자만 더한다).
  * 실행 문서(query/fragment)는 SDL 파일에 오지 않지만 파서가 같은 문법을 받으므로 함께 둔다.
  */
-const IGNORED_KINDS = new Set<string>([
+export const IGNORED_KINDS = new Set<string>([
   Kind.SCHEMA_DEFINITION,
   Kind.SCHEMA_EXTENSION,
+  Kind.SCALAR_TYPE_EXTENSION,
+  Kind.UNION_TYPE_EXTENSION,
+  Kind.DIRECTIVE_EXTENSION,
   Kind.OPERATION_DEFINITION,
   Kind.FRAGMENT_DEFINITION,
 ]);

--- a/scripts/sdl-description-coverage.ts
+++ b/scripts/sdl-description-coverage.ts
@@ -61,6 +61,19 @@ export interface SdlFile {
 const ROOT_TYPES = new Set(['Query', 'Mutation', 'Subscription']);
 
 /**
+ * 의도적으로 집계하지 않는 정의 종류.
+ *
+ * schema 선언은 루트 타입을 이름짓는 배선일 뿐 프론트가 소비하는 API 요소가 아니다.
+ * 실행 문서(query/fragment)는 SDL 파일에 오지 않지만 파서가 같은 문법을 받으므로 함께 둔다.
+ */
+const IGNORED_KINDS = new Set<string>([
+  Kind.SCHEMA_DEFINITION,
+  Kind.SCHEMA_EXTENSION,
+  Kind.OPERATION_DEFINITION,
+  Kind.FRAGMENT_DEFINITION,
+]);
+
+/**
  * 이름만으로 의미가 자명해 설명을 요구하지 않는 필드.
  *
  * 왜 제외하는가: 전부 채우게 하면 "상품 ID" 같은 무의미한 설명이 수백 개 생긴다.
@@ -203,7 +216,7 @@ type Recorder = (
   hasDescription: boolean,
 ) => void;
 
-function collectDefinition(
+export function collectDefinition(
   def: DefinitionNode,
   file: string,
   record: Recorder,
@@ -300,6 +313,28 @@ function collectDefinition(
     return;
   }
 
+  // directive는 선언 설명과 인자 설명이 유일한 문서다.
+  if (def.kind === Kind.DIRECTIVE_DEFINITION) {
+    const typeName = def.name.value;
+    record(
+      'outputType',
+      file,
+      `@${typeName}`,
+      !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+    );
+    for (const arg of def.arguments ?? []) {
+      if (inputTypeNames.has(namedTypeOf(arg))) continue;
+      if (isExemptFieldName(arg.name.value)) continue;
+      record(
+        'rootArgScalar',
+        file,
+        `@${typeName}(${arg.name.value})`,
+        Boolean(arg.description?.value.trim()),
+      );
+    }
+    return;
+  }
+
   // union·scalar는 필드가 없어 선언 설명이 유일한 문서다.
   if (
     def.kind === Kind.UNION_TYPE_DEFINITION ||
@@ -336,7 +371,18 @@ function collectDefinition(
         Boolean(value.description?.value.trim()),
       );
     }
+    return;
   }
+
+  if (IGNORED_KINDS.has(def.kind)) return;
+
+  // 여기 오면 이 스크립트가 모르는 SDL 구문이다. 조용히 넘기면 그 구문으로 추가된
+  // 요소가 집계에서 통째로 빠져 게이트가 무력화된다. 손으로 적은 목록은 반드시
+  // 빠지는 자리가 생기므로(directive를 그렇게 놓쳤다) 구조로 막는다.
+  throw new Error(
+    `[docs:check] 처리하지 않은 SDL 정의 종류: ${def.kind} (${file}). ` +
+      '집계 대상이면 collectDefinition에, 아니면 IGNORED_KINDS에 근거와 함께 추가하라.',
+  );
 }
 
 export function percentOf(stat: CategoryStat): number {

--- a/scripts/sdl-description-coverage.ts
+++ b/scripts/sdl-description-coverage.ts
@@ -10,7 +10,11 @@
  * 검증할 수 있다.
  */
 
-import type { DefinitionNode, InputValueDefinitionNode } from 'graphql';
+import type {
+  DefinitionNode,
+  DocumentNode,
+  InputValueDefinitionNode,
+} from 'graphql';
 import { Kind, parse } from 'graphql';
 
 /** 문서 트리 깊이 순. 게이트 출력도 이 순서를 따른다. */
@@ -29,7 +33,7 @@ export type Category = (typeof CATEGORIES)[number];
 
 export const CATEGORY_LABELS: Record<Category, string> = {
   rootField: 'Query/Mutation 필드',
-  rootArgScalar: '루트 인자(스칼라·ID)',
+  rootArgScalar: '루트 인자(비 input)',
   inputType: 'input 타입 선언',
   inputField: 'input 필드',
   outputType: '출력 type 선언',
@@ -54,19 +58,6 @@ export interface SdlFile {
 }
 
 const ROOT_TYPES = new Set(['Query', 'Mutation', 'Subscription']);
-
-/**
- * input 객체가 아니라 스칼라로 취급할 타입명.
- * 커스텀 스칼라를 추가하면 여기에도 넣어야 한다.
- */
-const SCALAR_TYPE_NAMES = new Set([
-  'String',
-  'Int',
-  'Float',
-  'Boolean',
-  'ID',
-  'DateTime',
-]);
 
 /**
  * 이름만으로 의미가 자명해 설명을 요구하지 않는 필드.
@@ -131,8 +122,30 @@ function namedTypeOf(node: InputValueDefinitionNode): string {
   return type.name.value;
 }
 
+/**
+ * SDL에 선언된 input 객체 타입명을 모은다.
+ *
+ * 왜 스칼라 allowlist가 아닌가: 하드코딩한 스칼라 목록은 `scalar URL` 같은 커스텀
+ * 스칼라가 추가되면 그 타입 인자를 통째로 집계에서 빠뜨린다. "input 객체가 아니면
+ * 대상"으로 뒤집으면 커스텀 스칼라도 enum 인자도 자동으로 포함된다 — 둘 다 설명을
+ * 적을 자리가 인자뿐이라 원래 대상이어야 한다.
+ */
+function collectInputTypeNames(documents: DocumentNode[]): Set<string> {
+  const names = new Set<string>();
+  for (const doc of documents) {
+    for (const def of doc.definitions) {
+      if (def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION) {
+        names.add(def.name.value);
+      }
+    }
+  }
+  return names;
+}
+
 export function collectCoverage(files: SdlFile[]): Coverage {
   const coverage = emptyCoverage();
+  const documents = files.map((file) => parse(file.sdl));
+  const inputTypeNames = collectInputTypeNames(documents);
 
   const record = (
     category: Category,
@@ -146,11 +159,11 @@ export function collectCoverage(files: SdlFile[]): Coverage {
     else stat.missing.push(`${file}: ${label}`);
   };
 
-  for (const { path, sdl } of files) {
-    for (const def of parse(sdl).definitions) {
-      collectDefinition(def, path, record);
+  files.forEach(({ path }, index) => {
+    for (const def of documents[index].definitions) {
+      collectDefinition(def, path, record, inputTypeNames);
     }
-  }
+  });
 
   return coverage;
 }
@@ -166,6 +179,7 @@ function collectDefinition(
   def: DefinitionNode,
   file: string,
   record: Recorder,
+  inputTypeNames: Set<string>,
 ): void {
   if (
     def.kind === Kind.OBJECT_TYPE_DEFINITION ||
@@ -182,8 +196,8 @@ function collectDefinition(
         );
         for (const arg of field.arguments ?? []) {
           // input 객체 인자는 설명을 input 타입 쪽에 두면 되므로 게이트 대상이 아니다.
-          // 스칼라·ID 인자는 인자 설명 외에 형식을 적을 자리가 없다.
-          if (!SCALAR_TYPE_NAMES.has(namedTypeOf(arg))) continue;
+          // 그 외(스칼라·ID·커스텀 스칼라·enum)는 인자 설명 외에 적을 자리가 없다.
+          if (inputTypeNames.has(namedTypeOf(arg))) continue;
           if (isExemptFieldName(arg.name.value)) continue;
           record(
             'rootArgScalar',

--- a/scripts/sdl-description-coverage.ts
+++ b/scripts/sdl-description-coverage.ts
@@ -13,6 +13,7 @@
 import type {
   DefinitionNode,
   DocumentNode,
+  FieldDefinitionNode,
   InputValueDefinitionNode,
 } from 'graphql';
 import { Kind, parse } from 'graphql';
@@ -33,7 +34,7 @@ export type Category = (typeof CATEGORIES)[number];
 
 export const CATEGORY_LABELS: Record<Category, string> = {
   rootField: 'Query/Mutation 필드',
-  rootArgScalar: '루트 인자(비 input)',
+  rootArgScalar: '필드 인자(비 input)',
   inputType: 'input 타입 선언',
   inputField: 'input 필드',
   outputType: '출력 type 선언',
@@ -171,6 +172,30 @@ export function collectCoverage(files: SdlFile[]): Coverage {
   return coverage;
 }
 
+/**
+ * 필드 인자를 기록한다. 루트든 아니든 인자는 설명을 적을 자리가 인자뿐이라 규칙이 같다.
+ *
+ * input 객체 인자만 제외한다 — 그쪽은 input 타입 선언·필드에 설명을 두면 된다.
+ */
+function recordFieldArgs(
+  field: FieldDefinitionNode,
+  ownerLabel: string,
+  file: string,
+  record: Recorder,
+  inputTypeNames: Set<string>,
+): void {
+  for (const arg of field.arguments ?? []) {
+    if (inputTypeNames.has(namedTypeOf(arg))) continue;
+    if (isExemptFieldName(arg.name.value)) continue;
+    record(
+      'rootArgScalar',
+      file,
+      `${ownerLabel}.${field.name.value}(${arg.name.value})`,
+      Boolean(arg.description?.value.trim()),
+    );
+  }
+}
+
 type Recorder = (
   category: Category,
   file: string,
@@ -197,18 +222,7 @@ function collectDefinition(
           `${typeName}.${field.name.value}`,
           Boolean(field.description?.value.trim()),
         );
-        for (const arg of field.arguments ?? []) {
-          // input 객체 인자는 설명을 input 타입 쪽에 두면 되므로 게이트 대상이 아니다.
-          // 그 외(스칼라·ID·커스텀 스칼라·enum)는 인자 설명 외에 적을 자리가 없다.
-          if (inputTypeNames.has(namedTypeOf(arg))) continue;
-          if (isExemptFieldName(arg.name.value)) continue;
-          record(
-            'rootArgScalar',
-            file,
-            `${typeName}.${field.name.value}(${arg.name.value})`,
-            Boolean(arg.description?.value.trim()),
-          );
-        }
+        recordFieldArgs(field, typeName, file, record, inputTypeNames);
       }
       return;
     }
@@ -222,6 +236,7 @@ function collectDefinition(
       );
     }
     for (const field of def.fields ?? []) {
+      recordFieldArgs(field, typeName, file, record, inputTypeNames);
       if (isExemptFieldName(field.name.value)) continue;
       record(
         'outputField',
@@ -248,6 +263,7 @@ function collectDefinition(
       );
     }
     for (const field of def.fields ?? []) {
+      recordFieldArgs(field, typeName, file, record, inputTypeNames);
       if (isExemptFieldName(field.name.value)) continue;
       record(
         'outputField',
@@ -281,6 +297,21 @@ function collectDefinition(
         Boolean(field.description?.value.trim()),
       );
     }
+    return;
+  }
+
+  // union·scalar는 필드가 없어 선언 설명이 유일한 문서다.
+  if (
+    def.kind === Kind.UNION_TYPE_DEFINITION ||
+    def.kind === Kind.SCALAR_TYPE_DEFINITION
+  ) {
+    const typeName = def.name.value;
+    record(
+      'outputType',
+      file,
+      typeName,
+      !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+    );
     return;
   }
 

--- a/scripts/sdl-description-coverage.ts
+++ b/scripts/sdl-description-coverage.ts
@@ -134,7 +134,10 @@ function collectInputTypeNames(documents: DocumentNode[]): Set<string> {
   const names = new Set<string>();
   for (const doc of documents) {
     for (const def of doc.definitions) {
-      if (def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION) {
+      if (
+        def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ||
+        def.kind === Kind.INPUT_OBJECT_TYPE_EXTENSION
+      ) {
         names.add(def.name.value);
       }
     }
@@ -230,14 +233,20 @@ function collectDefinition(
     return;
   }
 
-  if (def.kind === Kind.INTERFACE_TYPE_DEFINITION) {
+  if (
+    def.kind === Kind.INTERFACE_TYPE_DEFINITION ||
+    def.kind === Kind.INTERFACE_TYPE_EXTENSION
+  ) {
     const typeName = def.name.value;
-    record(
-      'outputType',
-      file,
-      typeName,
-      !isPlaceholderDescription(typeName, def.description?.value ?? ''),
-    );
+    // 확장에는 타입 선언 설명을 붙일 수 없으므로 선언은 정의에서만 센다.
+    if (def.kind === Kind.INTERFACE_TYPE_DEFINITION) {
+      record(
+        'outputType',
+        file,
+        typeName,
+        !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+      );
+    }
     for (const field of def.fields ?? []) {
       if (isExemptFieldName(field.name.value)) continue;
       record(
@@ -250,14 +259,19 @@ function collectDefinition(
     return;
   }
 
-  if (def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION) {
+  if (
+    def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ||
+    def.kind === Kind.INPUT_OBJECT_TYPE_EXTENSION
+  ) {
     const typeName = def.name.value;
-    record(
-      'inputType',
-      file,
-      typeName,
-      !isPlaceholderDescription(typeName, def.description?.value ?? ''),
-    );
+    if (def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION) {
+      record(
+        'inputType',
+        file,
+        typeName,
+        !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+      );
+    }
     for (const field of def.fields ?? []) {
       if (isExemptFieldName(field.name.value)) continue;
       record(
@@ -270,14 +284,19 @@ function collectDefinition(
     return;
   }
 
-  if (def.kind === Kind.ENUM_TYPE_DEFINITION) {
+  if (
+    def.kind === Kind.ENUM_TYPE_DEFINITION ||
+    def.kind === Kind.ENUM_TYPE_EXTENSION
+  ) {
     const typeName = def.name.value;
-    record(
-      'enumType',
-      file,
-      typeName,
-      !isPlaceholderDescription(typeName, def.description?.value ?? ''),
-    );
+    if (def.kind === Kind.ENUM_TYPE_DEFINITION) {
+      record(
+        'enumType',
+        file,
+        typeName,
+        !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+      );
+    }
     for (const value of def.values ?? []) {
       record(
         'enumValue',

--- a/scripts/sdl-description-coverage.ts
+++ b/scripts/sdl-description-coverage.ts
@@ -73,7 +73,10 @@ const SCALAR_TYPE_NAMES = new Set([
  *
  * 왜 제외하는가: 전부 채우게 하면 "상품 ID" 같은 무의미한 설명이 수백 개 생긴다.
  * order-checkout.graphql이 이미 비자명 필드(idempotencyKey·pickupAt)에만 근거를
- * 적고 productId·quantity는 비워 뒀는데, 단순 유무 집계는 그 판단에 벌점을 준다.
+ * 적고 productId는 비워 뒀는데, 단순 유무 집계는 그 판단에 벌점을 준다.
+ *
+ * quantity처럼 맥락에 따라 단위·상한 설명이 필요한 이름은 일부러 넣지 않았다 —
+ * 제외 목록이 넓어지면 설명이 필요한 자리를 가린다.
  *
  * 제외는 분모에서 빼는 것일 뿐 작성을 막지 않는다 — 맥락이 필요하면 자유롭게 단다.
  */
@@ -277,35 +280,67 @@ export function percentOf(stat: CategoryStat): number {
   return (stat.documented / stat.total) * 100;
 }
 
+export interface Baseline {
+  documented: number;
+  total: number;
+}
+
 export interface Violation {
   category: Category;
+  /** 'ratio' 커버리지 비율 하락 · 'count' 미기재 건수 증가 */
+  reason: 'ratio' | 'count';
   actual: number;
   threshold: number;
+  actualMissing: number;
+  baselineMissing: number;
   missing: string[];
 }
 
+export function missingCountOf(baseline: Baseline): number {
+  return baseline.total - baseline.documented;
+}
+
 /**
- * 임계치 미달 항목을 돌려준다.
+ * 기준선 대비 회귀를 찾는다. 두 조건을 함께 건다.
  *
- * 소수 셋째 자리에서 비교한다 — 임계치를 실측치로 고정하는 운용이라
- * 부동소수 오차로 자기 자신에게 걸리는 걸 막아야 한다.
+ * 1. 미기재 건수가 기준선보다 늘면 실패.
+ * 2. 커버리지 비율이 기준선보다 떨어지면 실패.
+ *
+ * 왜 둘 다인가: 비율만 보면 기준선이 0%인 카테고리를 영영 못 막는다
+ * (0/6 → 0/7도 0% >= 0%라 통과). 건수만 보면 설명이 있던 필드를 지워 비율이
+ * 떨어지는 회귀를 놓친다.
+ *
+ * 비율 비교는 소수 여유(1e-9)를 둔다 — 기준선을 실측 분수로 고정하는 운용이라
+ * 부동소수 오차로 자기 자신에게 걸리면 안 된다.
  */
 export function findViolations(
   coverage: Coverage,
-  thresholds: Record<Category, number>,
+  baselines: Record<Category, Baseline>,
 ): Violation[] {
   const violations: Violation[] = [];
   for (const category of CATEGORIES) {
     const stat = coverage[category];
+    const baseline = baselines[category];
     const actual = percentOf(stat);
-    const threshold = thresholds[category];
+    const threshold = percentOf({ ...baseline, missing: [] });
+    const actualMissing = stat.missing.length;
+    const baselineMissing = missingCountOf(baseline);
+
+    const base = {
+      category,
+      actual,
+      threshold,
+      actualMissing,
+      baselineMissing,
+      missing: stat.missing,
+    };
+
+    if (actualMissing > baselineMissing) {
+      violations.push({ ...base, reason: 'count' });
+      continue;
+    }
     if (actual + 1e-9 < threshold) {
-      violations.push({
-        category,
-        actual,
-        threshold,
-        missing: stat.missing,
-      });
+      violations.push({ ...base, reason: 'ratio' });
     }
   }
   return violations;

--- a/scripts/sdl-description-coverage.ts
+++ b/scripts/sdl-description-coverage.ts
@@ -1,0 +1,312 @@
+/**
+ * SDL description 커버리지 측정 로직.
+ *
+ * 왜: SDL에 설명 없는 필드를 추가해도 `yarn validate`가 통과한다. dto:check가
+ * SDL↔DTO 동기화를 도구로 강제하듯, 문서 커버리지도 사람 주의력이 아니라
+ * 게이트로 받쳐야 한다. (이슈 #250)
+ *
+ * 이 파일은 순수 함수만 둔다 — 파일 시스템 접근과 CLI는
+ * check-sdl-description-coverage.ts가 담당한다. 그래야 spec에서 SDL 문자열만으로
+ * 검증할 수 있다.
+ */
+
+import type { DefinitionNode, InputValueDefinitionNode } from 'graphql';
+import { Kind, parse } from 'graphql';
+
+/** 문서 트리 깊이 순. 게이트 출력도 이 순서를 따른다. */
+export const CATEGORIES = [
+  'rootField',
+  'rootArgScalar',
+  'inputType',
+  'inputField',
+  'outputType',
+  'outputField',
+  'enumType',
+  'enumValue',
+] as const;
+
+export type Category = (typeof CATEGORIES)[number];
+
+export const CATEGORY_LABELS: Record<Category, string> = {
+  rootField: 'Query/Mutation 필드',
+  rootArgScalar: '루트 인자(스칼라·ID)',
+  inputType: 'input 타입 선언',
+  inputField: 'input 필드',
+  outputType: '출력 type 선언',
+  outputField: '출력 type 필드',
+  enumType: 'enum 선언',
+  enumValue: 'enum 값',
+};
+
+export interface CategoryStat {
+  documented: number;
+  total: number;
+  /** 설명이 비어 있어 커버리지에서 빠진 요소들. `파일: 타입.필드` 형태. */
+  missing: string[];
+}
+
+export type Coverage = Record<Category, CategoryStat>;
+
+export interface SdlFile {
+  /** 리포트에 찍히는 경로. 보통 src 기준 상대 경로. */
+  path: string;
+  sdl: string;
+}
+
+const ROOT_TYPES = new Set(['Query', 'Mutation', 'Subscription']);
+
+/**
+ * input 객체가 아니라 스칼라로 취급할 타입명.
+ * 커스텀 스칼라를 추가하면 여기에도 넣어야 한다.
+ */
+const SCALAR_TYPE_NAMES = new Set([
+  'String',
+  'Int',
+  'Float',
+  'Boolean',
+  'ID',
+  'DateTime',
+]);
+
+/**
+ * 이름만으로 의미가 자명해 설명을 요구하지 않는 필드.
+ *
+ * 왜 제외하는가: 전부 채우게 하면 "상품 ID" 같은 무의미한 설명이 수백 개 생긴다.
+ * order-checkout.graphql이 이미 비자명 필드(idempotencyKey·pickupAt)에만 근거를
+ * 적고 productId·quantity는 비워 뒀는데, 단순 유무 집계는 그 판단에 벌점을 준다.
+ *
+ * 제외는 분모에서 빼는 것일 뿐 작성을 막지 않는다 — 맥락이 필요하면 자유롭게 단다.
+ */
+const EXEMPT_FIELD_NAMES = new Set([
+  'id',
+  'createdAt',
+  'updatedAt',
+  'deletedAt',
+]);
+
+/** `productId`, `storeIds`처럼 대상이 이름에 드러나는 식별자. */
+const EXEMPT_NAME_PATTERN = /(?:^|[a-z])Ids?$/;
+
+export function isExemptFieldName(name: string): boolean {
+  return EXEMPT_FIELD_NAMES.has(name) || EXEMPT_NAME_PATTERN.test(name);
+}
+
+/**
+ * 타입 이름을 되풀이하기만 하는 자동생성형 설명인지.
+ *
+ * 왜 필요한가: seller SDL에 `"""SellerOrderSummary 타입"""` 같은 설명이 70건 있다.
+ * 파서는 description이 있으므로 "문서화됨"으로 세지만 전달되는 정보는 0이다.
+ * 이걸 걸러내지 않으면 임계치가 거짓 안전을 준다.
+ */
+export function isPlaceholderDescription(
+  typeName: string,
+  description: string,
+): boolean {
+  const trimmed = description.trim();
+  if (trimmed.length === 0) return true;
+  const pattern = new RegExp(
+    `^${escapeRegExp(typeName)}\\s*(입력\\s*)?(타입|입력|enum|열거형)?\\.?$`,
+    'i',
+  );
+  return pattern.test(trimmed);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function emptyCoverage(): Coverage {
+  return CATEGORIES.reduce((acc, category) => {
+    acc[category] = { documented: 0, total: 0, missing: [] };
+    return acc;
+  }, {} as Coverage);
+}
+
+function namedTypeOf(node: InputValueDefinitionNode): string {
+  let type = node.type;
+  while (type.kind !== Kind.NAMED_TYPE) type = type.type;
+  return type.name.value;
+}
+
+export function collectCoverage(files: SdlFile[]): Coverage {
+  const coverage = emptyCoverage();
+
+  const record = (
+    category: Category,
+    file: string,
+    label: string,
+    hasDescription: boolean,
+  ): void => {
+    const stat = coverage[category];
+    stat.total += 1;
+    if (hasDescription) stat.documented += 1;
+    else stat.missing.push(`${file}: ${label}`);
+  };
+
+  for (const { path, sdl } of files) {
+    for (const def of parse(sdl).definitions) {
+      collectDefinition(def, path, record);
+    }
+  }
+
+  return coverage;
+}
+
+type Recorder = (
+  category: Category,
+  file: string,
+  label: string,
+  hasDescription: boolean,
+) => void;
+
+function collectDefinition(
+  def: DefinitionNode,
+  file: string,
+  record: Recorder,
+): void {
+  if (
+    def.kind === Kind.OBJECT_TYPE_DEFINITION ||
+    def.kind === Kind.OBJECT_TYPE_EXTENSION
+  ) {
+    const typeName = def.name.value;
+    if (ROOT_TYPES.has(typeName)) {
+      for (const field of def.fields ?? []) {
+        record(
+          'rootField',
+          file,
+          `${typeName}.${field.name.value}`,
+          Boolean(field.description?.value.trim()),
+        );
+        for (const arg of field.arguments ?? []) {
+          // input 객체 인자는 설명을 input 타입 쪽에 두면 되므로 게이트 대상이 아니다.
+          // 스칼라·ID 인자는 인자 설명 외에 형식을 적을 자리가 없다.
+          if (!SCALAR_TYPE_NAMES.has(namedTypeOf(arg))) continue;
+          if (isExemptFieldName(arg.name.value)) continue;
+          record(
+            'rootArgScalar',
+            file,
+            `${typeName}.${field.name.value}(${arg.name.value})`,
+            Boolean(arg.description?.value.trim()),
+          );
+        }
+      }
+      return;
+    }
+
+    if (def.kind === Kind.OBJECT_TYPE_DEFINITION) {
+      record(
+        'outputType',
+        file,
+        typeName,
+        !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+      );
+    }
+    for (const field of def.fields ?? []) {
+      if (isExemptFieldName(field.name.value)) continue;
+      record(
+        'outputField',
+        file,
+        `${typeName}.${field.name.value}`,
+        Boolean(field.description?.value.trim()),
+      );
+    }
+    return;
+  }
+
+  if (def.kind === Kind.INTERFACE_TYPE_DEFINITION) {
+    const typeName = def.name.value;
+    record(
+      'outputType',
+      file,
+      typeName,
+      !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+    );
+    for (const field of def.fields ?? []) {
+      if (isExemptFieldName(field.name.value)) continue;
+      record(
+        'outputField',
+        file,
+        `${typeName}.${field.name.value}`,
+        Boolean(field.description?.value.trim()),
+      );
+    }
+    return;
+  }
+
+  if (def.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION) {
+    const typeName = def.name.value;
+    record(
+      'inputType',
+      file,
+      typeName,
+      !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+    );
+    for (const field of def.fields ?? []) {
+      if (isExemptFieldName(field.name.value)) continue;
+      record(
+        'inputField',
+        file,
+        `${typeName}.${field.name.value}`,
+        Boolean(field.description?.value.trim()),
+      );
+    }
+    return;
+  }
+
+  if (def.kind === Kind.ENUM_TYPE_DEFINITION) {
+    const typeName = def.name.value;
+    record(
+      'enumType',
+      file,
+      typeName,
+      !isPlaceholderDescription(typeName, def.description?.value ?? ''),
+    );
+    for (const value of def.values ?? []) {
+      record(
+        'enumValue',
+        file,
+        `${typeName}.${value.name.value}`,
+        Boolean(value.description?.value.trim()),
+      );
+    }
+  }
+}
+
+export function percentOf(stat: CategoryStat): number {
+  if (stat.total === 0) return 100;
+  return (stat.documented / stat.total) * 100;
+}
+
+export interface Violation {
+  category: Category;
+  actual: number;
+  threshold: number;
+  missing: string[];
+}
+
+/**
+ * 임계치 미달 항목을 돌려준다.
+ *
+ * 소수 셋째 자리에서 비교한다 — 임계치를 실측치로 고정하는 운용이라
+ * 부동소수 오차로 자기 자신에게 걸리는 걸 막아야 한다.
+ */
+export function findViolations(
+  coverage: Coverage,
+  thresholds: Record<Category, number>,
+): Violation[] {
+  const violations: Violation[] = [];
+  for (const category of CATEGORIES) {
+    const stat = coverage[category];
+    const actual = percentOf(stat);
+    const threshold = thresholds[category];
+    if (actual + 1e-9 < threshold) {
+      violations.push({
+        category,
+        actual,
+        threshold,
+        missing: stat.missing,
+      });
+    }
+  }
+  return violations;
+}


### PR DESCRIPTION
이슈 #250. SDL 설명 커버리지를 `yarn validate`와 CI `check` job에 편입한다.

## 배경

SDL에 설명 없는 필드를 추가해도 CI가 그대로 통과했다. 그 결과 도메인별 편차가 크게 벌어져 있다 — seller-order 0% ↔ user-search 100%.

## 구성

| 파일 | 역할 |
| --- | --- |
| `scripts/sdl-description-coverage.ts` | 순수 집계 로직. FS·CLI와 분리해 SDL 문자열만으로 테스트 가능 |
| `scripts/check-sdl-description-coverage.ts` | CLI. `--report`(수치만) / `--warning`(종료코드 0) |
| `scripts/sdl-description-coverage.spec.ts` | 단위 테스트 14건 (DB 불필요) |
| `jest.scripts.config.js` | `package.json`의 jest는 `rootDir`이 `src`라 `scripts/` spec을 수집하지 못한다 |

`validate` 체인과 `pr-check.yml`의 `check` job에 `docs:check`·`test:scripts`를 넣었다. `check`는 이미 필수 status check라 **`terraform/main.tf` ruleset 변경은 불필요**하다.

## 단순 유무 집계를 쓰지 않은 이유

**1. 플레이스홀더 판정** — seller SDL에 `"""SellerOrderSummary 타입"""`처럼 이름만 되풀이하는 설명이 70건 있다. 파서는 `description`이 있으므로 "문서화됨"으로 세지만 정보량은 0이다. 이 판정을 넣자 실측치가 내려갔다:

| 요소 | 유무만 집계 | 플레이스홀더 판정 후 |
| --- | --- | --- |
| enum 선언 | 78.3% | **52.2%** |
| input 타입 선언 | 63.9% | **18.1%** |
| 출력 type 선언 | 72.9% | **49.6%** |

**2. 자명 필드 제외** — `id`·`createdAt`·`*Id`를 분모에서 뺀다. 전부 채우게 하면 "상품 ID" 같은 설명만 수백 개 늘어난다. `order-checkout.graphql`이 이미 비자명 필드(`idempotencyKey`·`pickupAt`)에만 근거를 적고 `productId`·`quantity`는 비워 뒀는데, 단순 집계는 그 판단에 오히려 벌점을 준다. 제외는 분모에서 빼는 것일 뿐 작성을 막지 않는다.

## 현재 수치 (임계치 = 실측치, 회귀만 차단)

```
Query/Mutation 필드       130/130  100.0%  (임계 100%)
루트 인자(스칼라·ID)          0/6    0.0%  (임계 0%)
input 타입 선언             13/72   18.1%  (임계 18%)
input 필드                 49/227   21.6%  (임계 21%)
출력 type 선언              66/133   49.6%  (임계 49%)
출력 type 필드             185/603   30.7%  (임계 30%)
enum 선언                   12/23   52.2%  (임계 52%)
enum 값                     10/81   12.3%  (임계 12%)
```

후속 PR에서 커버리지를 올린 뒤 임계치도 함께 상향한다.

## 테스트

14건 — 플레이스홀더 판정 4 / 자명 필드 제외 2 / 요소별 집계 6 / 임계치 비교 2.
마지막 항목에 "실측치를 그대로 임계치로 박아도 부동소수 오차로 자기 자신에게 걸리지 않는지"를 포함했다 — 임계치를 달성치로 고정하는 운용이라 필요하다.