### PR TITLE
docs(graphql): 인증·권한 요건과 스칼라 인자 형식 명시

### DIFF
--- a/src/features/conversation/conversation-center.graphql
+++ b/src/features/conversation/conversation-center.graphql
@@ -1,9 +1,10 @@
 extend type Query {
-  """알림센터 대화 탭 목록(구매자). 마지막 메시지 최신순."""
+  """알림센터 대화 탭 목록(구매자). 마지막 메시지 최신순. 로그인 필수. 본인 데이터만 대상이 된다."""
   myConversations(input: MyConversationsInput): MyConversationConnection!
   """
   채팅 상세 메시지 목록(최신순 키셋 커서). 구매자 본인 대화만 조회 가능하며,
   조회 시 last_read_at을 현재 시각으로 갱신한다(안읽음 배지 해소 부수효과).
+  로그인 필수.
   """
   conversationMessages(conversationId: ID!, input: ConversationMessagesInput): ConversationMessageConnection!
 }

--- a/src/features/conversation/conversation-inquiry.graphql
+++ b/src/features/conversation/conversation-inquiry.graphql
@@ -2,6 +2,7 @@ extend type Query {
   """
   문의 채팅 진입 컨텍스트(구매자). 매장 프로필·상담시간·치환 완료 인사말·질문 칩을
   한 번에 내려준다. 아직 대화가 없어도 조회 가능하며 그 경우 conversationId는 null.
+  로그인 필수.
   """
   storeInquiryContext(storeId: ID!): StoreInquiryContext!
 }
@@ -10,11 +11,13 @@ extend type Mutation {
   """
   구매자 텍스트 메시지 전송. 해당 매장과의 대화가 없으면 이 시점에 생성하고,
   치환 완료된 인사말을 매장 메시지로 먼저 저장한 뒤 유저 메시지를 저장한다.
+  로그인 필수.
   """
   sendConversationMessage(input: SendConversationMessageInput!): ConversationMessagesPayload!
   """
   질문 칩(FAQ) 전송. 유저 메시지(칩 제목)와 매장 자동응답(FAQ 답변 HTML)을
   한 트랜잭션으로 저장한다. 첫 전송이면 대화 생성 + 인사말 저장도 함께 수행.
+  로그인 필수.
   """
   sendConversationFaqMessage(input: SendConversationFaqMessageInput!): ConversationMessagesPayload!
 }

--- a/src/features/conversation/conversation-subscription.graphql
+++ b/src/features/conversation/conversation-subscription.graphql
@@ -4,9 +4,9 @@ extend type Subscription {
   소유자)만 구독할 수 있다. 인증은 graphql-ws connectionParams.authorization.
   """
   conversationMessageAdded(conversationId: ID!): ConversationMessage!
-  """구매자 대화 목록/배지 갱신 이벤트(새 메시지 도착 시)."""
+  """구매자 대화 목록/배지 갱신 이벤트(새 메시지 도착 시). 로그인 필수. 본인 데이터만 대상이 된다."""
   myConversationUpdated: ConversationListUpdate!
-  """판매자 대화 목록 갱신 이벤트(고객 메시지 도착 시)."""
+  """판매자 대화 목록 갱신 이벤트(고객 메시지 도착 시). 로그인 필수."""
   sellerConversationUpdated: SellerConversationListUpdate!
 }
 

--- a/src/features/conversation/conversation-subscription.graphql
+++ b/src/features/conversation/conversation-subscription.graphql
@@ -6,7 +6,10 @@ extend type Subscription {
   conversationMessageAdded(conversationId: ID!): ConversationMessage!
   """구매자 대화 목록/배지 갱신 이벤트(새 메시지 도착 시). 로그인 필수. 본인 데이터만 대상이 된다."""
   myConversationUpdated: ConversationListUpdate!
-  """판매자 대화 목록 갱신 이벤트(고객 메시지 도착 시). 로그인 필수."""
+  """
+판매자 대화 목록 갱신 이벤트(고객 메시지 도착 시).
+활성 매장을 보유한 판매자만 구독할 수 있다. 매장이 없거나 비활성·삭제 상태면 NOT_FOUND.
+"""
   sellerConversationUpdated: SellerConversationListUpdate!
 }
 

--- a/src/features/pickup/pickup.types.graphql
+++ b/src/features/pickup/pickup.types.graphql
@@ -1,8 +1,14 @@
 extend type Query {
   """월별 픽업 가능 날짜 (홈 전역 정책 기준). yearMonth: "YYYY-MM" """
-  pickupCalendar(yearMonth: String!): PickupCalendar!
+  pickupCalendar(
+    """대상 연월. "YYYY-MM" 형식(KST 기준). 예: "2026-09". 형식이 어긋나면 BAD_REQUEST."""
+    yearMonth: String!
+  ): PickupCalendar!
   """선택 날짜의 픽업 시간 슬롯. date: "YYYY-MM-DD" """
-  pickupTimeSlots(date: String!): PickupTimeSlots!
+  pickupTimeSlots(
+    """대상 날짜. "YYYY-MM-DD" 형식(KST 기준). 예: "2026-09-10". 형식이 어긋나면 BAD_REQUEST."""
+    date: String!
+  ): PickupTimeSlots!
 }
 
 type PickupCalendar {

--- a/src/features/search/search-entry.graphql
+++ b/src/features/search/search-entry.graphql
@@ -11,7 +11,13 @@ extend type Query {
 
 extend type Mutation {
   """검색 실행 기록. 로그인 시 최근 검색어(SearchHistory) 갱신 + 인기 검색어 집계 이벤트 기록, 비로그인 시 집계 이벤트만. 검색 실행 시 1회 호출(탭 전환·페이지네이션에는 호출하지 않는다)."""
-  recordSearch(keyword: String!): Boolean!
+  recordSearch(
+    """
+    기록할 검색어. 앞뒤 공백 제거 + 연속 공백 1칸 축약 후 저장한다. 빈 문자열이거나
+    200자(코드 포인트 기준)를 넘으면 BAD_REQUEST.
+    """
+    keyword: String!
+  ): Boolean!
 }
 
 input PopularSearchKeywordsInput {

--- a/src/features/seller/seller-content.graphql
+++ b/src/features/seller/seller-content.graphql
@@ -1,25 +1,25 @@
 extend type Query {
-  """내 매장 FAQ 목록을 조회한다."""
+  """내 매장 FAQ 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerFaqTopics: [SellerFaqTopic!]!
-  """내 매장 배너 목록을 조회한다."""
+  """내 매장 배너 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerBanners(input: SellerCursorInput): SellerBannerConnection!
-  """내 매장 감사 로그 목록을 조회한다."""
+  """내 매장 감사 로그 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerAuditLogs(input: SellerAuditLogListInput): SellerAuditLogConnection!
 }
 
 extend type Mutation {
-  """FAQ 항목을 생성한다."""
+  """FAQ 항목을 생성한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerCreateFaqTopic(input: SellerCreateFaqTopicInput!): SellerFaqTopic!
-  """FAQ 항목을 수정한다."""
+  """FAQ 항목을 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpdateFaqTopic(input: SellerUpdateFaqTopicInput!): SellerFaqTopic!
-  """FAQ 항목을 삭제한다."""
+  """FAQ 항목을 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteFaqTopic(topicId: ID!): Boolean!
 
-  """배너를 생성한다."""
+  """배너를 생성한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerCreateBanner(input: SellerCreateBannerInput!): SellerBanner!
-  """배너를 수정한다."""
+  """배너를 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpdateBanner(input: SellerUpdateBannerInput!): SellerBanner!
-  """배너를 삭제한다."""
+  """배너를 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteBanner(bannerId: ID!): Boolean!
 }
 

--- a/src/features/seller/seller-conversation.graphql
+++ b/src/features/seller/seller-conversation.graphql
@@ -1,12 +1,12 @@
 extend type Query {
-  """내 매장 대화방 목록을 조회한다."""
+  """내 매장 대화방 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerConversations(input: SellerCursorInput): SellerConversationConnection!
-  """대화방 메시지 목록을 조회한다."""
+  """대화방 메시지 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerConversationMessages(conversationId: ID!, input: SellerCursorInput): SellerConversationMessageConnection!
 }
 
 extend type Mutation {
-  """판매자 메시지를 발송한다."""
+  """판매자 메시지를 발송한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerSendConversationMessage(input: SellerSendConversationMessageInput!): SellerConversationMessage!
 }
 

--- a/src/features/seller/seller-order.graphql
+++ b/src/features/seller/seller-order.graphql
@@ -1,12 +1,12 @@
 extend type Query {
-  """내 매장 주문 목록을 조회한다."""
+  """내 매장 주문 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerOrderList(input: SellerOrderListInput): SellerOrderConnection!
-  """내 매장 주문 상세를 조회한다."""
+  """내 매장 주문 상세를 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerOrder(orderId: ID!): SellerOrderDetail!
 }
 
 extend type Mutation {
-  """주문 상태를 변경한다."""
+  """주문 상태를 변경한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpdateOrderStatus(input: SellerUpdateOrderStatusInput!): SellerOrderSummary!
 }
 

--- a/src/features/seller/seller-product.graphql
+++ b/src/features/seller/seller-product.graphql
@@ -1,59 +1,59 @@
 extend type Query {
-  """내 매장 상품 목록을 조회한다."""
+  """내 매장 상품 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerProducts(input: SellerProductListInput): SellerProductConnection!
-  """내 매장 상품 상세를 조회한다."""
+  """내 매장 상품 상세를 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerProduct(productId: ID!): SellerProduct!
 }
 
 extend type Mutation {
-  """내 매장 상품을 생성한다."""
+  """내 매장 상품을 생성한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerCreateProduct(input: SellerCreateProductInput!): SellerProduct!
-  """내 매장 상품을 수정한다."""
+  """내 매장 상품을 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpdateProduct(input: SellerUpdateProductInput!): SellerProduct!
-  """내 매장 상품을 삭제한다."""
+  """내 매장 상품을 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteProduct(productId: ID!): Boolean!
-  """내 매장 상품 활성 상태를 변경한다."""
+  """내 매장 상품 활성 상태를 변경한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerSetProductActive(input: SellerSetProductActiveInput!): SellerProduct!
 
-  """상품 이미지를 추가한다."""
+  """상품 이미지를 추가한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerAddProductImage(input: SellerAddProductImageInput!): SellerProductImage!
-  """상품 이미지를 삭제한다."""
+  """상품 이미지를 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteProductImage(imageId: ID!): Boolean!
-  """상품 이미지 순서를 변경한다."""
+  """상품 이미지 순서를 변경한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerReorderProductImages(input: SellerReorderProductImagesInput!): [SellerProductImage!]!
 
-  """상품 카테고리 연결을 설정한다."""
+  """상품 카테고리 연결을 설정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerSetProductCategories(input: SellerSetProductCategoriesInput!): SellerProduct!
-  """상품 태그 연결을 설정한다."""
+  """상품 태그 연결을 설정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerSetProductTags(input: SellerSetProductTagsInput!): SellerProduct!
 
-  """상품 옵션 그룹을 생성한다."""
+  """상품 옵션 그룹을 생성한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerCreateOptionGroup(input: SellerCreateOptionGroupInput!): SellerOptionGroup!
-  """상품 옵션 그룹을 수정한다."""
+  """상품 옵션 그룹을 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpdateOptionGroup(input: SellerUpdateOptionGroupInput!): SellerOptionGroup!
-  """상품 옵션 그룹을 삭제한다."""
+  """상품 옵션 그룹을 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteOptionGroup(optionGroupId: ID!): Boolean!
-  """상품 옵션 그룹 순서를 변경한다."""
+  """상품 옵션 그룹 순서를 변경한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerReorderOptionGroups(input: SellerReorderOptionGroupsInput!): [SellerOptionGroup!]!
 
-  """상품 옵션 아이템을 생성한다."""
+  """상품 옵션 아이템을 생성한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerCreateOptionItem(input: SellerCreateOptionItemInput!): SellerOptionItem!
-  """상품 옵션 아이템을 수정한다."""
+  """상품 옵션 아이템을 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpdateOptionItem(input: SellerUpdateOptionItemInput!): SellerOptionItem!
-  """상품 옵션 아이템을 삭제한다."""
+  """상품 옵션 아이템을 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteOptionItem(optionItemId: ID!): Boolean!
-  """상품 옵션 아이템 순서를 변경한다."""
+  """상품 옵션 아이템 순서를 변경한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerReorderOptionItems(input: SellerReorderOptionItemsInput!): [SellerOptionItem!]!
 
-  """상품 커스텀 템플릿을 등록 또는 수정한다."""
+  """상품 커스텀 템플릿을 등록 또는 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpsertProductCustomTemplate(input: SellerUpsertProductCustomTemplateInput!): SellerCustomTemplate!
-  """상품 커스텀 템플릿 활성 상태를 변경한다."""
+  """상품 커스텀 템플릿 활성 상태를 변경한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerSetProductCustomTemplateActive(input: SellerSetProductCustomTemplateActiveInput!): SellerCustomTemplate!
-  """커스텀 텍스트 토큰을 등록 또는 수정한다."""
+  """커스텀 텍스트 토큰을 등록 또는 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpsertProductCustomTextToken(input: SellerUpsertProductCustomTextTokenInput!): SellerCustomTextToken!
-  """커스텀 텍스트 토큰을 삭제한다."""
+  """커스텀 텍스트 토큰을 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteProductCustomTextToken(tokenId: ID!): Boolean!
-  """커스텀 텍스트 토큰 순서를 변경한다."""
+  """커스텀 텍스트 토큰 순서를 변경한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerReorderProductCustomTextTokens(input: SellerReorderProductCustomTextTokensInput!): [SellerCustomTextToken!]!
 }
 

--- a/src/features/seller/seller-store.graphql
+++ b/src/features/seller/seller-store.graphql
@@ -1,28 +1,28 @@
 extend type Query {
-  """내 매장 정보를 조회한다."""
+  """내 매장 정보를 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerMyStore: SellerStore!
-  """내 매장 요일별 영업시간 목록을 조회한다."""
+  """내 매장 요일별 영업시간 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerStoreBusinessHours: [SellerStoreBusinessHour!]!
-  """내 매장 특별휴무 목록을 조회한다."""
+  """내 매장 특별휴무 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerStoreSpecialClosures(input: SellerCursorInput): SellerStoreSpecialClosureConnection!
-  """내 매장 일별 생산 가능 수량 목록을 조회한다."""
+  """내 매장 일별 생산 가능 수량 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerStoreDailyCapacities(input: SellerDateCursorInput): SellerStoreDailyCapacityConnection!
 }
 
 extend type Mutation {
-  """내 매장 기본 정보를 수정한다."""
+  """내 매장 기본 정보를 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpdateStoreBasicInfo(input: SellerUpdateStoreBasicInfoInput!): SellerStore!
-  """내 매장 영업시간을 등록 또는 수정한다."""
+  """내 매장 영업시간을 등록 또는 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpsertStoreBusinessHour(input: SellerUpsertStoreBusinessHourInput!): SellerStoreBusinessHour!
-  """내 매장 특별휴무를 등록 또는 수정한다."""
+  """내 매장 특별휴무를 등록 또는 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpsertStoreSpecialClosure(input: SellerUpsertStoreSpecialClosureInput!): SellerStoreSpecialClosure!
-  """내 매장 특별휴무를 삭제한다."""
+  """내 매장 특별휴무를 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteStoreSpecialClosure(closureId: ID!): Boolean!
-  """내 매장 픽업 정책을 수정한다."""
+  """내 매장 픽업 정책을 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpdatePickupPolicy(input: SellerUpdatePickupPolicyInput!): SellerStore!
-  """내 매장 일별 생산 가능 수량을 등록 또는 수정한다."""
+  """내 매장 일별 생산 가능 수량을 등록 또는 수정한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerUpsertStoreDailyCapacity(input: SellerUpsertStoreDailyCapacityInput!): SellerStoreDailyCapacity!
-  """내 매장 일별 생산 가능 수량을 삭제한다."""
+  """내 매장 일별 생산 가능 수량을 삭제한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerDeleteStoreDailyCapacity(capacityId: ID!): Boolean!
 }
 

--- a/src/features/store/store-pickup-schedule.graphql
+++ b/src/features/store/store-pickup-schedule.graphql
@@ -1,8 +1,16 @@
 extend type Query {
   """매장별 월 픽업 가능 날짜. 없거나 비활성/삭제 매장이면 NOT_FOUND. 비로그인 접근 가능. yearMonth: "YYYY-MM" """
-  storePickupCalendar(storeId: ID!, yearMonth: String!): StorePickupCalendar!
+  storePickupCalendar(
+    storeId: ID!
+    """대상 연월. "YYYY-MM" 형식(KST 기준). 예: "2026-09". 형식이 어긋나면 BAD_REQUEST."""
+    yearMonth: String!
+  ): StorePickupCalendar!
   """매장별 선택 날짜의 픽업 시간 슬롯. date: "YYYY-MM-DD" """
-  storePickupTimeSlots(storeId: ID!, date: String!): StorePickupTimeSlots!
+  storePickupTimeSlots(
+    storeId: ID!
+    """대상 날짜. "YYYY-MM-DD" 형식(KST 기준). 예: "2026-09-10". 형식이 어긋나면 BAD_REQUEST."""
+    date: String!
+  ): StorePickupTimeSlots!
 }
 
 """매장별 월 픽업 달력(상품 상세 픽업 일정 선택용)."""

--- a/src/features/user/user-engagement.graphql
+++ b/src/features/user/user-engagement.graphql
@@ -1,11 +1,11 @@
 extend type Mutation {
-  """리뷰 좋아요"""
+  """리뷰 좋아요. 로그인 필수."""
   likeReview(reviewId: ID!): Boolean!
-  """리뷰 좋아요 해제(멱등: 좋아요가 없어도 true)"""
+  """리뷰 좋아요 해제(멱등: 좋아요가 없어도 true). 로그인 필수."""
   unlikeReview(reviewId: ID!): Boolean!
-  """리뷰 댓글 작성"""
+  """리뷰 댓글 작성. 로그인 필수."""
   writeReviewComment(input: WriteReviewCommentInput!): MyReviewComment!
-  """내 리뷰 댓글 삭제(soft). 본인 댓글만 가능."""
+  """내 리뷰 댓글 삭제(soft). 로그인 필수. 본인 댓글만 가능."""
   deleteMyReviewComment(commentId: ID!): Boolean!
 }
 

--- a/src/features/user/user-mypage.graphql
+++ b/src/features/user/user-mypage.graphql
@@ -1,5 +1,5 @@
 extend type Query {
-  """마이페이지 메인 화면 집계 데이터"""
+  """마이페이지 메인 화면 집계 데이터. 로그인 필수. 본인 데이터만 대상이 된다."""
   myPageOverview: MyPageOverview!
 }
 

--- a/src/features/user/user-notification.graphql
+++ b/src/features/user/user-notification.graphql
@@ -1,14 +1,14 @@
 extend type Query {
-  """상단/하단 공통 UI용 카운트 정보 조회"""
+  """상단/하단 공통 UI용 카운트 정보 조회. 로그인 필수. 본인 데이터만 대상이 된다."""
   viewerCounts: ViewerCounts!
-  """알림 목록 조회"""
+  """알림 목록 조회. 로그인 필수. 본인 데이터만 대상이 된다."""
   myNotifications(input: MyNotificationsInput): NotificationConnection!
 }
 
 extend type Mutation {
-  """특정 알림 읽음 처리"""
+  """특정 알림 읽음 처리. 로그인 필수. 본인 데이터만 대상이 된다."""
   markNotificationRead(notificationId: ID!): Boolean!
-  """전체 알림 읽음 처리"""
+  """전체 알림 읽음 처리. 로그인 필수. 본인 데이터만 대상이 된다."""
   markAllNotificationsRead: Boolean!
 }
 

--- a/src/features/user/user-order.graphql
+++ b/src/features/user/user-order.graphql
@@ -1,7 +1,7 @@
 extend type Query {
-  """내 주문 목록 조회"""
+  """내 주문 목록 조회. 로그인 필수. 본인 데이터만 대상이 된다."""
   myOrders(input: MyOrdersInput): MyOrderConnection!
-  """내 주문 상세 조회"""
+  """내 주문 상세 조회. 로그인 필수. 본인 데이터만 대상이 된다."""
   myOrder(orderId: ID!): MyOrderDetail!
 }
 

--- a/src/features/user/user-profile.graphql
+++ b/src/features/user/user-profile.graphql
@@ -1,20 +1,26 @@
 extend type Query {
   """현재 로그인한 유저 정보 조회"""
   me: MePayload!
-  """닉네임 중복 확인"""
-  checkNicknameAvailability(nickname: String!): NicknameAvailability!
+  """닉네임 중복 확인. 로그인 필수."""
+  checkNicknameAvailability(
+    """
+    검사할 닉네임. 앞뒤 공백을 제거한 뒤 2~20자, 한글·영문·숫자·언더스코어만 허용한다.
+    규칙 위반은 예외가 아니라 available=false와 reason으로 돌려준다.
+    """
+    nickname: String!
+  ): NicknameAvailability!
 }
 
 extend type Mutation {
-  """온보딩 완료 처리(필수 정보 입력)"""
+  """온보딩 완료 처리(필수 정보 입력). 로그인 필수. 본인 데이터만 대상이 된다."""
   completeOnboarding(input: CompleteOnboardingInput!): MePayload!
-  """프로필 정보 수정"""
+  """프로필 정보 수정. 로그인 필수. 본인 데이터만 대상이 된다."""
   updateMyProfile(input: UpdateMyProfileInput!): MePayload!
-  """프로필 이미지 URL 업데이트"""
+  """프로필 이미지 URL 업데이트. 로그인 필수. 본인 데이터만 대상이 된다."""
   updateMyProfileImage(input: UpdateMyProfileImageInput!): MePayload!
-  """회원 탈퇴(soft delete)"""
+  """회원 탈퇴(soft delete). 로그인 필수. 본인 데이터만 대상이 된다."""
   deleteMyAccount: Boolean!
-  """프로필 이미지 업로드용 Presigned URL 발급"""
+  """프로필 이미지 업로드용 Presigned URL 발급. 로그인 필수. 본인 데이터만 대상이 된다."""
   createProfileImageUploadUrl(input: CreateProfileImageUploadUrlInput!): ProfileImageUploadUrl!
 }
 

--- a/src/features/user/user-recent-view.graphql
+++ b/src/features/user/user-recent-view.graphql
@@ -1,14 +1,14 @@
 extend type Query {
-  """최근 본 상품 목록 조회"""
+  """최근 본 상품 목록 조회. 로그인 필수. 본인 데이터만 대상이 된다."""
   myRecentViewedProducts(input: MyRecentViewedProductsInput): RecentViewedProductConnection!
 }
 
 extend type Mutation {
-  """상품 상세 진입 시 호출하여 최근 본 상품에 기록"""
+  """상품 상세 진입 시 호출하여 최근 본 상품에 기록. 로그인 필수. 본인 데이터만 대상이 된다."""
   recordProductView(productId: ID!): Boolean!
-  """최근 본 상품 단건 삭제"""
+  """최근 본 상품 단건 삭제. 로그인 필수. 본인 데이터만 대상이 된다."""
   deleteRecentViewedProduct(productId: ID!): Boolean!
-  """최근 본 상품 전체 삭제"""
+  """최근 본 상품 전체 삭제. 로그인 필수. 본인 데이터만 대상이 된다."""
   clearRecentViewedProducts: Boolean!
 }
 

--- a/src/features/user/user-review.graphql
+++ b/src/features/user/user-review.graphql
@@ -1,9 +1,9 @@
 extend type Query {
-  """내가 작성한 리뷰 목록"""
+  """내가 작성한 리뷰 목록. 로그인 필수. 본인 데이터만 대상이 된다."""
   myReviews(input: MyReviewsInput): MyReviewConnection!
-  """리뷰 작성 가능한 주문 아이템 목록(마이페이지 '리뷰 남기기' 탭). 픽업 완료 + 활성 리뷰 미존재."""
+  """리뷰 작성 가능한 주문 아이템 목록(마이페이지 '리뷰 남기기' 탭). 픽업 완료 + 활성 리뷰 미존재. 로그인 필수. 본인 데이터만 대상이 된다."""
   myReviewableOrderItems(input: MyReviewableOrderItemsInput): MyReviewableOrderItemConnection!
-  """주문 아이템에 대한 리뷰 작성 가능 여부 및 기존 리뷰"""
+  """주문 아이템에 대한 리뷰 작성 가능 여부 및 기존 리뷰. 로그인 필수. 본인 데이터만 대상이 된다."""
   myReviewForOrderItem(orderItemId: ID!): MyReviewOrNull!
 }
 
@@ -35,11 +35,11 @@ type MyReviewableOrderItem {
 }
 
 extend type Mutation {
-  """리뷰 미디어 업로드용 Presigned URL 발급"""
+  """리뷰 미디어 업로드용 Presigned URL 발급. 로그인 필수."""
   createReviewMediaUploadUrl(input: CreateReviewMediaUploadUrlInput!): ReviewMediaUploadUrl!
-  """리뷰 작성"""
+  """리뷰 작성. 로그인 필수."""
   writeReview(input: WriteReviewInput!): MyReview!
-  """내 리뷰 삭제(soft)"""
+  """내 리뷰 삭제(soft). 로그인 필수. 본인 데이터만 대상이 된다."""
   deleteMyReview(reviewId: ID!): Boolean!
 }
 

--- a/src/features/user/user-search.graphql
+++ b/src/features/user/user-search.graphql
@@ -1,12 +1,12 @@
 extend type Query {
-  """최근 검색어 목록 조회"""
+  """최근 검색어 목록 조회. 로그인 필수. 본인 데이터만 대상이 된다."""
   mySearchHistories(input: MySearchHistoriesInput): SearchHistoryConnection!
 }
 
 extend type Mutation {
-  """특정 검색어 기록 삭제"""
+  """특정 검색어 기록 삭제. 로그인 필수. 본인 데이터만 대상이 된다."""
   deleteSearchHistory(id: ID!): Boolean!
-  """검색어 기록 전체 삭제"""
+  """검색어 기록 전체 삭제. 로그인 필수. 본인 데이터만 대상이 된다."""
   clearSearchHistories: Boolean!
 }
 

--- a/src/features/user/user-wishlist.graphql
+++ b/src/features/user/user-wishlist.graphql
@@ -1,14 +1,14 @@
 extend type Query {
-  """내 찜 목록"""
+  """내 찜 목록. 로그인 필수. 본인 데이터만 대상이 된다."""
   myWishlist(input: MyWishlistInput): MyWishlistConnection!
   """찜 상품의 매장별 그룹 목록 (찜 상품 수 desc, 동점 시 최근 찜 순). 로그인 필요."""
   myWishlistStoreGroups(input: MyWishlistStoreGroupsInput): MyWishlistStoreGroupsConnection!
 }
 
 extend type Mutation {
-  """찜 추가 (멱등: 이미 있어도 true 반환, soft-delete된 항목은 복원)"""
+  """찜 추가 (멱등: 이미 있어도 true 반환, soft-delete된 항목은 복원). 로그인 필수. 본인 데이터만 대상이 된다."""
   addToWishlist(productId: ID!): Boolean!
-  """찜 해제 (멱등: 이미 없어도 true 반환)"""
+  """찜 해제 (멱등: 이미 없어도 true 반환). 로그인 필수. 본인 데이터만 대상이 된다."""
   removeFromWishlist(productId: ID!): Boolean!
 }
 


### PR DESCRIPTION
프론트가 문서만 보고는 어떤 API에 토큰이 필요한지 알 수 없었다. JWT가 필수인 루트 필드 97개 중 설명에서 인증을 언급한 건 **9개(9%)** 뿐이었고, 특히 판매자 API 50개는 전부 인증 필수인데 **단 하나도** 그 사실을 적지 않았다. 401/403을 받아 봐야 아는 상태였다.

## 인증 요건 — JWT 97/97, Optional 12/12

| 대상 | 건수 | 문구 |
| --- | --- | --- |
| 판매자 | 50 | `판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND.` |
| 본인 데이터 대상 | 28 | `로그인 필수. 본인 데이터만 대상이 된다.` |
| 나머지 | 10 | `로그인 필수.` |

합계 50+28+10 = 88건이다.

판매자 문구는 추정이 아니라 `SellerBaseService.requireSellerContext`가 **실제로 던지는 예외**를 근거로 적었다. 권한 자체는 구현돼 있었고 문서에만 없던 것이다.

"본인 데이터만 대상이 된다"고 적은 28건은 리졸버가 전부 `@CurrentUser()`를 받아 서비스에 accountId를 넘기는지 확인했다(28/28). 대표 사례로 `markNotificationRead`·`deleteSearchHistory`·`deleteMyReview`는 repository where절에 `account_id`가 함께 들어가 남의 리소스에 닿지 않는다.

이미 소유권만 적혀 있던 `conversationMessages`·`deleteMyReviewComment` 2건도 로그인 요건을 덧붙여 표기를 통일했다.

## 스칼라 루트 인자 6건

이름만으로 형식을 알 수 없고 **설명 외에 적을 자리가 없는** 것들이다.

| 인자 | 명시한 내용 | 근거 |
| --- | --- | --- |
| `pickupCalendar`·`storePickupCalendar(yearMonth)` | `"YYYY-MM"` (KST) | `parseKstYearMonth` |
| `pickupTimeSlots`·`storePickupTimeSlots(date)` | `"YYYY-MM-DD"` (KST) | `parseKstDate` |
| `checkNicknameAvailability(nickname)` | 2~20자, 한글·영문·숫자·언더스코어. **규칙 위반은 예외가 아니라 `available=false` + `reason`** | `MIN/MAX_NICKNAME_LENGTH`, 닉네임 정규식 |
| `recordSearch(keyword)` | 공백 정규화 후 저장, 200자(코드 포인트) 초과는 BAD_REQUEST | `normalizeSearchKeyword` |

`productId` 류 식별자 인자 34건은 이름으로 충분해 대상에서 제외했다.

## 커버리지 영향

`docs:check` 기준 **필드 인자(비 input) 0/6 → 6/6 (100%)**.

## 검증

SDL 변경만이라 런타임 동작은 바뀌지 않는다. 전체 225 suites / 1,869건 통과, `tsc`·`dto:check`·`arch:check`·`docs:check`·`test:scripts` 통과.