### PR TITLE
fix: 릴리즈 리뷰 반영 (옵션 그룹 계약 설명 3건 정정)

### DIFF
--- a/src/features/product/product-detail.graphql
+++ b/src/features/product/product-detail.graphql
@@ -39,11 +39,11 @@ type ProductDetailOptionGroup {
   name: String!
   """그룹 안내 문구(섹션 인트로)."""
   description: String
-  """필수 선택 여부. true면 이 그룹에서 최소 1개를 골라야 주문이 된다."""
+  """필수 선택 여부. true면 선택 개수가 minSelect~maxSelect 범위 안이어야 하고, false면 0개 선택도 허용된다."""
   isRequired: Boolean!
   """최소 선택 개수."""
   minSelect: Int!
-  """최대 선택 개수. minSelect와 같으면 단일 선택처럼 동작한다."""
+  """최대 선택 개수. minSelect와 함께 허용 개수를 정한다(둘 다 1이면 단일 선택)."""
   maxSelect: Int!
   """섹션 노출 순서. 오름차순."""
   sortOrder: Int!

--- a/src/features/seller/seller-product.graphql
+++ b/src/features/seller/seller-product.graphql
@@ -86,9 +86,9 @@ type SellerOptionItem {
   optionGroupId: ID!
   """선택지 이름."""
   title: String!
-  """선택지 설명. 소속 그룹의 optionRequiresDescription이 true면 필수다."""
+  """선택지 설명. 미등록 시 null."""
   description: String
-  """선택지 이미지 URL. 소속 그룹의 optionRequiresImage가 true면 필수다."""
+  """선택지 이미지 URL. 미등록 시 null."""
   imageUrl: String
   """이 선택지를 고를 때 더해지는 금액(원). 음수면 할인으로 동작한다."""
   priceDelta: Int!
@@ -109,15 +109,22 @@ type SellerOptionGroup {
   name: String!
   """그룹 안내 문구(상품 상세 옵션 섹션 인트로)."""
   description: String
-  """필수 선택 여부. true면 이 그룹에서 최소 1개를 골라야 주문이 된다."""
+  """미선택 허용 여부. false면 0개도 유효하고, true면 선택 개수가 minSelect~maxSelect 범위 안이어야 한다."""
   isRequired: Boolean!
   """최소 선택 개수."""
   minSelect: Int!
-  """최대 선택 개수. minSelect와 같으면 단일 선택처럼 동작한다."""
+  """최대 선택 개수. minSelect와 함께 허용 개수를 정한다(둘 다 1이면 단일 선택)."""
   maxSelect: Int!
-  """true면 이 그룹의 선택지에 description이 필수다."""
+  """
+  선택지에 구매자 커스텀 입력(설명)이 필요한 그룹인지.
+  현재는 커스텀 체크아웃이 확장되기 전이라, 이 값이 true인 그룹의 옵션을 고르면
+  주문이 거절된다(잠정 가드). 켜기 전에 주문 가능 여부를 확인해야 한다.
+  """
   optionRequiresDescription: Boolean!
-  """true면 이 그룹의 선택지에 imageUrl이 필수다."""
+  """
+  선택지에 구매자 커스텀 입력(이미지)이 필요한 그룹인지.
+  optionRequiresDescription과 마찬가지로 현재는 true인 그룹의 옵션 선택이 거절된다.
+  """
   optionRequiresImage: Boolean!
   """상품 안에서의 그룹 노출 순서. 오름차순."""
   sortOrder: Int!
@@ -328,17 +335,17 @@ input SellerCreateOptionGroupInput {
   name: String!
   """그룹 안내 문구."""
   description: String
-  """필수 선택 여부. 기본 true."""
+  """미선택 허용 여부. 기본 true(미선택 불가)."""
   isRequired: Boolean = true
   """최소 선택 개수. 기본 1."""
   minSelect: Int = 1
-  """최대 선택 개수. 기본 1(단일 선택)."""
+  """최대 선택 개수. 기본 1. minSelect와 함께 허용 개수를 정한다."""
   maxSelect: Int = 1
-  """true면 이 그룹의 선택지에 설명이 필수가 된다. 기본 false."""
+  """구매자 커스텀 입력(설명)이 필요한 그룹으로 표시한다. 기본 false. 현재는 켜면 해당 옵션 주문이 거절된다."""
   optionRequiresDescription: Boolean = false
-  """true면 이 그룹의 선택지에 이미지가 필수가 된다. 기본 false."""
+  """구매자 커스텀 입력(이미지)이 필요한 그룹으로 표시한다. 기본 false. 현재는 켜면 해당 옵션 주문이 거절된다."""
   optionRequiresImage: Boolean = false
-  """노출 순서. 미지정 시 맨 뒤."""
+  """노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
   sortOrder: Int
   """노출 여부. 기본 true."""
   isActive: Boolean = true
@@ -357,9 +364,9 @@ input SellerUpdateOptionGroupInput {
   minSelect: Int
   """최대 선택 개수."""
   maxSelect: Int
-  """true면 이 그룹의 선택지에 설명이 필수가 된다."""
+  """구매자 커스텀 입력(설명)이 필요한 그룹으로 표시한다."""
   optionRequiresDescription: Boolean
-  """true면 이 그룹의 선택지에 이미지가 필수가 된다."""
+  """구매자 커스텀 입력(이미지)이 필요한 그룹으로 표시한다."""
   optionRequiresImage: Boolean
   """노출 순서."""
   sortOrder: Int
@@ -382,13 +389,13 @@ input SellerCreateOptionItemInput {
   optionGroupId: ID!
   """선택지 이름."""
   title: String!
-  """선택지 설명. 그룹이 optionRequiresDescription이면 필수."""
+  """선택지 설명."""
   description: String
-  """선택지 이미지 URL. 그룹이 optionRequiresImage면 필수."""
+  """선택지 이미지 URL."""
   imageUrl: String
   """추가 금액(원). 기본 0이고 음수면 할인으로 동작한다."""
   priceDelta: Int = 0
-  """노출 순서. 미지정 시 맨 뒤."""
+  """노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
   sortOrder: Int
   """노출 여부. 기본 true."""
   isActive: Boolean = true
@@ -448,7 +455,7 @@ input SellerUpsertProductCustomTextTokenInput {
   defaultText: String!
   """입력 가능한 최대 글자 수. 기본 30."""
   maxLength: Int = 30
-  """입력 화면 노출 순서. 미지정 시 맨 뒤."""
+  """입력 화면 노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
   sortOrder: Int
   """필수 입력 여부. 기본 true."""
   isRequired: Boolean = true

--- a/src/features/seller/seller-product.graphql
+++ b/src/features/seller/seller-product.graphql
@@ -364,9 +364,9 @@ input SellerUpdateOptionGroupInput {
   minSelect: Int
   """최대 선택 개수."""
   maxSelect: Int
-  """구매자 커스텀 입력(설명)이 필요한 그룹으로 표시한다."""
+  """구매자 커스텀 입력(설명)이 필요한 그룹으로 표시한다. 현재는 켜면 해당 옵션 주문이 거절된다."""
   optionRequiresDescription: Boolean
-  """구매자 커스텀 입력(이미지)이 필요한 그룹으로 표시한다."""
+  """구매자 커스텀 입력(이미지)이 필요한 그룹으로 표시한다. 현재는 켜면 해당 옵션 주문이 거절된다."""
   optionRequiresImage: Boolean
   """노출 순서."""
   sortOrder: Int

--- a/src/features/seller/seller-product.graphql
+++ b/src/features/seller/seller-product.graphql
@@ -109,7 +109,7 @@ type SellerOptionGroup {
   name: String!
   """그룹 안내 문구(상품 상세 옵션 섹션 인트로)."""
   description: String
-  """미선택 허용 여부. false면 0개도 유효하고, true면 선택 개수가 minSelect~maxSelect 범위 안이어야 한다."""
+  """필수 선택 여부. true면 선택 개수가 minSelect~maxSelect 범위 안이어야 하고, false면 0개 선택도 허용된다."""
   isRequired: Boolean!
   """최소 선택 개수."""
   minSelect: Int!
@@ -335,7 +335,7 @@ input SellerCreateOptionGroupInput {
   name: String!
   """그룹 안내 문구."""
   description: String
-  """미선택 허용 여부. 기본 true(미선택 불가)."""
+  """필수 선택 여부. 기본 true. false면 0개 선택도 허용된다."""
   isRequired: Boolean = true
   """최소 선택 개수. 기본 1."""
   minSelect: Int = 1
@@ -358,7 +358,7 @@ input SellerUpdateOptionGroupInput {
   name: String
   """그룹 안내 문구."""
   description: String
-  """미선택 허용 여부. false면 0개도 유효하다."""
+  """필수 선택 여부. false면 0개 선택도 허용된다."""
   isRequired: Boolean
   """최소 선택 개수."""
   minSelect: Int

--- a/src/features/seller/seller-product.graphql
+++ b/src/features/seller/seller-product.graphql
@@ -229,7 +229,7 @@ input SellerProductListInput {
   limit: Int = 20
   """이전 응답의 nextCursor. 첫 페이지는 생략한다."""
   cursor: ID
-  """노출 여부 필터. 미지정 시 활성 상품만 반환한다(기본 true)."""
+  """노출 여부 필터. 생략하면 서버가 활성 상품만 반환한다(SDL 기본값이 아니라 서비스 기본 동작)."""
   isActive: Boolean
   """카테고리 필터. 해당 카테고리가 연결된 상품만."""
   categoryId: ID
@@ -358,7 +358,7 @@ input SellerUpdateOptionGroupInput {
   name: String
   """그룹 안내 문구."""
   description: String
-  """필수 선택 여부."""
+  """미선택 허용 여부. false면 0개도 유효하다."""
   isRequired: Boolean
   """최소 선택 개수."""
   minSelect: Int


### PR DESCRIPTION
릴리즈 PR #289 리뷰 추가분. **세 건 다 클라이언트가 그대로 따르면 유효한 주문을 막거나 무효한 조합을 만든다.**

| 대상 | 적었던 것 | 실제 |
| --- | --- | --- |
| `optionRequiresDescription` / `Image` | 선택지에 설명·이미지를 **필수로 만든다** | 옵션 생성은 null이어도 통과. 대신 **체크아웃이 그 그룹 선택을 통째로 거절**한다 (`order-checkout.service.ts:243-250`) |
| `sortOrder` 생략 | **맨 뒤**에 붙는다 | 옵션 그룹·선택지·커스텀 토큰은 `?? 0` → **0**. 맨 뒤는 상품 이미지(`?? count`)만 |
| `isRequired` / `minSelect` / `maxSelect` | true면 **최소 1개** 필수 / min=max면 단일 선택 | `count`를 `[min, max]`로만 보고 `is_required`는 **0개 허용 여부만** 가른다 (`order-checkout.service.ts:230-235`) |

## 각 건의 실제 피해

**커스텀 플래그** — 판매자가 "선택지에 설명을 필수로 걸자"고 켜면, 그 그룹의 옵션은 **주문 자체가 거절된다.** 커스텀 체크아웃 확장 전까지의 잠정 가드다(이슈 #212). 설명이 정반대 인상을 준다.

**sortOrder** — 상품 이미지 문구를 나머지 셋에 복사했다. **네 자리 중 셋이 틀렸다.**

**선택 개수** — `isRequired: true, minSelect: 0`이면 0개도 유효하고 `min=max=2`면 정확히 2개다. 클라이언트가 이 설명으로 라디오/체크박스를 고르면 유효한 주문을 막는다.

## 검증

전체 225 suites **1,874건** 통과. `tsc`·`docs:check` 통과.