### PR TITLE
fix: 릴리즈 리뷰 반영 (계약 설명 3건 정정)

### DIFF
--- a/src/features/conversation/conversation-subscription.graphql
+++ b/src/features/conversation/conversation-subscription.graphql
@@ -8,7 +8,8 @@ extend type Subscription {
   myConversationUpdated: ConversationListUpdate!
   """
 판매자 대화 목록 갱신 이벤트(고객 메시지 도착 시).
-활성 매장을 보유한 판매자만 구독할 수 있다. 매장이 없거나 비활성·삭제 상태면 NOT_FOUND.
+삭제되지 않은 매장을 보유한 판매자만 구독할 수 있다. 매장이 없거나 삭제됐으면 NOT_FOUND.
+비활성(is_active=false) 매장은 구독이 유지된다 — 노출만 꺼진 사이에도 고객 문의는 받아야 한다.
 """
   sellerConversationUpdated: SellerConversationListUpdate!
 }

--- a/src/features/seller/seller-content.graphql
+++ b/src/features/seller/seller-content.graphql
@@ -225,7 +225,7 @@ type SellerAuditLog {
   id: ID!
   """조작한 계정 ID."""
   actorAccountId: ID!
-  """대상 매장 ID. 매장에 속하지 않는 조작(비밀번호 변경 등)이면 null."""
+  """대상 매장 ID. 판매자가 매장을 보유하면 채워지고, 보유하지 않은 상태의 조작에서만 null이다."""
   storeId: ID
   """조작 대상 종류."""
   targetType: SellerAuditTargetType!

--- a/src/features/seller/seller-product.graphql
+++ b/src/features/seller/seller-product.graphql
@@ -226,7 +226,7 @@ input SellerProductListInput {
   isActive: Boolean
   """카테고리 필터. 해당 카테고리가 연결된 상품만."""
   categoryId: ID
-  """상품명 부분일치 검색."""
+  """상품명 또는 연결된 태그명 부분일치 검색. 둘 중 하나만 맞아도 포함된다."""
   search: String
 }
 


### PR DESCRIPTION
릴리즈 PR #289 리뷰 추가분. **동작은 바꾸지 않고 설명만** 실제 계약에 맞춘다.

셋 다 원인이 같다 — **코드의 일부만 보고 적었다.**

| 대상 | 적었던 것 | 실제 |
| --- | --- | --- |
| `sellerConversationUpdated` | **활성** 매장 보유자만 구독 | `activeWhere`는 `{ deleted_at: null }`뿐. `is_active`를 포함하는 건 `visibleWhere` (`prisma/active-where.ts:15,18`) → **비활성 매장도 구독 열림** |
| `SellerProductListInput.search` | **상품명** 부분일치 | `OR`로 상품명 **+ 태그명**을 함께 본다 (`product.repository.ts:145-157`) |
| `SellerAuditLog.storeId` | 비밀번호 변경 등이면 **null** | `store?.id`를 넣어 **매장 보유 판매자면 채워진다** (`seller-credential.service.ts:205`) |

## 첫 건에서 코드가 아니라 설명을 고친 이유

`is_active`를 조건에 넣는 선택지도 있었지만, **매장을 비활성으로 돌려도 진행 중인 고객 문의는 계속 받아야 한다.** 노출만 잠시 끈 사이 메시지를 놓치는 쪽이 더 나쁘다. 지금 동작이 맞고 내 설명이 틀렸다.

## 검증

전체 225 suites **1,874건** 통과. `tsc`·`docs:check` 통과.