### PR TITLE
fix: 릴리즈 리뷰 반영 (판매자 대화 목록 커서를 정렬 키와 일치시킴)

### DIFF
--- a/src/features/conversation/repositories/conversation.repository.spec.ts
+++ b/src/features/conversation/repositories/conversation.repository.spec.ts
@@ -50,23 +50,66 @@ describe('ConversationRepository (real DB)', () => {
       expect(rows[0].id).not.toBe(b.conversation.id);
     });
 
-    it('cursor보다 id가 작은 row만 반환 (내림차순 페이지네이션)', async () => {
-      const customer = await createAccount(prisma, { account_type: 'USER' });
+    it('커서 이후 페이지만 반환한다 ((updated_at, id) desc 키셋)', async () => {
       const store = await createStore(prisma);
-      const c1 = await prisma.storeConversation.create({
-        data: { account_id: customer.id, store_id: store.id },
-      });
-      const customer2 = await createAccount(prisma, { account_type: 'USER' });
-      const c2 = await prisma.storeConversation.create({
-        data: { account_id: customer2.id, store_id: store.id },
-      });
+      const make = async (updatedAt: Date) => {
+        const customer = await createAccount(prisma, { account_type: 'USER' });
+        return prisma.storeConversation.create({
+          data: {
+            account_id: customer.id,
+            store_id: store.id,
+            updated_at: updatedAt,
+          },
+        });
+      };
+      const newer = await make(new Date('2026-09-03T00:00:00Z'));
+      const older = await make(new Date('2026-09-01T00:00:00Z'));
 
       const rows = await repo.listConversationsByStore({
         storeId: store.id,
         limit: 10,
-        cursor: c2.id,
+        cursor: { updatedAt: newer.updated_at, id: newer.id },
       });
-      expect(rows.map((r) => r.id)).toEqual([c1.id]);
+      expect(rows.map((r) => r.id)).toEqual([older.id]);
+    });
+
+    it('id가 더 큰 오래된 대화도 커서 페이지에서 빠지지 않는다', async () => {
+      // 정렬은 updated_at desc인데 커서가 id 단독이면 `id < cursor`가 정렬과
+      // 무관한 행을 잘라내, id가 큰 오래된 대화가 목록에서 영영 빠졌다.
+      const store = await createStore(prisma);
+      const make = async (updatedAt: Date) => {
+        const customer = await createAccount(prisma, { account_type: 'USER' });
+        return prisma.storeConversation.create({
+          data: {
+            account_id: customer.id,
+            store_id: store.id,
+            updated_at: updatedAt,
+          },
+        });
+      };
+      // 나중에 만들어 id가 크지만 updated_at은 가장 오래된 대화
+      const first = await make(new Date('2026-09-03T00:00:00Z'));
+      const second = await make(new Date('2026-09-02T00:00:00Z'));
+      const lastById = await make(new Date('2026-09-01T00:00:00Z'));
+      expect(lastById.id > first.id).toBe(true);
+
+      const page1 = await repo.listConversationsByStore({
+        storeId: store.id,
+        limit: 2,
+      });
+      expect(page1.map((r) => r.id)).toEqual([
+        first.id,
+        second.id,
+        lastById.id,
+      ]);
+
+      const cursorRow = page1[1];
+      const page2 = await repo.listConversationsByStore({
+        storeId: store.id,
+        limit: 2,
+        cursor: { updatedAt: cursorRow.updated_at, id: cursorRow.id },
+      });
+      expect(page2.map((r) => r.id)).toEqual([lastById.id]);
     });
   });
 

--- a/src/features/conversation/repositories/conversation.repository.ts
+++ b/src/features/conversation/repositories/conversation.repository.ts
@@ -20,16 +20,38 @@ export interface ConversationMessageEntry {
 export class ConversationRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  /**
+   * 판매자 대화 목록 페이지. (updated_at, id) desc 키셋.
+   *
+   * 커서가 id 단독이면 정렬 순서와 무관한 행을 잘라내 목록에서 영영 빠지는
+   * 대화가 생긴다 — 정렬 키를 그대로 커서에 담는다. schema.prisma의
+   * [store_id, updated_at] 인덱스가 이 정렬을 받친다.
+   */
   async listConversationsByStore(args: {
     storeId: bigint;
     limit: number;
-    cursor?: bigint;
+    cursor?: { updatedAt: Date; id: bigint };
   }) {
+    const scope: Prisma.StoreConversationWhereInput = {
+      store_id: args.storeId,
+    };
     return this.prisma.storeConversation.findMany({
-      where: {
-        store_id: args.storeId,
-        ...(args.cursor ? { id: { lt: args.cursor } } : {}),
-      },
+      where: args.cursor
+        ? {
+            AND: [
+              scope,
+              {
+                OR: [
+                  { updated_at: { lt: args.cursor.updatedAt } },
+                  {
+                    updated_at: args.cursor.updatedAt,
+                    id: { lt: args.cursor.id },
+                  },
+                ],
+              },
+            ],
+          }
+        : scope,
       orderBy: [{ updated_at: 'desc' }, { id: 'desc' }],
       take: args.limit + 1,
     });

--- a/src/features/seller/constants/seller-error-messages.ts
+++ b/src/features/seller/constants/seller-error-messages.ts
@@ -3,6 +3,7 @@ import { MAX_PRODUCT_IMAGES } from '@/features/seller/constants/seller.constants
 // ── 공통 ──
 
 export const ACCOUNT_NOT_FOUND = 'Account not found.';
+export const INVALID_CURSOR = 'Invalid cursor.';
 export const SELLER_ONLY = 'Only SELLER account is allowed.';
 export const STORE_NOT_FOUND = 'Store not found.';
 export const DUPLICATE_IDS = 'Duplicate ids are not allowed.';

--- a/src/features/seller/dto/inputs/seller-conversation-list.input.ts
+++ b/src/features/seller/dto/inputs/seller-conversation-list.input.ts
@@ -1,0 +1,19 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+/**
+ * 판매자 대화 목록 입력.
+ *
+ * 커서가 (updated_at, id) 복합이라 공용 SellerCursorInput(id 단독)과 분리했다 —
+ * 정렬 키를 그대로 커서에 담지 않으면 목록에서 빠지는 대화가 생긴다.
+ */
+export class SellerConversationListInput {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+}

--- a/src/features/seller/seller-conversation.graphql
+++ b/src/features/seller/seller-conversation.graphql
@@ -1,6 +1,6 @@
 extend type Query {
   """내 매장 대화방 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
-  sellerConversations(input: SellerCursorInput): SellerConversationConnection!
+  sellerConversations(input: SellerConversationListInput): SellerConversationConnection!
   """대화방 메시지 목록을 조회한다. 판매자 로그인 필수. SELLER 계정이 아니면 FORBIDDEN, 매장을 보유하지 않으면 NOT_FOUND."""
   sellerConversationMessages(conversationId: ID!, input: SellerCursorInput): SellerConversationMessageConnection!
 }
@@ -23,6 +23,19 @@ type SellerConversation {
   updatedAt: DateTime!
 }
 
+"""
+대화방 목록 조회 조건.
+
+커서가 (갱신 시각, id) 복합이라 공용 SellerCursorInput과 형식이 다르다.
+불투명 토큰이므로 값의 형식에 의존하지 말고 이전 응답의 nextCursor를 그대로 넘긴다.
+"""
+input SellerConversationListInput {
+  """한 번에 가져올 개수. 기본 20, 1~100으로 보정된다."""
+  limit: Int = 20
+  """이전 응답의 nextCursor. 첫 페이지는 생략한다."""
+  cursor: String
+}
+
 """대화방 목록 페이지. 최근에 갱신된(updated_at 기준) 대화방이 먼저 온다."""
 type SellerConversationConnection {
   """대화방. 최근에 갱신된 순으로 온다."""
@@ -31,8 +44,8 @@ type SellerConversationConnection {
   totalCount: Int!
   """다음 페이지 존재 여부. limit+1 조회로 판정하므로 추가 쿼리가 없다."""
   hasMore: Boolean!
-  """다음 페이지 커서. null이면 마지막 페이지다."""
-  nextCursor: ID
+  """다음 페이지 커서(불투명 토큰). null이면 마지막 페이지다."""
+  nextCursor: String
 }
 
 """대화 메시지 1건. bodyFormat에 따라 bodyText 또는 bodyHtml 하나만 채워진다."""

--- a/src/features/seller/services/seller-conversation.service.ts
+++ b/src/features/seller/services/seller-conversation.service.ts
@@ -12,6 +12,10 @@ import {
 } from '@prisma/client';
 
 import { parseId } from '@/common/utils/id-parser';
+import {
+  buildTimestampIdCursor,
+  parseTimestampIdCursor,
+} from '@/common/utils/keyset-cursor';
 import { cleanNullableText } from '@/common/utils/text-cleaner';
 import {
   AUDIT_LOG_REPOSITORY,
@@ -28,11 +32,13 @@ import {
   BODY_TEXT_REQUIRED,
   CONVERSATION_NOT_FOUND,
   INVALID_BODY_FORMAT,
+  INVALID_CURSOR,
 } from '@/features/seller/constants/seller-error-messages';
 import {
   MAX_CONVERSATION_BODY_HTML_LENGTH,
   MAX_CONVERSATION_BODY_TEXT_LENGTH,
 } from '@/features/seller/constants/seller.constants';
+import type { SellerConversationListInput } from '@/features/seller/dto/inputs/seller-conversation-list.input';
 import type { SellerCursorInput } from '@/features/seller/dto/inputs/seller-cursor.input';
 import type { SellerSendConversationMessageInput } from '@/features/seller/dto/inputs/seller-send-conversation-message.input';
 import {
@@ -60,30 +66,41 @@ export class SellerConversationService extends SellerBaseService {
   ) {
     super(repo, auditLogs);
   }
+  /**
+   * 대화 목록은 (updated_at, id) desc 정렬이라 커서도 두 값을 함께 담는다.
+   * id 단독 커서로는 정렬 순서와 무관한 행을 잘라내 목록에서 빠지는 대화가 생긴다.
+   */
   async sellerConversations(
     accountId: bigint,
-    input?: SellerCursorInput,
+    input?: SellerConversationListInput,
   ): Promise<SellerCursorConnection<SellerConversationOutput>> {
     const ctx = await this.requireSellerContext(accountId);
-    const normalized = normalizeCursorInput({
-      limit: input?.limit ?? null,
-      cursor: input?.cursor ? parseId(input.cursor) : null,
-    });
+    const limit = Math.min(Math.max(input?.limit ?? 20, 1), 100);
+    const cursor = input?.cursor
+      ? parseTimestampIdCursor(input.cursor, INVALID_CURSOR)
+      : undefined;
 
     const [rows, totalCount] = await Promise.all([
       this.conversationRepository.listConversationsByStore({
         storeId: ctx.storeId,
-        limit: normalized.limit,
-        cursor: normalized.cursor,
+        limit,
+        ...(cursor
+          ? { cursor: { updatedAt: cursor.timestamp, id: cursor.id } }
+          : {}),
       }),
       this.conversationRepository.countConversationsByStore(ctx.storeId),
     ]);
 
-    const paged = nextCursorOf(rows, normalized.limit);
+    const hasMore = rows.length > limit;
+    const items = hasMore ? rows.slice(0, limit) : rows;
+    const last = items[items.length - 1];
     return {
-      items: paged.items.map((row) => this.toConversationOutput(row)),
-      nextCursor: paged.nextCursor,
-      hasMore: paged.hasMore,
+      items: items.map((row) => this.toConversationOutput(row)),
+      nextCursor:
+        hasMore && last
+          ? buildTimestampIdCursor(last.updated_at, last.id)
+          : null,
+      hasMore,
       totalCount,
     };
   }


### PR DESCRIPTION
릴리즈 PR #289 리뷰에서 나온 지적. **main에 직접 커밋하지 않고 develop으로 먼저 반영**한다.

## 문제

정렬은 `(updated_at, id) desc`인데 커서는 `id` 단독이라, `id < cursor`가 정렬 순서와 무관한 행을 잘라낸다.

```
A(id=100, 09-03)  B(id=5, 09-02)  C(id=200, 09-01)   ← updated_at desc 정렬
limit=2 → [A, B], nextCursor = 5
다음 페이지: id < 5  →  C(200)가 영영 안 나온다
```

`hasMore=true`와 겹치면 클라이언트가 있지도 않은 페이지를 좇는다. **PR #286이 `hasMore`를 노출하면서 이 결함이 실제 피해로 바뀌었다.**

## 정렬을 낮추지 않고 커서를 맞춘 이유

`schema.prisma`에 `[store_id, updated_at]` 인덱스가 있다 — `updated_at` 정렬은 의도적이고 최적화까지 돼 있어, `id desc`로 낮추면 그 인덱스와 의도를 버리게 된다.

구매자 대화 목록이 **이미 같은 문제를 `(last_message_at, id)` 복합 커서로 풀어 뒀고** 공용 유틸(`common/utils/keyset-cursor`)도 있어 그대로 재사용했다.

## 변경

- `listConversationsByStore` — `(updated_at, id)` desc 키셋 where로 교체
- `sellerConversations` — `parseTimestampIdCursor` / `buildTimestampIdCursor` 사용
- `SellerConversationListInput` 신설. 커서 형식이 공용 `SellerCursorInput`(id 단독)과 달라 분리했고, SDL의 `cursor`·`nextCursor`도 `ID` → `String`(불투명 토큰)으로 바꿨다

## 같은 유형 전수 확인

seller 목록 8종의 정렬 키와 커서 키를 대조했다. **어긋난 건 이 목록 하나뿐**이고 나머지 7종은 `id desc` + `id` 커서로 일관된다.

## 테스트

+1건 — "id가 더 큰 오래된 대화가 커서 페이지에서 빠지지 않는다". 옛 동작(id 단독 커서)으로 되돌리면 **이 테스트만 실패하는 것까지 확인**했다.

전체 225 suites **1,874건** 통과. `lint`·`tsc`·`dto:check`·`docs:check`·`arch:check` 통과.