### PR TITLE
refactor(seller): Connection 형태를 구매자 API와 정합화 (hasMore·totalCount)

### DIFF
--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -35,6 +35,13 @@ export class ConversationRepository {
     });
   }
 
+  /** 판매자 대화방 전체 수(커서 무관). 목록 where와 커서 조건만 다르다. */
+  async countConversationsByStore(storeId: bigint): Promise<number> {
+    return this.prisma.storeConversation.count({
+      where: { store_id: storeId },
+    });
+  }
+
   async findConversationByIdAndStore(args: {
     conversationId: bigint;
     storeId: bigint;
@@ -59,6 +66,13 @@ export class ConversationRepository {
       },
       orderBy: { id: 'desc' },
       take: args.limit + 1,
+    });
+  }
+
+  /** 대화방 메시지 전체 수(커서 무관). */
+  async countConversationMessages(conversationId: bigint): Promise<number> {
+    return this.prisma.storeConversationMessage.count({
+      where: { conversation_id: conversationId },
     });
   }
 

--- a/src/features/order/repositories/order.repository.ts
+++ b/src/features/order/repositories/order.repository.ts
@@ -559,6 +559,67 @@ export class OrderRepository {
     });
   }
 
+  /** 매장 주문 목록의 필터 조건. 목록과 카운트가 같은 조건을 보도록 한 곳에서 만든다(커서 제외). */
+  private storeOrderScopeWhere(args: {
+    storeId: bigint;
+    status?: OrderStatus;
+    fromCreatedAt?: Date;
+    toCreatedAt?: Date;
+    fromPickupAt?: Date;
+    toPickupAt?: Date;
+    search?: string;
+  }): Prisma.OrderWhereInput {
+    return {
+      ...(args.status ? { status: args.status } : {}),
+      ...(args.fromCreatedAt || args.toCreatedAt
+        ? {
+            created_at: {
+              ...(args.fromCreatedAt ? { gte: args.fromCreatedAt } : {}),
+              ...(args.toCreatedAt ? { lte: args.toCreatedAt } : {}),
+            },
+          }
+        : {}),
+      ...(args.fromPickupAt || args.toPickupAt
+        ? {
+            pickup_at: {
+              ...(args.fromPickupAt ? { gte: args.fromPickupAt } : {}),
+              ...(args.toPickupAt ? { lte: args.toPickupAt } : {}),
+            },
+          }
+        : {}),
+      ...(args.search
+        ? {
+            OR: [
+              { order_number: { contains: args.search } },
+              { buyer_name: { contains: args.search } },
+              { buyer_phone: { contains: args.search } },
+            ],
+          }
+        : {}),
+      items: {
+        some: {
+          store_id: args.storeId,
+          ...activeWhere,
+        },
+      },
+    };
+  }
+
+  /** 매장 주문 전체 건수(커서 무관). */
+  async countOrdersByStore(args: {
+    storeId: bigint;
+    status?: OrderStatus;
+    fromCreatedAt?: Date;
+    toCreatedAt?: Date;
+    fromPickupAt?: Date;
+    toPickupAt?: Date;
+    search?: string;
+  }): Promise<number> {
+    return this.prisma.order.count({
+      where: this.storeOrderScopeWhere(args),
+    });
+  }
+
   async listOrdersByStore(args: {
     storeId: bigint;
     limit: number;
@@ -573,38 +634,7 @@ export class OrderRepository {
     return this.prisma.order.findMany({
       where: {
         ...(args.cursor ? { id: { lt: args.cursor } } : {}),
-        ...(args.status ? { status: args.status } : {}),
-        ...(args.fromCreatedAt || args.toCreatedAt
-          ? {
-              created_at: {
-                ...(args.fromCreatedAt ? { gte: args.fromCreatedAt } : {}),
-                ...(args.toCreatedAt ? { lte: args.toCreatedAt } : {}),
-              },
-            }
-          : {}),
-        ...(args.fromPickupAt || args.toPickupAt
-          ? {
-              pickup_at: {
-                ...(args.fromPickupAt ? { gte: args.fromPickupAt } : {}),
-                ...(args.toPickupAt ? { lte: args.toPickupAt } : {}),
-              },
-            }
-          : {}),
-        ...(args.search
-          ? {
-              OR: [
-                { order_number: { contains: args.search } },
-                { buyer_name: { contains: args.search } },
-                { buyer_phone: { contains: args.search } },
-              ],
-            }
-          : {}),
-        items: {
-          some: {
-            store_id: args.storeId,
-            ...activeWhere,
-          },
-        },
+        ...this.storeOrderScopeWhere(args),
       },
       orderBy: { id: 'desc' },
       take: args.limit + 1,

--- a/src/features/product/repositories/product.repository.ts
+++ b/src/features/product/repositories/product.repository.ts
@@ -118,6 +118,61 @@ export interface ProductDetailRow {
 @Injectable()
 export class ProductRepository {
   constructor(private readonly prisma: PrismaService) {}
+  /** 상품 목록의 필터 조건. 목록과 카운트가 같은 조건을 보도록 한 곳에서 만든다(커서 제외). */
+  private storeProductScopeWhere(args: {
+    storeId: bigint;
+    isActive?: boolean;
+    categoryId?: bigint;
+    search?: string;
+  }): Prisma.ProductWhereInput {
+    return {
+      store_id: args.storeId,
+      ...(args.isActive !== undefined ? { is_active: args.isActive } : {}),
+      ...(args.categoryId
+        ? {
+            // include의 링크·대상 가드와 동일 — 삭제된 연결이 필터에 걸리지 않게 한다
+            product_categories: {
+              some: {
+                category_id: args.categoryId,
+                ...activeWhere,
+                category: activeWhere,
+              },
+            },
+          }
+        : {}),
+      ...(args.search
+        ? {
+            OR: [
+              { name: { contains: args.search } },
+              {
+                product_tags: {
+                  some: {
+                    ...activeWhere,
+                    tag: {
+                      name: { contains: args.search },
+                      ...activeWhere,
+                    },
+                  },
+                },
+              },
+            ],
+          }
+        : {}),
+    };
+  }
+
+  /** 상품 전체 건수(커서 무관). */
+  async countProductsByStore(args: {
+    storeId: bigint;
+    isActive?: boolean;
+    categoryId?: bigint;
+    search?: string;
+  }): Promise<number> {
+    return this.prisma.product.count({
+      where: this.storeProductScopeWhere(args),
+    });
+  }
+
   async listProductsByStore(args: {
     storeId: bigint;
     limit: number;
@@ -128,39 +183,8 @@ export class ProductRepository {
   }) {
     return this.prisma.product.findMany({
       where: {
-        store_id: args.storeId,
         ...(args.cursor ? { id: { lt: args.cursor } } : {}),
-        ...(args.isActive !== undefined ? { is_active: args.isActive } : {}),
-        ...(args.categoryId
-          ? {
-              // include의 링크·대상 가드와 동일 — 삭제된 연결이 필터에 걸리지 않게 한다
-              product_categories: {
-                some: {
-                  category_id: args.categoryId,
-                  ...activeWhere,
-                  category: activeWhere,
-                },
-              },
-            }
-          : {}),
-        ...(args.search
-          ? {
-              OR: [
-                { name: { contains: args.search } },
-                {
-                  product_tags: {
-                    some: {
-                      ...activeWhere,
-                      tag: {
-                        name: { contains: args.search },
-                        ...activeWhere,
-                      },
-                    },
-                  },
-                },
-              ],
-            }
-          : {}),
+        ...this.storeProductScopeWhere(args),
       },
       // soft-delete extension은 root만 patch하므로 nested relation에 가드를 명시한다
       include: {

--- a/src/features/seller/repositories/seller.repository.ts
+++ b/src/features/seller/repositories/seller.repository.ts
@@ -146,6 +146,13 @@ export class SellerRepository {
     });
   }
 
+  /** 특별휴무 전체 건수(커서 무관). */
+  async countStoreSpecialClosures(storeId: bigint): Promise<number> {
+    return this.prisma.storeSpecialClosure.count({
+      where: { store_id: storeId },
+    });
+  }
+
   async updateStoreDailyCapacity(
     capacityId: bigint,
     data: { capacityDate: Date; capacity: number },
@@ -199,6 +206,36 @@ export class SellerRepository {
     });
   }
 
+  /** 일별 생산 수량의 날짜 범위 조건. 목록과 카운트가 공유한다. */
+  private dailyCapacityScopeWhere(args: {
+    storeId: bigint;
+    fromDate?: Date;
+    toDate?: Date;
+  }): Prisma.StoreDailyCapacityWhereInput {
+    return {
+      store_id: args.storeId,
+      ...(args.fromDate || args.toDate
+        ? {
+            capacity_date: {
+              ...(args.fromDate ? { gte: args.fromDate } : {}),
+              ...(args.toDate ? { lte: args.toDate } : {}),
+            },
+          }
+        : {}),
+    };
+  }
+
+  /** 일별 생산 수량 전체 건수(커서 무관). */
+  async countStoreDailyCapacities(args: {
+    storeId: bigint;
+    fromDate?: Date;
+    toDate?: Date;
+  }): Promise<number> {
+    return this.prisma.storeDailyCapacity.count({
+      where: this.dailyCapacityScopeWhere(args),
+    });
+  }
+
   async listStoreDailyCapacities(args: {
     storeId: bigint;
     limit: number;
@@ -208,16 +245,8 @@ export class SellerRepository {
   }) {
     return this.prisma.storeDailyCapacity.findMany({
       where: {
-        store_id: args.storeId,
         ...(args.cursor ? { id: { lt: args.cursor } } : {}),
-        ...(args.fromDate || args.toDate
-          ? {
-              capacity_date: {
-                ...(args.fromDate ? { gte: args.fromDate } : {}),
-                ...(args.toDate ? { lte: args.toDate } : {}),
-              },
-            }
-          : {}),
+        ...this.dailyCapacityScopeWhere(args),
       },
       orderBy: { id: 'desc' },
       take: args.limit + 1,
@@ -279,6 +308,13 @@ export class SellerRepository {
     });
   }
 
+  /** 목록과 카운트가 같은 조건을 보도록 where를 한 곳에서 만든다(커서는 페이지 조건이라 제외). */
+  private bannerScopeWhere(storeId: bigint): Prisma.BannerWhereInput {
+    return {
+      OR: [{ link_store_id: storeId }, { link_product: { store_id: storeId } }],
+    };
+  }
+
   async listBannersByStore(args: {
     storeId: bigint;
     limit: number;
@@ -287,20 +323,16 @@ export class SellerRepository {
     return this.prisma.banner.findMany({
       where: {
         ...(args.cursor ? { id: { lt: args.cursor } } : {}),
-        OR: [
-          {
-            link_store_id: args.storeId,
-          },
-          {
-            link_product: {
-              store_id: args.storeId,
-            },
-          },
-        ],
+        ...this.bannerScopeWhere(args.storeId),
       },
       orderBy: [{ id: 'desc' }],
       take: args.limit + 1,
     });
+  }
+
+  /** 배너 전체 건수(커서 무관). */
+  async countBannersByStore(storeId: bigint): Promise<number> {
+    return this.prisma.banner.count({ where: this.bannerScopeWhere(storeId) });
   }
 
   async findBannerByIdForStore(args: { bannerId: bigint; storeId: bigint }) {
@@ -417,23 +449,31 @@ export function normalizeCursorInput(input?: {
   };
 }
 
+/**
+ * limit+1개를 조회한 결과에서 페이지와 다음 커서를 뽑는다.
+ *
+ * hasMore는 추가 쿼리 없이 나온다 — limit보다 많이 왔으면 다음 페이지가 있다는 뜻이다.
+ */
 export function nextCursorOf<T extends { id: bigint }>(
   rows: T[],
   limit: number,
 ): {
   items: T[];
   nextCursor: string | null;
+  hasMore: boolean;
 } {
   if (rows.length <= limit) {
     return {
       items: rows,
       nextCursor: null,
+      hasMore: false,
     };
   }
 
   const sliced = rows.slice(0, limit);
   return {
     items: sliced,
+    hasMore: true,
     nextCursor: sliced[sliced.length - 1]?.id.toString() ?? null,
   };
 }

--- a/src/features/seller/seller-content.graphql
+++ b/src/features/seller/seller-content.graphql
@@ -126,6 +126,10 @@ type SellerBanner {
 type SellerBannerConnection {
   """배너. 최신 등록이 먼저 온다."""
   items: [SellerBanner!]!
+  """조건에 맞는 전체 건수(현재 페이지와 무관). 커서 필터는 제외하고 센다."""
+  totalCount: Int!
+  """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
+  hasMore: Boolean!
   """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }
@@ -245,9 +249,13 @@ type SellerAuditLog {
 type SellerAuditLogConnection {
   """감사 로그. 최신 기록이 먼저 온다."""
   items: [SellerAuditLog!]!
+  """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
+  hasMore: Boolean!
   """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }
+
+# totalCount는 두지 않는다 — 감사 로그는 누적형이라 매 조회 COUNT가 부담이다.
 
 """감사 로그 조회 조건."""
 input SellerAuditLogListInput {

--- a/src/features/seller/seller-conversation.graphql
+++ b/src/features/seller/seller-conversation.graphql
@@ -27,6 +27,10 @@ type SellerConversation {
 type SellerConversationConnection {
   """대화방. 최근에 갱신된 순으로 온다."""
   items: [SellerConversation!]!
+  """조건에 맞는 전체 건수(현재 페이지와 무관). 커서 필터는 제외하고 센다."""
+  totalCount: Int!
+  """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
+  hasMore: Boolean!
   """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }
@@ -53,6 +57,10 @@ type SellerConversationMessage {
 type SellerConversationMessageConnection {
   """메시지. 최신 메시지가 먼저 온다."""
   items: [SellerConversationMessage!]!
+  """조건에 맞는 전체 건수(현재 페이지와 무관). 커서 필터는 제외하고 센다."""
+  totalCount: Int!
+  """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
+  hasMore: Boolean!
   """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }

--- a/src/features/seller/seller-order.graphql
+++ b/src/features/seller/seller-order.graphql
@@ -33,6 +33,10 @@ type SellerOrderSummary {
 type SellerOrderConnection {
   """주문 카드. 최신 주문이 먼저 온다."""
   items: [SellerOrderSummary!]!
+  """조건에 맞는 전체 건수(현재 페이지와 무관). 커서 필터는 제외하고 센다."""
+  totalCount: Int!
+  """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
+  hasMore: Boolean!
   """다음 페이지 커서. null이면 마지막 페이지다. 불투명 토큰이라 값의 형식에 의존하지 않는다."""
   nextCursor: ID
 }

--- a/src/features/seller/seller-product.graphql
+++ b/src/features/seller/seller-product.graphql
@@ -208,6 +208,10 @@ type SellerProduct {
 type SellerProductConnection {
   """상품. 최신 등록이 먼저 온다."""
   items: [SellerProduct!]!
+  """조건에 맞는 전체 건수(현재 페이지와 무관). 커서 필터는 제외하고 센다."""
+  totalCount: Int!
+  """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
+  hasMore: Boolean!
   """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }

--- a/src/features/seller/seller-store.graphql
+++ b/src/features/seller/seller-store.graphql
@@ -111,6 +111,10 @@ type SellerStoreSpecialClosure {
 type SellerStoreSpecialClosureConnection {
   """특별휴무. 최신 등록이 먼저 온다."""
   items: [SellerStoreSpecialClosure!]!
+  """조건에 맞는 전체 건수(현재 페이지와 무관). 커서 필터는 제외하고 센다."""
+  totalCount: Int!
+  """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
+  hasMore: Boolean!
   """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }
@@ -130,6 +134,10 @@ type SellerStoreDailyCapacity {
 type SellerStoreDailyCapacityConnection {
   """일별 생산 수량 설정. 최신 등록이 먼저 온다."""
   items: [SellerStoreDailyCapacity!]!
+  """조건에 맞는 전체 건수(현재 페이지와 무관). 커서 필터는 제외하고 센다."""
+  totalCount: Int!
+  """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
+  hasMore: Boolean!
   """다음 페이지 커서. null이면 마지막 페이지다."""
   nextCursor: ID
 }

--- a/src/features/seller/services/seller-audit.service.spec.ts
+++ b/src/features/seller/services/seller-audit.service.spec.ts
@@ -56,6 +56,28 @@ describe('SellerAuditService (real DB)', () => {
       expect(result.items[0].storeId).toBe(store.id.toString());
     });
 
+    it('hasMore는 내려주되 totalCount는 내리지 않는다', async () => {
+      // 감사 로그는 누적형이라 매 조회 COUNT를 피한다(의도된 예외).
+      const { account } = await setupSellerWithStore(prisma);
+      await faqService.sellerCreateFaqTopic(account.id, {
+        title: 'F1',
+        answerHtml: '<p>x</p>',
+      });
+      await faqService.sellerCreateFaqTopic(account.id, {
+        title: 'F2',
+        answerHtml: '<p>x</p>',
+      });
+
+      const partial = await service.sellerAuditLogs(account.id, { limit: 1 });
+      expect(partial.items).toHaveLength(1);
+      expect(partial.hasMore).toBe(true);
+      expect(partial.totalCount).toBeUndefined();
+
+      const all = await service.sellerAuditLogs(account.id, { limit: 50 });
+      expect(all.hasMore).toBe(false);
+      expect(all.totalCount).toBeUndefined();
+    });
+
     it('targetType 필터링이 동작한다', async () => {
       const { account } = await setupSellerWithStore(prisma);
       await faqService.sellerCreateFaqTopic(account.id, {

--- a/src/features/seller/services/seller-audit.service.ts
+++ b/src/features/seller/services/seller-audit.service.ts
@@ -58,6 +58,8 @@ export class SellerAuditService
     return {
       items: paged.items.map((row) => toAuditLogOutput(row)),
       nextCursor: paged.nextCursor,
+      hasMore: paged.hasMore,
+      // totalCount는 내리지 않는다 — 감사 로그는 누적형이라 매 조회 COUNT가 부담이다
     };
   }
 

--- a/src/features/seller/services/seller-banner.service.ts
+++ b/src/features/seller/services/seller-banner.service.ts
@@ -79,16 +79,21 @@ export class SellerBannerService
       cursor: input?.cursor ? parseId(input.cursor) : null,
     });
 
-    const rows = await this.repo.listBannersByStore({
-      storeId: ctx.storeId,
-      limit: normalized.limit,
-      cursor: normalized.cursor,
-    });
+    const [rows, totalCount] = await Promise.all([
+      this.repo.listBannersByStore({
+        storeId: ctx.storeId,
+        limit: normalized.limit,
+        cursor: normalized.cursor,
+      }),
+      this.repo.countBannersByStore(ctx.storeId),
+    ]);
 
     const paged = nextCursorOf(rows, normalized.limit);
     return {
       items: paged.items.map((row) => toBannerOutput(row)),
       nextCursor: paged.nextCursor,
+      hasMore: paged.hasMore,
+      totalCount,
     };
   }
 

--- a/src/features/seller/services/seller-conversation.service.ts
+++ b/src/features/seller/services/seller-conversation.service.ts
@@ -70,16 +70,21 @@ export class SellerConversationService extends SellerBaseService {
       cursor: input?.cursor ? parseId(input.cursor) : null,
     });
 
-    const rows = await this.conversationRepository.listConversationsByStore({
-      storeId: ctx.storeId,
-      limit: normalized.limit,
-      cursor: normalized.cursor,
-    });
+    const [rows, totalCount] = await Promise.all([
+      this.conversationRepository.listConversationsByStore({
+        storeId: ctx.storeId,
+        limit: normalized.limit,
+        cursor: normalized.cursor,
+      }),
+      this.conversationRepository.countConversationsByStore(ctx.storeId),
+    ]);
 
     const paged = nextCursorOf(rows, normalized.limit);
     return {
       items: paged.items.map((row) => this.toConversationOutput(row)),
       nextCursor: paged.nextCursor,
+      hasMore: paged.hasMore,
+      totalCount,
     };
   }
 
@@ -101,16 +106,21 @@ export class SellerConversationService extends SellerBaseService {
       cursor: input?.cursor ? parseId(input.cursor) : null,
     });
 
-    const rows = await this.conversationRepository.listConversationMessages({
-      conversationId,
-      limit: normalized.limit,
-      cursor: normalized.cursor,
-    });
+    const [rows, totalCount] = await Promise.all([
+      this.conversationRepository.listConversationMessages({
+        conversationId,
+        limit: normalized.limit,
+        cursor: normalized.cursor,
+      }),
+      this.conversationRepository.countConversationMessages(conversationId),
+    ]);
 
     const paged = nextCursorOf(rows, normalized.limit);
     return {
       items: paged.items.map((row) => this.toConversationMessageOutput(row)),
       nextCursor: paged.nextCursor,
+      hasMore: paged.hasMore,
+      totalCount,
     };
   }
 

--- a/src/features/seller/services/seller-order.service.spec.ts
+++ b/src/features/seller/services/seller-order.service.spec.ts
@@ -103,6 +103,47 @@ describe('SellerOrderService (real DB)', () => {
       expect(result.items[0].status).toBe('CONFIRMED');
     });
 
+    it('결과가 0건이면 totalCount 0, hasMore false', async () => {
+      const { account } = await setupSellerWithStore(prisma);
+      const result = await service.sellerOrderList(account.id);
+      expect(result).toMatchObject({ totalCount: 0, hasMore: false });
+      expect(result.nextCursor).toBeNull();
+    });
+
+    it('정확히 limit개면 hasMore false, 초과하면 true', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      await createStoreOrder(store.id);
+      await createStoreOrder(store.id);
+
+      const exact = await service.sellerOrderList(account.id, { limit: 2 });
+      expect(exact.items).toHaveLength(2);
+      expect(exact.hasMore).toBe(false);
+      expect(exact.nextCursor).toBeNull();
+
+      const partial = await service.sellerOrderList(account.id, { limit: 1 });
+      expect(partial.items).toHaveLength(1);
+      expect(partial.hasMore).toBe(true);
+      expect(partial.nextCursor).not.toBeNull();
+    });
+
+    it('totalCount는 페이지가 아니라 필터 전체 건수다', async () => {
+      const { account, store } = await setupSellerWithStore(prisma);
+      await createStoreOrder(store.id, { status: 'SUBMITTED' });
+      await createStoreOrder(store.id, { status: 'SUBMITTED' });
+      await createStoreOrder(store.id, { status: 'CONFIRMED' });
+
+      // limit으로 잘라도 totalCount는 조건에 맞는 전체를 센다
+      const paged = await service.sellerOrderList(account.id, { limit: 1 });
+      expect(paged.items).toHaveLength(1);
+      expect(paged.totalCount).toBe(3);
+
+      // 필터는 totalCount에도 반영된다
+      const filtered = await service.sellerOrderList(account.id, {
+        status: 'SUBMITTED',
+      });
+      expect(filtered.totalCount).toBe(2);
+    });
+
     it('잘못된 status enum이면 BadRequestException', async () => {
       const { account } = await setupSellerWithStore(prisma);
       await expect(

--- a/src/features/seller/services/seller-order.service.ts
+++ b/src/features/seller/services/seller-order.service.ts
@@ -87,10 +87,8 @@ export class SellerOrderService extends SellerBaseService {
       cursor: input?.cursor ? parseId(input.cursor) : null,
     });
 
-    const rows = await this.orderRepository.listOrdersByStore({
+    const filters = {
       storeId: ctx.storeId,
-      limit: normalized.limit,
-      cursor: normalized.cursor,
       status: input?.status
         ? this.orderDomainService.parseStatus(input.status)
         : undefined,
@@ -99,12 +97,23 @@ export class SellerOrderService extends SellerBaseService {
       fromPickupAt: toDate(input?.fromPickupAt),
       toPickupAt: toDate(input?.toPickupAt),
       search: input?.search?.trim() || undefined,
-    });
+    };
+
+    const [rows, totalCount] = await Promise.all([
+      this.orderRepository.listOrdersByStore({
+        ...filters,
+        limit: normalized.limit,
+        cursor: normalized.cursor,
+      }),
+      this.orderRepository.countOrdersByStore(filters),
+    ]);
 
     const paged = nextCursorOf(rows, normalized.limit);
     return {
       items: paged.items.map((row) => this.toOrderSummaryOutput(row)),
       nextCursor: paged.nextCursor,
+      hasMore: paged.hasMore,
+      totalCount,
     };
   }
 

--- a/src/features/seller/services/seller-product-query.service.ts
+++ b/src/features/seller/services/seller-product-query.service.ts
@@ -46,19 +46,28 @@ export class SellerProductQueryService
       cursor: input?.cursor ? parseId(input.cursor) : null,
     });
 
-    const rows = await this.productRepository.listProductsByStore({
+    const filters = {
       storeId: ctx.storeId,
-      limit: normalized.limit,
-      cursor: normalized.cursor,
       isActive: input?.isActive ?? true,
       categoryId: input?.categoryId ? parseId(input.categoryId) : undefined,
       search: input?.search?.trim() || undefined,
-    });
+    };
+
+    const [rows, totalCount] = await Promise.all([
+      this.productRepository.listProductsByStore({
+        ...filters,
+        limit: normalized.limit,
+        cursor: normalized.cursor,
+      }),
+      this.productRepository.countProductsByStore(filters),
+    ]);
 
     const paged = nextCursorOf(rows, normalized.limit);
     return {
       items: paged.items.map((row) => toProductOutput(row)),
       nextCursor: paged.nextCursor,
+      hasMore: paged.hasMore,
+      totalCount,
     };
   }
 

--- a/src/features/seller/services/seller-store-hours.service.ts
+++ b/src/features/seller/services/seller-store-hours.service.ts
@@ -75,16 +75,21 @@ export class SellerStoreHoursService
       cursor: input?.cursor ? parseId(input.cursor) : null,
     });
 
-    const rows = await this.repo.listStoreSpecialClosures({
-      storeId: ctx.storeId,
-      limit: normalized.limit,
-      cursor: normalized.cursor,
-    });
+    const [rows, totalCount] = await Promise.all([
+      this.repo.listStoreSpecialClosures({
+        storeId: ctx.storeId,
+        limit: normalized.limit,
+        cursor: normalized.cursor,
+      }),
+      this.repo.countStoreSpecialClosures(ctx.storeId),
+    ]);
 
     const paged = nextCursorOf(rows, normalized.limit);
     return {
       items: paged.items.map((row) => toStoreSpecialClosureOutput(row)),
       nextCursor: paged.nextCursor,
+      hasMore: paged.hasMore,
+      totalCount,
     };
   }
 

--- a/src/features/seller/services/seller-store-policy.service.ts
+++ b/src/features/seller/services/seller-store-policy.service.ts
@@ -64,18 +64,27 @@ export class SellerStorePolicyService
       cursor: input?.cursor ? parseId(input.cursor) : null,
     });
 
-    const rows = await this.repo.listStoreDailyCapacities({
+    const filters = {
       storeId: ctx.storeId,
-      limit: normalized.limit,
-      cursor: normalized.cursor,
       fromDate: toDate(input?.fromDate),
       toDate: toDate(input?.toDate),
-    });
+    };
+
+    const [rows, totalCount] = await Promise.all([
+      this.repo.listStoreDailyCapacities({
+        ...filters,
+        limit: normalized.limit,
+        cursor: normalized.cursor,
+      }),
+      this.repo.countStoreDailyCapacities(filters),
+    ]);
 
     const paged = nextCursorOf(rows, normalized.limit);
     return {
       items: paged.items.map((row) => toStoreDailyCapacityOutput(row)),
       nextCursor: paged.nextCursor,
+      hasMore: paged.hasMore,
+      totalCount,
     };
   }
 

--- a/src/features/seller/types/seller-output.type.ts
+++ b/src/features/seller/types/seller-output.type.ts
@@ -285,4 +285,10 @@ export interface SellerAuditLogOutput {
 export interface SellerCursorConnection<T> {
   items: T[];
   nextCursor: string | null;
+  /** 다음 페이지 존재 여부. limit+1 조회 결과로 판정하므로 추가 쿼리가 없다. */
+  hasMore: boolean;
+  /**
+   * 조건에 맞는 전체 건수. 감사 로그처럼 누적량이 커 COUNT가 부담인 목록은 내리지 않는다.
+   */
+  totalCount?: number;
 }


### PR DESCRIPTION
판매자 목록 8종이 `{ items, nextCursor }`만 내려줘 구매자 Connection과 형태가 달랐다. 프론트가 "더 있는지"를 `nextCursor`의 null 여부로 추론해야 했고, 전체 건수는 알 방법이 없었다.

## 변경

| 필드 | 대상 | 비용 |
| --- | --- | --- |
| `hasMore: Boolean!` | **8종 전부** | **없음** |
| `totalCount: Int!` | 7종 (`sellerAuditLogs` 제외) | 목록당 COUNT 1회 |

`hasMore`가 공짜인 이유는 `nextCursorOf`가 이미 `limit+1` 조회 결과로 다음 페이지 유무를 판정하고 있었기 때문이다. 그 값을 버리고 있었을 뿐이라 노출만 했다.

`sellerAuditLogs`만 `totalCount`를 제외했다 — 누적형 로그라 매 조회 COUNT가 부담이다. SDL에도 이유를 주석으로 남겼다.

## count 조건이 목록과 갈라지지 않게

배너·일별 수량·상품·주문은 필터 조건이 있어, 목록과 카운트가 **같은 where 빌더**를 보도록 분리했다. 커서만 페이지 조건으로 따로 붙인다.

```ts
where: {
  ...(args.cursor ? { id: { lt: args.cursor } } : {}),
  ...this.storeOrderScopeWhere(args),
}
```

조건이 두 곳에 복사돼 있으면 한쪽만 바뀌었을 때 `totalCount`가 조용히 틀려진다. 이 레포에 이미 같은 이유의 선례가 있다 — 매장 검색의 "후보 조건과 단일 소스" 주석.

## totalCount 의미

커서를 제외한 **필터 기준 전체 건수**다. 페이지 크기와 무관하고 `status` 같은 필터는 반영된다. 테스트로 고정했다.

## 테스트 +4

- 0건일 때 `totalCount` 0, `hasMore` false
- 정확히 limit개면 `hasMore` false / 초과하면 true (경계)
- `totalCount`가 페이지가 아니라 필터 전체를 센다
- 감사 로그는 `hasMore`만 내리고 `totalCount`는 `undefined`

전체 225 suites / **1,873건** 통과. `tsc`·`dto:check`·`arch:check`·`docs:check`·`test:scripts` 통과.

## 하위 호환

필드 추가라 기존 FE 쿼리는 그대로 동작한다.