### PR TITLE
docs(graphql): 구매자·공용 SDL 설명 보강 및 커버리지 기준선 100% 상향

### DIFF
--- a/scripts/check-sdl-description-coverage.ts
+++ b/scripts/check-sdl-description-coverage.ts
@@ -46,13 +46,13 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.yarn']);
  */
 const BASELINE: Record<Category, Baseline> = {
   rootField: { documented: 130, total: 130 },
-  rootArgScalar: { documented: 0, total: 6 },
-  inputType: { documented: 13, total: 72 },
-  inputField: { documented: 49, total: 227 },
-  outputType: { documented: 67, total: 134 },
-  outputField: { documented: 185, total: 603 },
-  enumType: { documented: 12, total: 23 },
-  enumValue: { documented: 10, total: 81 },
+  rootArgScalar: { documented: 6, total: 6 },
+  inputType: { documented: 72, total: 72 },
+  inputField: { documented: 227, total: 227 },
+  outputType: { documented: 134, total: 134 },
+  outputField: { documented: 603, total: 603 },
+  enumType: { documented: 17, total: 17 },
+  enumValue: { documented: 61, total: 61 },
 };
 
 const args = new Set(process.argv.slice(2));

--- a/src/features/conversation/conversation-center.graphql
+++ b/src/features/conversation/conversation-center.graphql
@@ -19,9 +19,11 @@ input MyConversationsInput {
 
 """대화 목록 응답"""
 type MyConversationConnection {
+  """대화방 카드. 마지막 메시지가 최근인 순으로 온다."""
   items: [MyConversationItem!]!
   """전체 대화 수"""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
   """다음 페이지 커서. 없으면 null"""
   nextCursor: String
@@ -32,11 +34,13 @@ type MyConversationItem {
   """대화 ID"""
   id: ID!
   storeId: ID!
+  """매장명."""
   storeName: String!
   """매장 프로필(로고) 이미지 URL. 미등록 시 null"""
   storeProfileImageUrl: String
   """마지막 메시지 미리보기(HTML 메시지는 태그 제거 plain text)"""
   lastMessagePreview: String
+  """마지막 메시지 시각. 목록 정렬 기준이다."""
   lastMessageAt: DateTime!
   """읽지 않은 수신 메시지 수(매장명 옆 "(3)" 표기용)"""
   unreadCount: Int!
@@ -52,9 +56,11 @@ input ConversationMessagesInput {
 
 """채팅 상세 메시지 응답(최신순)"""
 type ConversationMessageConnection {
+  """메시지. 최신순으로 오므로 화면에서는 역순으로 쌓는다."""
   items: [ConversationMessage!]!
   """대화 전체 메시지 수"""
   totalCount: Int!
+  """더 과거 메시지가 남아 있는지."""
   hasMore: Boolean!
   """다음(더 과거) 페이지 커서. 없으면 null"""
   nextCursor: String

--- a/src/features/conversation/conversation-inquiry.graphql
+++ b/src/features/conversation/conversation-inquiry.graphql
@@ -25,6 +25,7 @@ extend type Mutation {
 """문의 채팅 진입 컨텍스트"""
 type StoreInquiryContext {
   storeId: ID!
+  """매장명."""
   storeName: String!
   """매장 프로필(로고) 이미지 URL. 미등록 시 null"""
   profileImageUrl: String
@@ -42,6 +43,7 @@ type StoreInquiryContext {
 type InquiryBusinessHour {
   """0=일 ~ 6=토"""
   dayOfWeek: Int!
+  """해당 요일 휴무 여부. true면 openTime·closeTime이 null이다."""
   isClosed: Boolean!
   """오픈 시각 "HH:mm". 휴무면 null"""
   openTime: String
@@ -52,6 +54,7 @@ type InquiryBusinessHour {
 """질문 칩(매장 FAQ)"""
 type InquiryFaqTopic {
   id: ID!
+  """칩에 노출되는 질문 제목. 전송하면 이 문구가 유저 메시지로 저장된다."""
   title: String!
 }
 
@@ -59,27 +62,38 @@ type InquiryFaqTopic {
 type ConversationMessage {
   id: ID!
   conversationId: ID!
+  """발신 주체. 말풍선 좌우 배치 기준이다."""
   senderType: ConversationSenderType!
+  """본문 형식. 이 값에 따라 bodyText·bodyHtml 중 하나가 채워진다."""
   bodyFormat: ConversationBodyFormat!
+  """평문 본문. bodyFormat이 TEXT일 때 채워진다."""
   bodyText: String
+  """서식 본문. bodyFormat이 HTML일 때 채워진다."""
   bodyHtml: String
+  """발송 시각. 메시지 스트림 정렬은 id 기준이다."""
   createdAt: DateTime!
 }
 
 """메시지 전송 결과. 이번 호출로 저장된 메시지들을 생성 순으로 담는다(첫 전송이면 인사말 포함)"""
 type ConversationMessagesPayload {
+  """대화방 ID. 첫 전송이면 이번에 생성된 대화방 ID다."""
   conversationId: ID!
+  """이번 호출로 저장된 메시지. 생성 순이며 첫 전송이면 인사말이 맨 앞에 온다."""
   messages: [ConversationMessage!]!
 }
 
 """구매자 텍스트 메시지 전송 입력"""
 input SendConversationMessageInput {
+  """문의할 매장 ID. 대화방이 없으면 이 호출에서 생성된다."""
   storeId: ID!
+  """보낼 평문 메시지."""
   bodyText: String!
 }
 
 """질문 칩(FAQ) 전송 입력"""
 input SendConversationFaqMessageInput {
+  """문의할 매장 ID. 대화방이 없으면 이 호출에서 생성된다."""
   storeId: ID!
+  """선택한 질문 칩 ID. storeInquiryContext.faqTopics가 준 값을 쓴다."""
   faqTopicId: ID!
 }

--- a/src/features/conversation/conversation-subscription.graphql
+++ b/src/features/conversation/conversation-subscription.graphql
@@ -23,9 +23,11 @@ extend type Subscription {
 type ConversationListUpdate {
   conversationId: ID!
   storeId: ID!
+  """매장명."""
   storeName: String!
   """마지막 메시지 미리보기(HTML은 태그 제거)"""
   lastMessagePreview: String
+  """마지막 메시지 시각. 폐기 규칙의 1차 비교 키다."""
   lastMessageAt: DateTime!
   """이벤트 스냅샷 시점의 구매자 마지막 읽음 시각(폐기 규칙 비교용)"""
   lastReadAt: DateTime
@@ -36,8 +38,10 @@ type ConversationListUpdate {
 """판매자 대화 목록 갱신 이벤트. 도착 순서 비보장 — lastMessageAt 기준 폐기 규칙 동일."""
 type SellerConversationListUpdate {
   conversationId: ID!
+  """대화 상대인 구매자 계정 ID."""
   accountId: ID!
   """마지막 메시지 미리보기(HTML은 태그 제거)"""
   lastMessagePreview: String
+  """마지막 메시지 시각. 폐기 규칙의 비교 키다."""
   lastMessageAt: DateTime!
 }

--- a/src/features/order/order-checkout.graphql
+++ b/src/features/order/order-checkout.graphql
@@ -15,6 +15,7 @@ input CreateOrderInput {
   optionItemIds: [ID!]!
   """픽업 일시. 매장 정책(영업시간·휴무·capacity·리드타임·슬롯 정렬) 재검증."""
   pickupAt: DateTime!
+  """주문 수량. 기본 1."""
   quantity: Int = 1
   """미입력 시 프로필 닉네임 사용."""
   buyerName: String
@@ -25,8 +26,12 @@ input CreateOrderInput {
 """주문 생성 결과 요약. 상세는 myOrder로 재조회."""
 type CreateOrderOutput {
   orderId: ID!
+  """주문번호. 화면·문의에 쓰는 식별자."""
   orderNumber: String!
+  """생성 직후 상태. 항상 SUBMITTED다."""
   status: OrderStatusType!
+  """확정된 픽업 일시. 서버가 매장 정책으로 재검증한 값이다."""
   pickupAt: DateTime!
+  """서버가 스냅샷한 최종 결제 금액(원). 클라이언트 계산값이 아니다."""
   totalPrice: Int!
 }

--- a/src/features/pickup/pickup.types.graphql
+++ b/src/features/pickup/pickup.types.graphql
@@ -11,25 +11,38 @@ extend type Query {
   ): PickupTimeSlots!
 }
 
+"""월별 픽업 달력. 요청한 연월의 모든 날짜가 담긴다."""
 type PickupCalendar {
+  """요청한 연월. "YYYY-MM"."""
   yearMonth: String!
+  """해당 월의 전 날짜. 선택 불가한 날도 사유와 함께 포함된다."""
   days: [PickupDay!]!
 }
 
+"""달력의 하루."""
 type PickupDay {
+  """날짜. "YYYY-MM-DD" (KST)."""
   date: String!
+  """픽업 예약 가능 여부."""
   selectable: Boolean!
   """선택 불가 사유. PAST | OUT_OF_RANGE (선택 가능 시 null)."""
   reason: String
 }
 
+"""선택 날짜의 픽업 시간 슬롯. 오전·오후로 나눠 내려준다."""
 type PickupTimeSlots {
+  """요청한 날짜. "YYYY-MM-DD" (KST)."""
   date: String!
+  """12:00 이전 슬롯."""
   morning: [PickupSlot!]!
+  """12:00 이후 슬롯."""
   afternoon: [PickupSlot!]!
 }
 
+"""픽업 시간 슬롯 1칸. 영업시간 10:00~20:00을 30분 간격으로 나눈 것이라 마지막은 19:30이다."""
 type PickupSlot {
+  """슬롯 시각. "HH:mm" (KST)."""
   time: String!
+  """예약 가능 여부. 리드타임을 지났거나 예약 범위를 벗어나면 false."""
   available: Boolean!
 }

--- a/src/features/product/product-category.graphql
+++ b/src/features/product/product-category.graphql
@@ -3,6 +3,7 @@ extend type Query {
   categories(input: CategoriesInput): [CategoryItem!]!
 }
 
+"""전역 카테고리 조회 조건."""
 input CategoriesInput {
   """EVENT | STYLE | OTHER. 비우면 전체."""
   type: CategoryType
@@ -11,7 +12,10 @@ input CategoriesInput {
 """전역 카테고리 항목. '전체' 칩은 카테고리가 아니라 FE 가상 칩(필터 미적용)이라 포함하지 않는다."""
 type CategoryItem {
   id: ID!
+  """카테고리명. 칩에 그대로 노출된다."""
   name: String!
+  """분류 축. 홈 칩에는 EVENT만 노출된다."""
   categoryType: CategoryType!
+  """노출 순서. 오름차순."""
   sortOrder: Int!
 }

--- a/src/features/product/product-detail.graphql
+++ b/src/features/product/product-detail.graphql
@@ -8,16 +8,21 @@ type ProductDetail {
   id: ID!
   """소속 매장 ID(주문/매장 이동용)."""
   storeId: ID!
+  """상품명."""
   name: String!
+  """상품 설명. 미등록 시 null."""
   description: String
   """구매 전 필독사항."""
   purchaseNotice: String
   """상품 이미지(캐러셀·썸네일, sort_order asc)."""
   images: [String!]!
+  """정가(원)."""
   regularPrice: Int!
+  """할인가(원). 할인이 없으면 null이고 regularPrice가 표시가다."""
   salePrice: Int
   """할인율(0~100). salePrice 없으면 0."""
   discountRate: Int!
+  """통화 코드(ISO 4217). 현재는 KRW만 쓴다."""
   currency: String!
   """후기 탭 카운트."""
   reviewCount: Int!
@@ -30,23 +35,33 @@ type ProductDetail {
 """상품 상세 옵션 섹션(그룹)."""
 type ProductDetailOptionGroup {
   id: ID!
+  """그룹명(섹션 제목)."""
   name: String!
   """그룹 안내 문구(섹션 인트로)."""
   description: String
+  """필수 선택 여부. true면 이 그룹에서 최소 1개를 골라야 주문이 된다."""
   isRequired: Boolean!
+  """최소 선택 개수."""
   minSelect: Int!
+  """최대 선택 개수. minSelect와 같으면 단일 선택처럼 동작한다."""
   maxSelect: Int!
+  """섹션 노출 순서. 오름차순."""
   sortOrder: Int!
+  """이 그룹의 선택지. 활성 항목만 온다."""
   items: [ProductDetailOptionItem!]!
 }
 
 """상품 상세 옵션 항목."""
 type ProductDetailOptionItem {
   id: ID!
+  """선택지 이름."""
   title: String!
+  """선택지 설명. 미등록 시 null."""
   description: String
+  """선택지 이미지 URL. 미등록 시 null."""
   imageUrl: String
   """옵션 선택 시 가격 증감(원)."""
   priceDelta: Int!
+  """그룹 안에서의 노출 순서. 오름차순."""
   sortOrder: Int!
 }

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -9,6 +9,7 @@ extend type Query {
   randomCakes(input: RandomCakesInput): RandomCakesResult!
 }
 
+"""랜덤 케이크 조회 조건."""
 input RandomCakesInput {
   """EVENT 카테고리 ID. 비우면 '전체' 칩(필터 미적용)."""
   categoryId: ID
@@ -18,6 +19,7 @@ input RandomCakesInput {
 
 """랜덤 케이크 그리드. '새로보기 1/3' 페이지 카운트는 FE 로컬 상태(서버 무관)."""
 type RandomCakesResult {
+  """무작위 추출된 케이크 카드. 호출마다 구성이 달라진다."""
   items: [RandomCake!]!
 }
 
@@ -30,6 +32,7 @@ type RandomCake {
   thumbnailUrl: String!
 }
 
+"""인기 케이크 조회 조건."""
 input PopularCakesInput {
   """EVENT 카테고리 ID. 비우면 '전체' 칩(필터 미적용)."""
   categoryId: ID
@@ -39,9 +42,11 @@ input PopularCakesInput {
   limit: Int = 3
 }
 
+"""홈 인기 케이크 섹션 결과."""
 type PopularCakesResult {
   """카테고리 대표 배너. 등록된 배너가 없으면 null(FE placeholder 처리)."""
   banner: HomeBanner
+  """인기 케이크 카드. rank 오름차순."""
   items: [PopularCake!]!
   """랭킹 산출 기준 시각(서버 조회 시점)."""
   rankedAt: DateTime!
@@ -50,8 +55,11 @@ type PopularCakesResult {
 """홈 카테고리 대표 배너. linkType에 대응하는 링크 필드 하나만 채워진다."""
 type HomeBanner {
   id: ID!
+  """배너 이미지 URL."""
   imageUrl: String!
+  """배너 문구. 미입력 시 null."""
   title: String
+  """이동 대상 타입. 이 값에 따라 아래 링크 필드 중 하나만 채워진다."""
   linkType: BannerLinkType!
   """linkType=URL일 때 이동 URL."""
   linkUrl: String
@@ -67,6 +75,7 @@ type HomeBanner {
 
 """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기 카드 목록."""
 input CustomCakeShowcaseInput {
+  """가져올 후기 수. 기본값은 SDL 기본값을 따른다."""
   limit: Int = 5
 }
 
@@ -82,6 +91,7 @@ type CustomCakeShowcaseItem {
   authorNickname: String
   """리뷰 본문. 없으면 null."""
   reviewText: String
+  """좋아요 수. 이 값 기준 내림차순으로 정렬된다."""
   likeCount: Int!
   """사용자가 요청한 디자인 이미지(주문 커스텀 자유편집 크롭)."""
   beforeImageUrl: String!
@@ -94,14 +104,19 @@ type PopularCake {
   id: ID!
   """소속 매장 ID(상세 URL 구성용: /store/{storeId}/products/{id})."""
   storeId: ID!
+  """인기 순위. 1부터 시작한다."""
   rank: Int!
+  """상품명."""
   name: String!
   """대표 이미지(sort_order 최소). 없으면 null."""
   thumbnailUrl: String
+  """매장명."""
   storeName: String!
   """매장 위치 표기(예: 서울 청담동)."""
   regionLabel: String
+  """정가(원)."""
   regularPrice: Int!
+  """할인가(원). 할인이 없으면 null이고 regularPrice가 표시가다."""
   salePrice: Int
   """할인율(0~100). salePrice 없으면 0."""
   discountRate: Int!

--- a/src/features/product/product-reviews.graphql
+++ b/src/features/product/product-reviews.graphql
@@ -9,24 +9,30 @@ extend type Query {
   reviewComments(input: ReviewCommentsInput!): ReviewCommentConnection!
 }
 
+"""상품 리뷰 목록 조회 조건."""
 input ProductReviewsInput {
   productId: ID!
   """true면 사진(미디어) 있는 리뷰만(사진후기 그리드/사진후기 상세)."""
   photoOnly: Boolean = false
+  """정렬 기준. 기본 최신순. 정렬을 바꾸면 기존 cursor는 무효다."""
   sort: ReviewSort = LATEST
   """이전 페이지의 nextCursor 값(불투명 토큰). 동일 sort에서만 유효."""
   cursor: ID
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
 """상품 리뷰 목록(커서 기반)."""
 type ProductReviewConnection {
+  """리뷰. 요청한 sort 순서로 온다."""
   items: [ProductReview!]!
   """전체 리뷰 수(후기 탭 카운트). 0이면 빈 상태."""
   totalCount: Int!
   """사진 리뷰 수(사진후기 카운트)."""
   photoTotalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
+  """다음 페이지 커서. null이면 마지막 페이지다. 정렬을 바꾸면 기존 커서는 무효다."""
   nextCursor: ID
 }
 
@@ -35,8 +41,11 @@ type ProductReview {
   id: ID!
   """평점(0.0~5.0)."""
   rating: Float!
+  """리뷰 본문. 없으면 null."""
   content: String
+  """첨부 미디어. 없으면 빈 배열."""
   media: [ProductReviewMedia!]!
+  """좋아요 수."""
   likeCount: Int!
   """로그인 사용자의 좋아요 여부(비로그인 시 false)."""
   isLiked: Boolean!
@@ -48,14 +57,19 @@ type ProductReview {
   authorProfileImageUrl: String
   """주문 시 선택 옵션 스냅샷(커스텀 정보: 모양/크기/맛 등)."""
   customOptions: [ReviewCustomOption!]!
+  """작성 시각. 최신순 정렬 기준이다."""
   createdAt: DateTime!
 }
 
 """상품 리뷰 첨부 미디어."""
 type ProductReviewMedia {
+  """미디어 종류."""
   mediaType: ReviewMediaType!
+  """미디어 원본 URL."""
   mediaUrl: String!
+  """동영상 대표 프레임 URL. 이미지면 null일 수 있다."""
   thumbnailUrl: String
+  """노출 순서. 오름차순."""
   sortOrder: Int!
 }
 
@@ -78,36 +92,47 @@ type ReviewDetail {
 """리뷰 상세 상단 판매 케이크 정보."""
 type ReviewDetailProduct {
   productId: ID!
+  """상품명(현재 값). 리뷰 시점 스냅샷이 아니다."""
   name: String!
   """대표 이미지(sort_order 최소). 없으면 null."""
   thumbnailUrl: String
+  """매장명."""
   storeName: String!
   """매장 위치 표기(예: 인천 청라동)."""
   regionLabel: String
+  """정가(원)."""
   regularPrice: Int!
+  """할인가(원). 할인이 없으면 null."""
   salePrice: Int
   """할인율(0~100). salePrice 없으면 0."""
   discountRate: Int!
 }
 
+"""리뷰 댓글 목록 조회 조건."""
 input ReviewCommentsInput {
   reviewId: ID!
   """이전 페이지 마지막 댓글 id(이후부터 조회)."""
   cursor: ID
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
 """리뷰 댓글 목록(등록순, 커서 기반)."""
 type ReviewCommentConnection {
+  """댓글. 등록순으로 온다."""
   items: [ReviewCommentItem!]!
+  """전체 댓글 수."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
+  """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }
 
 """리뷰 댓글."""
 type ReviewCommentItem {
   id: ID!
+  """댓글 본문."""
   content: String!
   """작성자 닉네임(탈퇴 시 null)."""
   authorNickname: String
@@ -115,5 +140,6 @@ type ReviewCommentItem {
   authorProfileImageUrl: String
   """로그인 사용자 본인 댓글 여부(삭제 버튼 노출용, 비로그인 시 false)."""
   isMine: Boolean!
+  """작성 시각. 등록순 정렬 기준이다."""
   createdAt: DateTime!
 }

--- a/src/features/product/product-search.graphql
+++ b/src/features/product/product-search.graphql
@@ -17,6 +17,7 @@ enum ProductSearchSort {
   PRICE_DESC
 }
 
+"""상품 검색 조건. 필터 그룹 간에는 AND, 그룹 안에서는 OR로 결합된다."""
 input SearchProductsInput {
   """검색어(정규화: trim·공백 축약, 빈값/200자 초과 400)."""
   keyword: String!
@@ -30,15 +31,21 @@ input SearchProductsInput {
   maxPrice: Int
   """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
   regionIds: [ID!]
+  """정렬 기준. 기본 인기순."""
   sort: ProductSearchSort = POPULAR
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
   """조회 개수(최대 50)."""
   limit: Int = 20
 }
 
+"""상품 검색 결과 목록."""
 type SearchProductConnection {
+  """상품 카드. 요청한 sort 순서로 온다."""
   items: [SearchProduct!]!
+  """조건에 맞는 전체 상품 수. 탭 카운트에 쓴다."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
 }
 
@@ -47,18 +54,23 @@ type SearchProduct {
   id: ID!
   """소속 매장 ID(상세 URL 구성용: /store/{storeId}/products/{id})."""
   storeId: ID!
+  """상품명."""
   name: String!
   """대표 이미지(sort_order 최소). 없으면 null."""
   thumbnailUrl: String
+  """매장명."""
   storeName: String!
   """매장 위치 표기(예: 인천 청라동)."""
   regionLabel: String
+  """정가(원)."""
   regularPrice: Int!
+  """할인가(원). 할인이 없으면 null이고 regularPrice가 표시가다."""
   salePrice: Int
   """할인율(0~100). salePrice 없으면 0."""
   discountRate: Int!
   """상품 평균 평점(0.0~5.0, 소수 첫째 자리). 리뷰 없으면 0.0."""
   ratingAverage: Float!
+  """리뷰 수."""
   reviewCount: Int!
   """로그인 사용자의 찜 여부(비로그인 시 false)."""
   isWishlisted: Boolean!
@@ -69,6 +81,7 @@ extend type Query {
   searchProductFacets(input: SearchProductFacetsInput!): SearchProductFacets!
 }
 
+"""가격 분포 조회 조건. 가격 필터만 빼고 상품 검색과 같은 조건을 받는다."""
 input SearchProductFacetsInput {
   """검색어(정규화: trim·공백 축약, 빈값/200자 초과 400)."""
   keyword: String!
@@ -82,6 +95,7 @@ input SearchProductFacetsInput {
 
 """가격 분포. 버킷은 5,000원 고정 폭으로 0원부터 70,000원까지, 마지막은 '70,000원 이상'(maxPrice null)."""
 type SearchProductFacets {
+  """가격 버킷. minPrice 오름차순으로 온다."""
   buckets: [SearchPriceBucket!]!
   """조건에 맞는 상품의 최저 표시가. 결과 없으면 null."""
   minPrice: Int
@@ -93,7 +107,10 @@ type SearchProductFacets {
 
 """가격 버킷 [minPrice, maxPrice). maxPrice null = 상한 없음."""
 type SearchPriceBucket {
+  """구간 하한(원, 포함)."""
   minPrice: Int!
+  """구간 상한(원, 미포함). null이면 상한 없는 마지막 구간이다."""
   maxPrice: Int
+  """이 구간에 속한 상품 수."""
   count: Int!
 }

--- a/src/features/product/product-storefront.graphql
+++ b/src/features/product/product-storefront.graphql
@@ -9,8 +9,11 @@ extend type Query {
 """매장 상품 카테고리(사이드바 항목)."""
 type StoreProductCategory {
   id: ID!
+  """카테고리명. 섹션 제목으로 쓴다."""
   name: String!
+  """분류 축."""
   categoryType: CategoryType!
+  """섹션 노출 순서. 오름차순."""
   sortOrder: Int!
   """이 매장의 해당 카테고리 활성 상품 수."""
   productCount: Int!
@@ -26,6 +29,7 @@ enum CategoryType {
   OTHER
 }
 
+"""매장 상품 목록 조회 조건. 필터는 AND로 결합된다."""
 input StoreProductsInput {
   storeId: ID!
   """특정 카테고리 섹션만. 비우면 전체."""
@@ -34,27 +38,36 @@ input StoreProductsInput {
   search: String
   """이전 페이지 마지막 항목 id(이후부터 조회)."""
   cursor: ID
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
 """매장 상품 목록(커서 기반)."""
 type StoreProductConnection {
+  """상품 카드. 등록 최신순으로 온다."""
   items: [StoreProduct!]!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
+  """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }
 
 """매장 상품 카드."""
 type StoreProduct {
   id: ID!
+  """상품명."""
   name: String!
+  """상품 설명. 미등록 시 null."""
   description: String
   """대표 이미지(sort_order 최소). 없으면 null."""
   thumbnailUrl: String
+  """정가(원)."""
   regularPrice: Int!
+  """할인가(원). 할인이 없으면 null이고 regularPrice가 표시가다."""
   salePrice: Int
   """할인율(0~100). salePrice 없으면 0."""
   discountRate: Int!
+  """통화 코드(ISO 4217). 현재는 KRW만 쓴다."""
   currency: String!
   """소속 카테고리 ID(FE 섹션 그룹핑/스크롤 스파이용)."""
   categoryIds: [ID!]!

--- a/src/features/region/region.types.graphql
+++ b/src/features/region/region.types.graphql
@@ -7,15 +7,20 @@ extend type Query {
   searchRegions(input: SearchRegionsInput!): [RegionSearchResult!]!
 }
 
+"""지역 자동검색 입력."""
 input SearchRegionsInput {
+  """검색어. 1·2차 지역명 모두를 대상으로 부분일치 검색한다."""
   keyword: String!
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
 """1차 광역 지역 (예: 서울 북부, 인천)"""
 type RegionGroup {
   id: ID!
+  """화면에 노출되는 1차 지역명."""
   name: String!
+  """URL·쿼리에 쓰는 영문 식별자."""
   slug: String!
   """하위 2차 지역 보유 여부 (전국 등은 false)"""
   hasChildren: Boolean!
@@ -24,16 +29,23 @@ type RegionGroup {
 """2차 시군구 지역 (예: 강남구, 수원시영통구)"""
 type Region {
   id: ID!
+  """상위 1차 지역 ID. 최상위면 null."""
   parentId: ID
+  """화면에 노출되는 2차 지역명."""
   name: String!
+  """URL·쿼리에 쓰는 영문 식별자."""
   slug: String!
+  """지역 계층 깊이. 1=광역, 2=시군구."""
   level: Int!
 }
 
 """지역 검색 결과. 동명 시군구 구분을 위해 상위 지역명을 동반."""
 type RegionSearchResult {
   id: ID!
+  """매칭된 지역명."""
   name: String!
+  """상위 1차 지역명. 동명 시군구를 구분하는 용도이며 1차 지역이면 null."""
   parentName: String
+  """지역 계층 깊이. 1=광역, 2=시군구."""
   level: Int!
 }

--- a/src/features/search/search-entry.graphql
+++ b/src/features/search/search-entry.graphql
@@ -20,6 +20,7 @@ extend type Mutation {
   ): Boolean!
 }
 
+"""인기 검색어 조회 조건."""
 input PopularSearchKeywordsInput {
   """노출 개수(최대 20 — 스냅샷 저장 상한)."""
   limit: Int = 10
@@ -37,21 +38,27 @@ enum SearchKeywordTrend {
   NEW
 }
 
+"""인기 검색어 스냅샷. 정각마다 갱신된다."""
 type PopularSearchKeywordsResult {
+  """순위 오름차순."""
   items: [PopularSearchKeyword!]!
   """스냅샷 기준 시각(정각). 화면의 'YY.MM.DD HH:mm 기준' 표기. 스냅샷이 없으면 null."""
   rankedAt: DateTime
 }
 
+"""인기 검색어 1건."""
 type PopularSearchKeyword {
   """순위(1부터)."""
   rank: Int!
+  """정규화된 검색어."""
   keyword: String!
+  """직전 스냅샷 대비 순위 변동."""
   trend: SearchKeywordTrend!
   """집계 윈도우(직전 24시간) 내 검색 횟수."""
   searchCount: Int!
 }
 
+"""실시간 판매 Best 조회 조건."""
 input RealtimeBestCakesInput {
   """카드 수(최대 20)."""
   limit: Int = 10
@@ -59,6 +66,7 @@ input RealtimeBestCakesInput {
 
 """실시간 판매 Best. 카드는 홈 인기 케이크와 동일 타입(지역·매장명·케이크명·가격·할인율)."""
 type RealtimeBestCakesResult {
+  """판매 Best 카드. 순위 오름차순."""
   items: [PopularCake!]!
   """집계 기준 시각(호출 시점). 화면의 'YY.MM.DD HH:mm 기준' 표기."""
   rankedAt: DateTime!

--- a/src/features/search/search-result.graphql
+++ b/src/features/search/search-result.graphql
@@ -3,6 +3,7 @@ extend type Query {
   searchSummary(input: SearchSummaryInput!): SearchSummary!
 }
 
+"""검색 결과 탭 카운트 조회 조건."""
 input SearchSummaryInput {
   """검색어(정규화: trim·공백 축약, 빈값/200자 초과 400)."""
   keyword: String!
@@ -10,7 +11,10 @@ input SearchSummaryInput {
   regionIds: [ID!]
 }
 
+"""검색 결과 탭 카운트. '전체 N'은 두 값을 FE가 합산한다."""
 type SearchSummary {
+  """조건에 맞는 상품 수."""
   productCount: Int!
+  """조건에 맞는 매장 수."""
   storeCount: Int!
 }

--- a/src/features/store/store-detail.graphql
+++ b/src/features/store/store-detail.graphql
@@ -6,11 +6,13 @@ extend type Query {
 """매장 상세 헤더(구매자용)."""
 type StoreDetail {
   id: ID!
+  """매장명."""
   storeName: String!
   """매장 위치 표기(예: 인천 청라동)."""
   regionLabel: String
   """평균 평점(0.0~5.0, 소수 첫째 자리)."""
   ratingAverage: Float!
+  """리뷰 수."""
   reviewCount: Int!
   """로그인 사용자의 찜 여부(비로그인 시 false)."""
   isWishlisted: Boolean!
@@ -24,6 +26,7 @@ type StoreDetail {
   latitude: Float
   """경도(지도). 미설정 시 null."""
   longitude: Float
+  """지도 진입에 쓸 provider."""
   mapProvider: StoreMapProvider!
   """영업시간 표기 텍스트(예: 10:00AM ~ 19:00PM)."""
   businessHoursText: String
@@ -31,5 +34,6 @@ type StoreDetail {
   regularClosureText: String
   """찾아오는 길 안내."""
   accessGuideText: String
+  """매장 홈페이지·SNS URL. 미등록 시 null."""
   websiteUrl: String
 }

--- a/src/features/store/store-pickup-schedule.graphql
+++ b/src/features/store/store-pickup-schedule.graphql
@@ -15,12 +15,17 @@ extend type Query {
 
 """매장별 월 픽업 달력(상품 상세 픽업 일정 선택용)."""
 type StorePickupCalendar {
+  """요청한 연월. "YYYY-MM"."""
   yearMonth: String!
+  """해당 월의 전 날짜. 선택 불가한 날도 사유와 함께 포함된다."""
   days: [StorePickupDay!]!
 }
 
+"""매장 달력의 하루. 매장 영업요일·특별휴무·일별 생산 수량이 모두 반영된 결과다."""
 type StorePickupDay {
+  """날짜. "YYYY-MM-DD" (KST)."""
   date: String!
+  """픽업 예약 가능 여부."""
   selectable: Boolean!
   """선택 불가 사유. PAST | OUT_OF_RANGE | CLOSED(휴무·영업요일 아님·당일 잔여 슬롯 없음) | CAPACITY_FULL. 선택 가능 시 null."""
   reason: String
@@ -28,12 +33,18 @@ type StorePickupDay {
 
 """매장별 특정 날짜의 픽업 시간 슬롯. 영업하지 않는 날은 빈 배열."""
 type StorePickupTimeSlots {
+  """요청한 날짜. "YYYY-MM-DD" (KST)."""
   date: String!
+  """12:00 이전 슬롯."""
   morning: [StorePickupSlot!]!
+  """12:00 이후 슬롯."""
   afternoon: [StorePickupSlot!]!
 }
 
+"""매장 픽업 시간 슬롯 1칸. 간격은 매장의 pickupSlotIntervalMinutes 정책을 따른다."""
 type StorePickupSlot {
+  """슬롯 시각. "HH:mm" (KST)."""
   time: String!
+  """예약 가능 여부. 매장 리드타임·영업시간·잔여 수량을 반영한 값이다."""
   available: Boolean!
 }

--- a/src/features/store/store-reviews.graphql
+++ b/src/features/store/store-reviews.graphql
@@ -3,24 +3,30 @@ extend type Query {
   storeReviews(input: StoreReviewsInput!): StoreReviewConnection!
 }
 
+"""매장 리뷰 목록 조회 조건."""
 input StoreReviewsInput {
   storeId: ID!
   """true면 사진(미디어) 있는 리뷰만(사진후기 그리드)."""
   photoOnly: Boolean = false
+  """정렬 기준. 기본 최신순. 정렬을 바꾸면 기존 cursor는 무효다."""
   sort: ReviewSort = LATEST
   """이전 페이지의 nextCursor 값(불투명 토큰). 동일 sort에서만 유효."""
   cursor: ID
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
 """매장 리뷰 목록(커서 기반)."""
 type StoreReviewConnection {
+  """리뷰. 요청한 sort 순서로 온다."""
   items: [StoreReview!]!
   """전체 리뷰 수(후기 탭 카운트). 0이면 빈 상태."""
   totalCount: Int!
   """사진 리뷰 수(사진후기 카운트)."""
   photoTotalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
+  """다음 페이지 커서. null이면 마지막 페이지다. 정렬을 바꾸면 기존 커서는 무효다."""
   nextCursor: ID
 }
 
@@ -29,8 +35,11 @@ type StoreReview {
   id: ID!
   """평점(0.0~5.0)."""
   rating: Float!
+  """리뷰 본문. 없으면 null."""
   content: String
+  """첨부 미디어. 없으면 빈 배열."""
   media: [StoreReviewMedia!]!
+  """좋아요 수."""
   likeCount: Int!
   """로그인 사용자의 좋아요 여부(비로그인 시 false)."""
   isLiked: Boolean!
@@ -38,13 +47,18 @@ type StoreReview {
   authorNickname: String
   """연결 상품명(주문 시점 스냅샷)."""
   productName: String!
+  """작성 시각. 최신순 정렬 기준이다."""
   createdAt: DateTime!
 }
 
 """매장 리뷰 첨부 미디어."""
 type StoreReviewMedia {
+  """미디어 종류."""
   mediaType: ReviewMediaType!
+  """미디어 원본 URL."""
   mediaUrl: String!
+  """동영상 대표 프레임 URL. 이미지면 null일 수 있다."""
   thumbnailUrl: String
+  """노출 순서. 오름차순."""
   sortOrder: Int!
 }

--- a/src/features/store/store-search.graphql
+++ b/src/features/store/store-search.graphql
@@ -3,30 +3,38 @@ extend type Query {
   searchStores(input: SearchStoresInput!): SearchStoreConnection!
 }
 
+"""매장 검색 조건. 커서가 아니라 오프셋 방식이다."""
 input SearchStoresInput {
   """검색어(정규화: trim·공백 축약, 빈값/200자 초과 400)."""
   keyword: String!
   """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
   regionIds: [ID!]
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
   """조회 개수(최대 50)."""
   limit: Int = 20
 }
 
+"""매장 검색 결과 목록."""
 type SearchStoreConnection {
+  """매장 카드. 인기순으로 온다 — 찜 수·리뷰 통계·최근 주문 수로 산출하며 검색어 관련도는 반영하지 않는다."""
   items: [SearchStore!]!
+  """조건에 맞는 전체 매장 수. 탭 카운트에 쓴다."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
 }
 
 """검색 결과 매장 카드(로고·평점·지역·대표 케이크 이미지·찜)."""
 type SearchStore {
   id: ID!
+  """매장명."""
   storeName: String!
   """매장 프로필(로고) 이미지. 미등록 시 null."""
   profileImageUrl: String
   """평균 평점(0.0~5.0, 소수 첫째 자리). 리뷰 없으면 0.0."""
   ratingAverage: Float!
+  """리뷰 수."""
   reviewCount: Int!
   """매장 위치 표기(예: 서울 용산구)."""
   regionLabel: String

--- a/src/features/store/store-today-pickup.graphql
+++ b/src/features/store/store-today-pickup.graphql
@@ -3,17 +3,23 @@ extend type Query {
   todayPickupStores(input: TodayPickupStoresInput): TodayPickupStoreConnection!
 }
 
+"""오늘 픽업 가능 매장 조회 조건. 커서가 아니라 오프셋 방식이다."""
 input TodayPickupStoresInput {
   """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
   regionIds: [ID!]
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
+"""오늘 픽업 가능 매장 목록."""
 type TodayPickupStoreConnection {
+  """매장 카드. 오늘 픽업 가능한 매장만 담긴다."""
   items: [TodayPickupStore!]!
   """오늘 픽업 가능한 매장 총수."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
   """슬롯 산출 기준 시각(서버 조회 시점). 화면의 'N시 기준' 표기에 사용."""
   asOf: DateTime!
@@ -22,9 +28,11 @@ type TodayPickupStoreConnection {
 """오늘 픽업 가능 매장 카드 + 슬롯 그리드."""
 type TodayPickupStore {
   id: ID!
+  """매장명."""
   storeName: String!
   """평균 평점(0.0~5.0, 소수 첫째 자리)."""
   ratingAverage: Float!
+  """리뷰 수."""
   reviewCount: Int!
   """매장 위치 표기(예: 인천 청라동)."""
   regionLabel: String
@@ -38,6 +46,8 @@ type TodayPickupStore {
 
 """픽업 슬롯("HH:MM")."""
 type TodayPickupSlot {
+  """슬롯 시각. "HH:MM" (KST)."""
   time: String!
+  """지금 예약 가능한지. 리드타임이 지난 슬롯은 false."""
   available: Boolean!
 }

--- a/src/features/store/store-wishlist.graphql
+++ b/src/features/store/store-wishlist.graphql
@@ -10,25 +10,34 @@ extend type Mutation {
   removeStoreFromWishlist(storeId: ID!): Boolean!
 }
 
+"""찜한 매장 목록 조회 조건. 커서가 아니라 오프셋 방식이다."""
 input MyWishlistedStoresInput {
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
+"""찜한 매장 목록. 최근 찜한 순으로 온다."""
 type MyWishlistedStoresConnection {
+  """찜한 매장 카드. 최근 찜한 순으로 온다."""
   items: [WishlistedStoreSummary!]!
+  """전체 찜 매장 수. offset·limit과 무관하다."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
 }
 
 """찜한 매장 카드"""
 type WishlistedStoreSummary {
   storeId: ID!
+  """매장명."""
   storeName: String!
   """매장 프로필(로고) 이미지. 미등록 시 null."""
   profileImageUrl: String
   """평균 평점(0.0~5.0, 소수 첫째 자리). 리뷰 없으면 0.0."""
   ratingAverage: Float!
+  """리뷰 수."""
   reviewCount: Int!
   """매장 위치 표기(예: 인천 청라동)."""
   regionLabel: String

--- a/src/features/store/store.types.graphql
+++ b/src/features/store/store.types.graphql
@@ -3,16 +3,23 @@ extend type Query {
   popularStores(input: PopularStoresInput): PopularStoreConnection!
 }
 
+"""인기 매장 조회 조건. 커서가 아니라 오프셋 방식이다."""
 input PopularStoresInput {
   """2차 시군구 ID 다중 선택. 비우면 전국 대상."""
   regionIds: [ID!]
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
+"""인기 매장 목록. rank 오름차순이다."""
 type PopularStoreConnection {
+  """인기 매장 카드. rank 오름차순."""
   items: [PopularStore!]!
+  """조건에 맞는 전체 매장 수. offset·limit과 무관하다."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
   """랭킹 산출 기준 시각(서버 조회 시점). 화면의 'N시 기준' 표기에 사용."""
   rankedAt: DateTime!
@@ -21,10 +28,13 @@ type PopularStoreConnection {
 """인기 매장 카드"""
 type PopularStore {
   id: ID!
+  """인기 순위. 1부터 시작하며 rankedAt 시점 기준이다."""
   rank: Int!
+  """매장명."""
   storeName: String!
   """평균 평점(0.0~5.0, 소수 첫째 자리)."""
   ratingAverage: Float!
+  """리뷰 수."""
   reviewCount: Int!
   """매장 위치 표기(예: 서울특별시 역삼동)."""
   regionLabel: String

--- a/src/features/user/user-engagement.graphql
+++ b/src/features/user/user-engagement.graphql
@@ -9,6 +9,7 @@ extend type Mutation {
   deleteMyReviewComment(commentId: ID!): Boolean!
 }
 
+"""리뷰 댓글 작성 입력."""
 input WriteReviewCommentInput {
   reviewId: ID!
   """1~500자"""
@@ -19,6 +20,8 @@ input WriteReviewCommentInput {
 type MyReviewComment {
   id: ID!
   reviewId: ID!
+  """댓글 본문."""
   content: String!
+  """작성 시각."""
   createdAt: DateTime!
 }

--- a/src/features/user/user-mypage.graphql
+++ b/src/features/user/user-mypage.graphql
@@ -13,6 +13,7 @@ type MyPageOverview {
   recentViewedProducts: [RecentViewedProductSummary!]!
 }
 
+"""마이페이지 상단 카운트 카드."""
 type MyPageCounts {
   """진행중 + 저장된 커스텀 드래프트 수"""
   customDraftCount: Int!
@@ -24,11 +25,16 @@ type MyPageCounts {
   myReviewCount: Int!
 }
 
+"""진행중 주문 요약 카드. 픽업 완료·취소는 제외된다."""
 type OngoingOrderSummary {
   orderId: ID!
+  """주문번호."""
   orderNumber: String!
+  """현재 주문 상태."""
   status: OrderStatusType!
+  """주문 생성 시각."""
   createdAt: DateTime!
+  """픽업 예정 일시."""
   pickupAt: DateTime!
   """첫 번째 OrderItem 기준 대표 상품명"""
   representativeProductName: String!
@@ -38,13 +44,20 @@ type OngoingOrderSummary {
   totalPrice: Int!
 }
 
+"""최근 본 상품 카드."""
 type RecentViewedProductSummary {
   productId: ID!
+  """상품명."""
   productName: String!
+  """대표 상품 이미지. 없으면 null."""
   representativeImageUrl: String
+  """할인가(원). 할인이 없으면 null."""
   salePrice: Int
+  """정가(원)."""
   regularPrice: Int!
+  """매장명."""
   storeName: String!
+  """마지막으로 본 시각. 목록 정렬 기준이다."""
   viewedAt: DateTime!
   """현재 사용자의 찜 여부"""
   isWishlisted: Boolean!

--- a/src/features/user/user-order.graphql
+++ b/src/features/user/user-order.graphql
@@ -9,23 +9,32 @@ extend type Query {
 input MyOrdersInput {
   """상태 필터 (복수 선택 가능). 미지정 시 전체"""
   statuses: [OrderStatusType!]
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
 """주문 목록 응답"""
 type MyOrderConnection {
+  """주문 카드. 최신 주문이 먼저 온다."""
   items: [MyOrderSummary!]!
+  """전체 주문 수. 상태 필터를 적용한 뒤의 총계이며 offset·limit과 무관하다."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
 }
 
 """유저 주문 목록 카드"""
 type MyOrderSummary {
   orderId: ID!
+  """주문번호. 화면·문의에 쓰는 식별자."""
   orderNumber: String!
+  """현재 주문 상태."""
   status: OrderStatusType!
+  """주문 생성 시각."""
   createdAt: DateTime!
+  """픽업 예정 일시."""
   pickupAt: DateTime!
   """대표 상품명 (첫 OrderItem 기준)"""
   representativeProductName: String!
@@ -44,23 +53,36 @@ type MyOrderSummary {
 """주문 상세"""
 type MyOrderDetail {
   orderId: ID!
+  """주문번호."""
   orderNumber: String!
+  """현재 주문 상태."""
   status: OrderStatusType!
+  """주문 생성 시각."""
   createdAt: DateTime!
+  """픽업 예정 일시."""
   pickupAt: DateTime!
 
+  """주문자 이름."""
   buyerName: String!
+  """주문자 연락처."""
   buyerPhone: String!
 
+  """할인 전 품목 합계(원)."""
   subtotalPrice: Int!
+  """할인 금액(원). 할인이 없으면 0."""
   discountPrice: Int!
+  """최종 결제 금액(원) = subtotalPrice - discountPrice."""
   totalPrice: Int!
 
-  """상태 스테퍼용 타임스탬프"""
+  """상태 스테퍼용 타임스탬프. 아직 그 상태를 거치지 않았으면 null이다."""
   submittedAt: DateTime
+  """CONFIRMED 도달 시각. 미도달 시 null."""
   confirmedAt: DateTime
+  """MADE(제작 완료) 도달 시각. 미도달 시 null."""
   madeAt: DateTime
+  """PICKED_UP 도달 시각. 미도달 시 null."""
   pickedUpAt: DateTime
+  """CANCELED 도달 시각. 취소되지 않았으면 null."""
   canceledAt: DateTime
 
   """상태 변경 히스토리"""
@@ -71,21 +93,33 @@ type MyOrderDetail {
   store: MyOrderStoreInfo!
 }
 
+"""주문 상태 변경 이력 1건."""
 type MyOrderStatusHistory {
+  """변경 전 상태. 최초 생성 이력이면 null."""
   fromStatus: OrderStatusType
+  """변경 후 상태."""
   toStatus: OrderStatusType!
+  """변경 시각."""
   changedAt: DateTime!
+  """변경 사유 메모. 취소 전이에는 판매자가 필수로 남긴다."""
   note: String
 }
 
+"""주문 품목 1건. 가격·옵션·커스텀은 전부 주문 당시 스냅샷이라 이후 상품이 바뀌어도 변하지 않는다."""
 type MyOrderItemDetail {
   orderItemId: ID!
   productId: ID!
+  """상품명(주문 당시)."""
   productName: String!
+  """대표 이미지 URL(주문 당시). 이미지가 없으면 null."""
   representativeImageUrl: String
+  """주문 수량."""
   quantity: Int!
+  """정가(원, 주문 당시)."""
   regularPrice: Int!
+  """할인가(원, 주문 당시). 할인이 없었으면 null."""
   salePrice: Int
+  """이 품목의 합계 금액(원). 옵션 추가금과 수량이 반영된 값이다."""
   itemSubtotalPrice: Int!
   """선택한 옵션 목록"""
   selectedOptions: [MyOrderItemSelectedOption!]!
@@ -93,43 +127,67 @@ type MyOrderItemDetail {
   customTexts: [MyOrderItemCustomText!]!
   """자유 커스텀(스냅샷)"""
   customFreeEdits: [MyOrderItemCustomFreeEdit!]!
-  """내 리뷰 작성 여부"""
+  """이 품목에 내가 남긴 활성 리뷰가 있는지."""
   hasMyReview: Boolean!
-  """리뷰 작성 가능 여부"""
+  """리뷰 작성 가능 여부. 주문이 PICKED_UP이고 활성 리뷰가 없을 때 true."""
   canWriteReview: Boolean!
 }
 
+"""선택한 옵션(주문 당시 스냅샷)."""
 type MyOrderItemSelectedOption {
+  """옵션 그룹명."""
   groupName: String!
+  """선택한 옵션명."""
   optionTitle: String!
+  """옵션 추가금(원). 음수면 할인으로 동작했다."""
   priceDelta: Int!
 }
 
+"""입력한 커스텀 문구(주문 당시 스냅샷)."""
 type MyOrderItemCustomText {
+  """문구 슬롯 식별 키."""
   tokenKey: String!
+  """슬롯의 기본 문구."""
   defaultText: String!
+  """실제로 입력한 문구."""
   valueText: String!
+  """입력 화면 노출 순서. 오름차순."""
   sortOrder: Int!
 }
 
+"""자유 편집 요청(주문 당시 스냅샷). 이미지 위 영역을 지정해 남긴 요청이다."""
 type MyOrderItemCustomFreeEdit {
+  """지정한 편집 영역을 잘라낸 이미지 URL."""
   cropImageUrl: String!
+  """해당 영역에 대한 요청 문구."""
   descriptionText: String!
+  """요청 순서. 오름차순."""
   sortOrder: Int!
+  """참고로 첨부한 이미지 URL 목록. 첨부가 없으면 빈 배열."""
   attachmentImageUrls: [String!]!
 }
 
+"""픽업할 매장 정보. 주문은 단일 매장 전제라 1건이다."""
 type MyOrderStoreInfo {
   storeId: ID!
+  """매장명."""
   storeName: String!
+  """매장 대표 연락처."""
   storePhone: String!
+  """전체 주소 문자열."""
   addressFull: String!
+  """시·도 단위. 매핑되지 않았으면 null."""
   addressCity: String
+  """시·군·구 단위. 매핑되지 않았으면 null."""
   addressDistrict: String
+  """읍·면·동 단위. 매핑되지 않았으면 null."""
   addressNeighborhood: String
+  """위도. 좌표 미등록 시 null."""
   latitude: Float
+  """경도. 좌표 미등록 시 null."""
   longitude: Float
   """영업시간 평문"""
   businessHoursText: String
+  """매장 홈페이지·SNS URL. 미등록 시 null."""
   websiteUrl: String
 }

--- a/src/features/user/user-profile.graphql
+++ b/src/features/user/user-profile.graphql
@@ -102,6 +102,7 @@ input UpdateMyProfileImageInput {
 
 """닉네임 사용 가능 여부"""
 type NicknameAvailability {
+  """사용 가능 여부. false면 reason에 사유가 담긴다."""
   available: Boolean!
   """미통과 시 이유"""
   reason: String
@@ -109,14 +110,20 @@ type NicknameAvailability {
 
 """프로필 이미지 업로드 URL 발급 입력"""
 input CreateProfileImageUploadUrlInput {
+  """업로드할 파일의 MIME 타입(예: image/jpeg)."""
   contentType: String!
+  """업로드할 파일 크기(바이트)."""
   contentLength: Int!
 }
 
 """프로필 이미지 업로드 URL 결과"""
 type ProfileImageUploadUrl {
+  """파일을 PUT할 Presigned URL. 만료 전에 써야 한다."""
   uploadUrl: String!
+  """업로드 완료 후 접근 가능한 URL. updateMyProfileImage에 그대로 넘긴다."""
   publicUrl: String!
+  """스토리지 객체 키."""
   key: String!
+  """uploadUrl 만료까지 남은 시간(초)."""
   expiresInSeconds: Int!
 }

--- a/src/features/user/user-recent-view.graphql
+++ b/src/features/user/user-recent-view.graphql
@@ -12,13 +12,20 @@ extend type Mutation {
   clearRecentViewedProducts: Boolean!
 }
 
+"""최근 본 상품 목록 조회 조건. 커서가 아니라 오프셋 방식이다."""
 input MyRecentViewedProductsInput {
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
+"""최근 본 상품 목록. 최근에 본 상품이 먼저 온다."""
 type RecentViewedProductConnection {
+  """최근 본 상품 카드. 최근에 본 순으로 온다."""
   items: [RecentViewedProductSummary!]!
+  """전체 기록 수. offset·limit과 무관한 총계다."""
   totalCount: Int!
+  """다음 페이지 존재 여부. offset+limit이 totalCount에 못 미치면 true."""
   hasMore: Boolean!
 }

--- a/src/features/user/user-review.graphql
+++ b/src/features/user/user-review.graphql
@@ -7,15 +7,21 @@ extend type Query {
   myReviewForOrderItem(orderItemId: ID!): MyReviewOrNull!
 }
 
+"""리뷰 작성 가능 목록 조회 조건. 커서가 아니라 오프셋 방식이다."""
 input MyReviewableOrderItemsInput {
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
+"""리뷰 작성 가능한 주문 품목 목록. 픽업 완료가 최근인 순으로 온다."""
 type MyReviewableOrderItemConnection {
+  """리뷰 작성 가능한 주문 품목. 픽업 완료가 최근인 순으로 온다."""
   items: [MyReviewableOrderItem!]!
   """'리뷰 남기기 N' 탭 카운트"""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
 }
 
@@ -27,6 +33,7 @@ type MyReviewableOrderItem {
   productName: String!
   """대표 상품 이미지. 없으면 null."""
   productImageUrl: String
+  """매장명."""
   storeName: String!
   """매장 위치 표기(예: 인천 청라동). 없으면 null."""
   regionLabel: String
@@ -43,40 +50,65 @@ extend type Mutation {
   deleteMyReview(reviewId: ID!): Boolean!
 }
 
+"""내 리뷰 목록 조회 조건. 커서가 아니라 오프셋 방식이다."""
 input MyReviewsInput {
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
+"""내가 쓴 리뷰 목록. 최신순."""
 type MyReviewConnection {
+  """내가 쓴 리뷰. 최신순으로 온다."""
   items: [MyReview!]!
+  """전체 리뷰 수. offset·limit과 무관한 총계다."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
 }
 
+"""내가 쓴 리뷰 1건."""
 type MyReview {
   reviewId: ID!
+  """이 리뷰가 달린 주문 품목 ID."""
   orderItemId: ID!
   productId: ID!
+  """상품명(주문 시점 스냅샷)."""
   productName: String!
+  """대표 상품 이미지. 없으면 null."""
   productImageUrl: String
+  """매장명."""
   storeName: String!
+  """별점. 1.0~5.0, 0.5 단위."""
   rating: Float!
+  """리뷰 본문. 삭제된 리뷰 등으로 본문이 없으면 null."""
   content: String
+  """첨부 미디어. 없으면 빈 배열."""
   media: [MyReviewMedia!]!
+  """작성 시각."""
   createdAt: DateTime!
 }
 
+"""특정 주문 품목에 대한 내 리뷰 조회 결과. 아직 안 썼으면 review가 null이다."""
 type MyReviewOrNull {
+  """작성한 리뷰. 없으면 null."""
   review: MyReview
+  """지금 리뷰를 쓸 수 있는지."""
   canWrite: Boolean!
+  """쓸 수 없는 사유 문구. canWrite가 true면 null이다(예: 이미 작성함, 픽업 미완료)."""
   reasonIfCannotWrite: String
 }
 
+"""리뷰에 첨부된 미디어 1건."""
 type MyReviewMedia {
+  """미디어 종류."""
   mediaType: ReviewMediaType!
+  """미디어 원본 URL."""
   mediaUrl: String!
+  """동영상 대표 프레임 URL. 이미지면 null일 수 있다."""
   thumbnailUrl: String
+  """노출 순서. 오름차순."""
   sortOrder: Int!
 }
 
@@ -88,32 +120,51 @@ enum ReviewMediaType {
   VIDEO
 }
 
+"""리뷰 미디어 업로드용 Presigned URL 발급 입력."""
 input CreateReviewMediaUploadUrlInput {
+  """업로드할 미디어 종류."""
   mediaType: ReviewMediaType!
+  """업로드할 파일의 MIME 타입(예: image/jpeg)."""
   contentType: String!
+  """업로드할 파일 크기(바이트)."""
   contentLength: Int!
 }
 
+"""발급된 업로드 URL. uploadUrl로 직접 PUT한 뒤 publicUrl을 writeReview에 넘긴다."""
 type ReviewMediaUploadUrl {
+  """파일을 PUT할 Presigned URL. 만료 전에 써야 한다."""
   uploadUrl: String!
+  """업로드 완료 후 접근 가능한 URL. writeReview의 mediaUrl로 그대로 넘긴다."""
   publicUrl: String!
+  """스토리지 객체 키."""
   key: String!
+  """uploadUrl 만료까지 남은 시간(초)."""
   expiresInSeconds: Int!
 }
 
+"""
+리뷰 작성 입력. 픽업 완료(PICKED_UP)된 주문 품목에만 쓸 수 있고, 품목당 1건이다.
+미디어는 이미지 최대 10장 또는 영상 1개까지 허용된다.
+"""
 input WriteReviewInput {
+  """리뷰 대상 주문 품목 ID. myReviewableOrderItems가 준 값을 그대로 쓴다."""
   orderItemId: ID!
   """별점 1.0 ~ 5.0 (0.5 단위)"""
   rating: Float!
   """최소 20자, 최대 1000자"""
   content: String!
+  """첨부 미디어. 생략하면 텍스트만 등록된다."""
   media: [WriteReviewMediaInput!]
 }
 
+"""리뷰 첨부 미디어 입력. createReviewMediaUploadUrl로 먼저 업로드한 뒤 그 결과를 넘긴다."""
 input WriteReviewMediaInput {
+  """미디어 종류."""
   mediaType: ReviewMediaType!
   """업로드 완료 후의 publicUrl"""
   mediaUrl: String!
+  """동영상 대표 프레임 URL."""
   thumbnailUrl: String
+  """노출 순서. 오름차순."""
   sortOrder: Int!
 }

--- a/src/features/user/user-wishlist.graphql
+++ b/src/features/user/user-wishlist.graphql
@@ -12,52 +12,75 @@ extend type Mutation {
   removeFromWishlist(productId: ID!): Boolean!
 }
 
+"""찜한 상품 목록 조회 조건. 커서가 아니라 오프셋 방식이다."""
 input MyWishlistInput {
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
   """특정 매장의 찜 상품만 조회(매장별 보기 → 매장 선택 화면)."""
   storeId: ID
 }
 
+"""찜한 상품 목록. 최근 찜한 순으로 온다."""
 type MyWishlistConnection {
+  """찜한 상품 카드. 최근 찜한 순으로 온다."""
   items: [WishlistItemSummary!]!
+  """전체 찜 상품 수(storeId 필터 적용 후). offset·limit과 무관하다."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
 }
 
+"""찜한 상품 카드."""
 type WishlistItemSummary {
   productId: ID!
   """소속 매장 ID(상세 이동용)."""
   storeId: ID!
+  """상품명."""
   productName: String!
+  """대표 상품 이미지. 없으면 null."""
   representativeImageUrl: String
+  """할인가(원). 할인이 없으면 null이고 regularPrice가 표시가다."""
   salePrice: Int
+  """정가(원)."""
   regularPrice: Int!
   """할인율(0~100). salePrice 없으면 0."""
   discountRate: Int!
+  """매장명."""
   storeName: String!
   """매장 위치 표기(예: 서울 대치동)."""
   regionLabel: String
   """상품 평균 평점(0.0~5.0, 소수 첫째 자리). 리뷰 없으면 0.0."""
   ratingAverage: Float!
+  """리뷰 수."""
   reviewCount: Int!
+  """찜한 시각. 목록 정렬 기준이다."""
   addedAt: DateTime!
 }
 
+"""매장별 보기 목록 조회 조건."""
 input MyWishlistStoreGroupsInput {
+  """건너뛸 개수. 기본 0."""
   offset: Int = 0
+  """한 번에 가져올 개수. 기본 20."""
   limit: Int = 20
 }
 
+"""매장별 보기 목록."""
 type MyWishlistStoreGroupsConnection {
+  """매장별 보기 행. 찜한 상품 수 내림차순이고, 같으면 최근에 찜한 매장이 먼저 온다."""
   items: [WishlistStoreGroup!]!
+  """찜 상품을 가진 매장 수."""
   totalCount: Int!
+  """다음 페이지 존재 여부."""
   hasMore: Boolean!
 }
 
 """매장별 보기 행(매장 + 찜 상품 수)"""
 type WishlistStoreGroup {
   storeId: ID!
+  """매장명."""
   storeName: String!
   """매장 프로필(로고) 이미지. 미등록 시 null."""
   profileImageUrl: String


### PR DESCRIPTION
seller 외 도메인의 남은 설명을 채워 **전 카테고리 커버리지를 100%로** 올린다. 이 작업(#281~#285)의 마지막 PR이다.

## 커버리지 — 8개 항목 전부 100%

| 요소 | 작업 전 | 최종 |
| --- | --- | --- |
| Query/Mutation 필드 | 130/130 | 130/130 |
| 필드 인자(비 input) | **0/6** | 6/6 |
| input 타입 선언 | 13/72 | 72/72 |
| input 필드 | 49/227 | 227/227 |
| 출력 type 선언 | 67/134 | 134/134 |
| 출력 type 필드 | 185/603 | 603/603 |
| enum 선언 | 12/23 | 17/17 |
| enum 값 | 10/81 | 61/61 |

*(분모는 자명한 필드 `id`·`createdAt`·`*Id`를 제외한 수치다. enum 총수가 준 것은 중복 6쌍을 통합했기 때문.)*

## 주요 보강

- `user-order`(74) · `user-review`(49) · `product-reviews`(50) · `product-search`(35) 등
- `region`·`pickup`·`store-pickup-schedule` — 커버리지 10% 미만이던 공용 타입
- **커서·페이지네이션 필드 전건.** `nextCursor`가 불투명 토큰이고 정렬을 바꾸면 무효라는 규약이 CLAUDE.md에만 있고 SDL에는 한 번도 없었다
- Connection의 `items`에는 "무엇이 담기는가"를 되풀이하는 대신 **정렬 기준**을 적었다(예: "최근 찜한 순으로 온다") — 프론트가 실제로 모르는 정보가 그쪽이다

## 기준선 100% 상향의 부수 효과

`docs:check` 기준선을 달성치인 100%로 올린다. 미기재 건수 기준선이 0이 되면서, PR #281 리뷰에서 *"기존 미기재를 채우면서 새 미기재를 추가하면 건수·비율 모두 통과한다"* 고 지적받아 유예했던 우회 경로가 **함께 닫힌다.** 이제 설명 없는 요소를 하나라도 추가하면 그 자리에서 실패한다.

검증: `root.graphql`에 설명 없는 타입 1개를 넣으면 `출력 type 선언: 미기재 1건 > 기준선 0건`으로 걸리는 것을 확인했다.

## 정렬 단정 전수 검증

`items` 계열에 적은 정렬 기준 13건을 repository `orderBy`와 대조했다. 찜 매장·찜 상품 `created_at desc`, 내 리뷰·주문 `created_at desc`, 최근 본 상품 `viewed_at desc`, 구매자 대화 `last_message_at desc`, 리뷰 작성 가능 `picked_up_at desc`, 매장 상품 `id desc`, 찜 매장 그룹 `count desc`.

이 과정에서 **매장 검색이 인기순만 쓰고 검색어 관련도를 반영하지 않는다**는 걸 확인해 설명을 고쳤다(`scoreAndSortByPopularity` — 찜 수·리뷰 통계·최근 주문 수). "관련도·인기 기준"이라 적었던 건 추론이었다.

## 검증

전체 225 suites / 1,869건 통과. `tsc`·`dto:check`·`arch:check`·`docs:check`·`test:scripts`(42건) 통과.
