### PR TITLE
fix: 릴리즈 리뷰 반영 (SDL 동작 단정 전수 정정)

### DIFF
--- a/scripts/check-sdl-description-coverage.ts
+++ b/scripts/check-sdl-description-coverage.ts
@@ -40,10 +40,10 @@ const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.yarn']);
 const BASELINE: Record<Category, Baseline> = {
   rootField: { documented: 130, total: 130 },
   fieldArg: { documented: 6, total: 6 },
-  inputType: { documented: 72, total: 72 },
-  inputField: { documented: 227, total: 227 },
+  inputType: { documented: 73, total: 73 },
+  inputField: { documented: 229, total: 229 },
   outputType: { documented: 134, total: 134 },
-  outputField: { documented: 603, total: 603 },
+  outputField: { documented: 618, total: 618 },
   enumType: { documented: 17, total: 17 },
   enumValue: { documented: 61, total: 61 },
 };

--- a/src/features/pickup/pickup.types.graphql
+++ b/src/features/pickup/pickup.types.graphql
@@ -1,12 +1,12 @@
 extend type Query {
   """월별 픽업 가능 날짜 (홈 전역 정책 기준). yearMonth: "YYYY-MM" """
   pickupCalendar(
-    """대상 연월. "YYYY-MM" 형식(KST 기준). 예: "2026-09". 형식이 어긋나면 BAD_REQUEST."""
+    """대상 연월. "YYYY-MM" 형식(KST 기준). 예: "2026-09". 형식이 어긋나면 BAD_USER_INPUT."""
     yearMonth: String!
   ): PickupCalendar!
   """선택 날짜의 픽업 시간 슬롯. date: "YYYY-MM-DD" """
   pickupTimeSlots(
-    """대상 날짜. "YYYY-MM-DD" 형식(KST 기준). 예: "2026-09-10". 형식이 어긋나면 BAD_REQUEST."""
+    """대상 날짜. "YYYY-MM-DD" 형식(KST 기준). 예: "2026-09-10". 형식이 어긋나면 BAD_USER_INPUT."""
     date: String!
   ): PickupTimeSlots!
 }

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -13,7 +13,7 @@ extend type Query {
 input RandomCakesInput {
   """EVENT 카테고리 ID. 비우면 '전체' 칩(필터 미적용)."""
   categoryId: ID
-  """이미지 수(기본 9 — 3열 그리드 9개 단위, figma 명세 기준). 1~30만 허용하며 벗어나면 BAD_REQUEST."""
+  """이미지 수(기본 9 — 3열 그리드 9개 단위, figma 명세 기준). 1~30만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 9
 }
 
@@ -75,7 +75,7 @@ type HomeBanner {
 
 """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기 카드 목록."""
 input CustomCakeShowcaseInput {
-  """가져올 후기 수. 기본 5, 1~20만 허용하며 벗어나면 BAD_REQUEST."""
+  """가져올 후기 수. 기본 5, 1~20만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 5
 }
 

--- a/src/features/product/product-home.graphql
+++ b/src/features/product/product-home.graphql
@@ -13,7 +13,7 @@ extend type Query {
 input RandomCakesInput {
   """EVENT 카테고리 ID. 비우면 '전체' 칩(필터 미적용)."""
   categoryId: ID
-  """이미지 수(3열 그리드 9개 단위 — figma 명세 기준)."""
+  """이미지 수(기본 9 — 3열 그리드 9개 단위, figma 명세 기준). 1~30만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 9
 }
 
@@ -75,7 +75,7 @@ type HomeBanner {
 
 """홈 '다른 사람들은 이렇게 만들었어요' 제작 후기 카드 목록."""
 input CustomCakeShowcaseInput {
-  """가져올 후기 수. 기본값은 SDL 기본값을 따른다."""
+  """가져올 후기 수. 기본 5, 1~20만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 5
 }
 

--- a/src/features/product/product-reviews.graphql
+++ b/src/features/product/product-reviews.graphql
@@ -18,7 +18,7 @@ input ProductReviewsInput {
   sort: ReviewSort = LATEST
   """이전 페이지의 nextCursor 값(불투명 토큰). 동일 sort에서만 유효."""
   cursor: ID
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 
@@ -113,7 +113,7 @@ input ReviewCommentsInput {
   reviewId: ID!
   """이전 페이지 마지막 댓글 id(이후부터 조회)."""
   cursor: ID
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 

--- a/src/features/product/product-reviews.graphql
+++ b/src/features/product/product-reviews.graphql
@@ -18,7 +18,7 @@ input ProductReviewsInput {
   sort: ReviewSort = LATEST
   """이전 페이지의 nextCursor 값(불투명 토큰). 동일 sort에서만 유효."""
   cursor: ID
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 
@@ -113,7 +113,7 @@ input ReviewCommentsInput {
   reviewId: ID!
   """이전 페이지 마지막 댓글 id(이후부터 조회)."""
   cursor: ID
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/product/product-storefront.graphql
+++ b/src/features/product/product-storefront.graphql
@@ -38,7 +38,7 @@ input StoreProductsInput {
   search: String
   """이전 페이지 마지막 항목 id(이후부터 조회)."""
   cursor: ID
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/product/product-storefront.graphql
+++ b/src/features/product/product-storefront.graphql
@@ -38,7 +38,7 @@ input StoreProductsInput {
   search: String
   """이전 페이지 마지막 항목 id(이후부터 조회)."""
   cursor: ID
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 

--- a/src/features/region/region.types.graphql
+++ b/src/features/region/region.types.graphql
@@ -11,7 +11,7 @@ extend type Query {
 input SearchRegionsInput {
   """검색어. 1·2차 지역명 모두를 대상으로 부분일치 검색한다."""
   keyword: String!
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 

--- a/src/features/region/region.types.graphql
+++ b/src/features/region/region.types.graphql
@@ -11,7 +11,7 @@ extend type Query {
 input SearchRegionsInput {
   """검색어. 1·2차 지역명 모두를 대상으로 부분일치 검색한다."""
   keyword: String!
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/search/search-entry.graphql
+++ b/src/features/search/search-entry.graphql
@@ -14,7 +14,7 @@ extend type Mutation {
   recordSearch(
     """
     기록할 검색어. 앞뒤 공백 제거 + 연속 공백 1칸 축약 후 저장한다. 빈 문자열이거나
-    200자(코드 포인트 기준)를 넘으면 BAD_REQUEST.
+    200자(코드 포인트 기준)를 넘으면 BAD_USER_INPUT.
     """
     keyword: String!
   ): Boolean!

--- a/src/features/seller/seller-common.graphql
+++ b/src/features/seller/seller-common.graphql
@@ -5,7 +5,7 @@ ID 키셋 커서 기반 목록 조회 공통 입력. 판매자 목록 API가 공
 정렬 기준이 바뀌면 이전에 받은 커서는 무효가 된다.
 """
 input SellerCursorInput {
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
   """이전 응답의 nextCursor. 첫 페이지는 생략한다."""
   cursor: ID

--- a/src/features/seller/seller-content.graphql
+++ b/src/features/seller/seller-content.graphql
@@ -45,7 +45,7 @@ input SellerCreateFaqTopicInput {
   title: String!
   """FAQ 답변 본문(HTML)."""
   answerHtml: String!
-  """노출 순서. 미지정 시 서버가 정한 기본값이 들어간다."""
+  """노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
   sortOrder: Int
   """노출 여부. 기본 true."""
   isActive: Boolean = true
@@ -156,7 +156,7 @@ input SellerCreateBannerInput {
   startsAt: DateTime
   """노출 종료 일시. 생략 시 종료 제한 없음."""
   endsAt: DateTime
-  """같은 슬롯 안에서의 노출 순서."""
+  """같은 슬롯 안에서의 노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
   sortOrder: Int
   """노출 여부. 기본 true."""
   isActive: Boolean = true

--- a/src/features/seller/seller-content.graphql
+++ b/src/features/seller/seller-content.graphql
@@ -45,7 +45,7 @@ input SellerCreateFaqTopicInput {
   title: String!
   """FAQ 답변 본문(HTML)."""
   answerHtml: String!
-  """노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
+  """노출 순서. 오름차순이고 같으면 id 오름차순. 미지정 시 0이라 기존이 모두 0이면 맨 뒤에 온다."""
   sortOrder: Int
   """노출 여부. 기본 true."""
   isActive: Boolean = true
@@ -156,7 +156,7 @@ input SellerCreateBannerInput {
   startsAt: DateTime
   """노출 종료 일시. 생략 시 종료 제한 없음."""
   endsAt: DateTime
-  """같은 슬롯 안에서의 노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
+  """같은 슬롯 안에서의 노출 순서. 구매자 노출은 오름차순(같으면 id 오름차순)으로 1건만 뽑는다. 미지정 시 0."""
   sortOrder: Int
   """노출 여부. 기본 true."""
   isActive: Boolean = true
@@ -260,7 +260,7 @@ type SellerAuditLogConnection {
 
 """감사 로그 조회 조건."""
 input SellerAuditLogListInput {
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
   """이전 응답의 nextCursor. 첫 페이지는 생략한다."""
   cursor: ID

--- a/src/features/seller/seller-conversation.graphql
+++ b/src/features/seller/seller-conversation.graphql
@@ -30,7 +30,7 @@ type SellerConversation {
 불투명 토큰이므로 값의 형식에 의존하지 말고 이전 응답의 nextCursor를 그대로 넘긴다.
 """
 input SellerConversationListInput {
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
   """이전 응답의 nextCursor. 첫 페이지는 생략한다."""
   cursor: String
@@ -86,7 +86,7 @@ type SellerConversationMessageConnection {
 }
 
 """
-판매자 메시지 발송 입력. bodyFormat에 맞는 본문 필드가 비어 있으면 BAD_REQUEST.
+판매자 메시지 발송 입력. bodyFormat에 맞는 본문 필드가 비어 있으면 BAD_USER_INPUT.
 내 매장의 대화방이 아니면 NOT_FOUND.
 """
 input SellerSendConversationMessageInput {

--- a/src/features/seller/seller-order.graphql
+++ b/src/features/seller/seller-order.graphql
@@ -45,7 +45,7 @@ type SellerOrderConnection {
 주문 목록 조회 조건. 모든 필터는 AND로 결합되고, 미지정 필터는 적용되지 않는다.
 """
 input SellerOrderListInput {
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
   """이전 응답의 nextCursor. 첫 페이지는 생략한다."""
   cursor: ID
@@ -189,12 +189,12 @@ type SellerOrderDetail {
 
 """
 주문 상태 변경 입력. 전이 규칙은 OrderStatusType 설명을 따르며, 규칙에 어긋나면
-BAD_REQUEST로 거절된다.
+BAD_USER_INPUT으로 거절된다.
 """
 input SellerUpdateOrderStatusInput {
   orderId: ID!
   """변경할 상태. 현재 상태에서 진입 가능한 값이어야 한다."""
   toStatus: OrderStatusType!
-  """변경 사유 메모. toStatus가 CANCELED면 필수이고, 없으면 BAD_REQUEST."""
+  """변경 사유 메모. toStatus가 CANCELED면 필수이고, 없으면 BAD_USER_INPUT."""
   note: String
 }

--- a/src/features/seller/seller-product.graphql
+++ b/src/features/seller/seller-product.graphql
@@ -225,7 +225,7 @@ type SellerProductConnection {
 
 """상품 목록 조회 조건. 필터는 AND로 결합되고 미지정 필터는 적용되지 않는다."""
 input SellerProductListInput {
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
   """이전 응답의 nextCursor. 첫 페이지는 생략한다."""
   cursor: ID
@@ -303,7 +303,7 @@ input SellerAddProductImageInput {
 
 """
 상품 이미지 순서 변경 입력. 배열 순서가 곧 새 노출 순서다.
-현재 이미지 전부를 빠짐없이 담아야 하며, 개수가 다르거나 남의 이미지 ID가 섞이면 BAD_REQUEST.
+현재 이미지 전부를 빠짐없이 담아야 하며, 개수가 다르거나 남의 이미지 ID가 섞이면 BAD_USER_INPUT.
 """
 input SellerReorderProductImagesInput {
   productId: ID!
@@ -345,7 +345,7 @@ input SellerCreateOptionGroupInput {
   optionRequiresDescription: Boolean = false
   """구매자 커스텀 입력(이미지)이 필요한 그룹으로 표시한다. 기본 false. 현재는 켜면 해당 옵션 주문이 거절된다."""
   optionRequiresImage: Boolean = false
-  """노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
+  """노출 순서. 오름차순이고 동률의 순서는 보장하지 않는다. 미지정 시 0."""
   sortOrder: Int
   """노출 여부. 기본 true."""
   isActive: Boolean = true
@@ -395,7 +395,7 @@ input SellerCreateOptionItemInput {
   imageUrl: String
   """추가 금액(원). 기본 0이고 음수면 할인으로 동작한다."""
   priceDelta: Int = 0
-  """노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
+  """노출 순서. 오름차순이고 동률의 순서는 보장하지 않는다. 미지정 시 0."""
   sortOrder: Int
   """노출 여부. 기본 true."""
   isActive: Boolean = true
@@ -455,7 +455,7 @@ input SellerUpsertProductCustomTextTokenInput {
   defaultText: String!
   """입력 가능한 최대 글자 수. 기본 30."""
   maxLength: Int = 30
-  """입력 화면 노출 순서. 미지정 시 0이 들어간다(맨 뒤가 아니다)."""
+  """입력 화면 노출 순서. 오름차순이고 동률의 순서는 보장하지 않는다. 미지정 시 0."""
   sortOrder: Int
   """필수 입력 여부. 기본 true."""
   isRequired: Boolean = true

--- a/src/features/seller/seller-store.graphql
+++ b/src/features/seller/seller-store.graphql
@@ -28,7 +28,7 @@ extend type Mutation {
 
 """날짜 범위 필터가 붙은 커서 목록 입력. 일별 생산 수량 조회에 쓴다."""
 input SellerDateCursorInput {
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
   """이전 응답의 nextCursor. 첫 페이지는 생략한다."""
   cursor: ID
@@ -202,7 +202,7 @@ input SellerUpsertStoreSpecialClosureInput {
 
 """
 픽업 정책 수정 입력. 세 값이 함께 픽업 달력·시간 슬롯 생성 규칙을 이룬다.
-범위를 벗어나면 BAD_REQUEST.
+범위를 벗어나면 BAD_USER_INPUT.
 """
 input SellerUpdatePickupPolicyInput {
   """픽업 예약 시간 슬롯 간격(분)."""

--- a/src/features/store/store-pickup-schedule.graphql
+++ b/src/features/store/store-pickup-schedule.graphql
@@ -2,13 +2,13 @@ extend type Query {
   """매장별 월 픽업 가능 날짜. 없거나 비활성/삭제 매장이면 NOT_FOUND. 비로그인 접근 가능. yearMonth: "YYYY-MM" """
   storePickupCalendar(
     storeId: ID!
-    """대상 연월. "YYYY-MM" 형식(KST 기준). 예: "2026-09". 형식이 어긋나면 BAD_REQUEST."""
+    """대상 연월. "YYYY-MM" 형식(KST 기준). 예: "2026-09". 형식이 어긋나면 BAD_USER_INPUT."""
     yearMonth: String!
   ): StorePickupCalendar!
   """매장별 선택 날짜의 픽업 시간 슬롯. date: "YYYY-MM-DD" """
   storePickupTimeSlots(
     storeId: ID!
-    """대상 날짜. "YYYY-MM-DD" 형식(KST 기준). 예: "2026-09-10". 형식이 어긋나면 BAD_REQUEST."""
+    """대상 날짜. "YYYY-MM-DD" 형식(KST 기준). 예: "2026-09-10". 형식이 어긋나면 BAD_USER_INPUT."""
     date: String!
   ): StorePickupTimeSlots!
 }

--- a/src/features/store/store-reviews.graphql
+++ b/src/features/store/store-reviews.graphql
@@ -12,7 +12,7 @@ input StoreReviewsInput {
   sort: ReviewSort = LATEST
   """이전 페이지의 nextCursor 값(불투명 토큰). 동일 sort에서만 유효."""
   cursor: ID
-  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/store/store-reviews.graphql
+++ b/src/features/store/store-reviews.graphql
@@ -12,7 +12,7 @@ input StoreReviewsInput {
   sort: ReviewSort = LATEST
   """이전 페이지의 nextCursor 값(불투명 토큰). 동일 sort에서만 유효."""
   cursor: ID
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~100만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 

--- a/src/features/store/store-today-pickup.graphql
+++ b/src/features/store/store-today-pickup.graphql
@@ -9,7 +9,7 @@ input TodayPickupStoresInput {
   regionIds: [ID!]
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 

--- a/src/features/store/store-today-pickup.graphql
+++ b/src/features/store/store-today-pickup.graphql
@@ -9,7 +9,7 @@ input TodayPickupStoresInput {
   regionIds: [ID!]
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/store/store-wishlist.graphql
+++ b/src/features/store/store-wishlist.graphql
@@ -14,7 +14,7 @@ extend type Mutation {
 input MyWishlistedStoresInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 

--- a/src/features/store/store-wishlist.graphql
+++ b/src/features/store/store-wishlist.graphql
@@ -14,7 +14,7 @@ extend type Mutation {
 input MyWishlistedStoresInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/store/store.types.graphql
+++ b/src/features/store/store.types.graphql
@@ -9,7 +9,7 @@ input PopularStoresInput {
   regionIds: [ID!]
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 

--- a/src/features/store/store.types.graphql
+++ b/src/features/store/store.types.graphql
@@ -9,7 +9,7 @@ input PopularStoresInput {
   regionIds: [ID!]
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/user/user-order.graphql
+++ b/src/features/user/user-order.graphql
@@ -11,7 +11,7 @@ input MyOrdersInput {
   statuses: [OrderStatusType!]
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 
@@ -85,7 +85,7 @@ type MyOrderDetail {
   """CANCELED 도달 시각. 취소되지 않았으면 null."""
   canceledAt: DateTime
 
-  """상태 변경 이력. 발생한 순(오래된 것부터)으로 온다 — 판매자 주문 상세(최신순)와 방향이 반대다."""
+  """상태 변경 이력. 오래된 순이다(판매자 주문 상세는 최신순 — 방향이 반대다)."""
   statusHistories: [MyOrderStatusHistory!]!
   """주문 아이템 목록"""
   items: [MyOrderItemDetail!]!

--- a/src/features/user/user-order.graphql
+++ b/src/features/user/user-order.graphql
@@ -11,7 +11,7 @@ input MyOrdersInput {
   statuses: [OrderStatusType!]
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 
@@ -85,7 +85,7 @@ type MyOrderDetail {
   """CANCELED 도달 시각. 취소되지 않았으면 null."""
   canceledAt: DateTime
 
-  """상태 변경 히스토리"""
+  """상태 변경 이력. 발생한 순(오래된 것부터)으로 온다 — 판매자 주문 상세(최신순)와 방향이 반대다."""
   statusHistories: [MyOrderStatusHistory!]!
   """주문 아이템 목록"""
   items: [MyOrderItemDetail!]!

--- a/src/features/user/user-recent-view.graphql
+++ b/src/features/user/user-recent-view.graphql
@@ -16,7 +16,7 @@ extend type Mutation {
 input MyRecentViewedProductsInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/user/user-recent-view.graphql
+++ b/src/features/user/user-recent-view.graphql
@@ -16,7 +16,7 @@ extend type Mutation {
 input MyRecentViewedProductsInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 

--- a/src/features/user/user-review.graphql
+++ b/src/features/user/user-review.graphql
@@ -11,7 +11,7 @@ extend type Query {
 input MyReviewableOrderItemsInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 
@@ -54,7 +54,7 @@ extend type Mutation {
 input MyReviewsInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 
@@ -159,7 +159,6 @@ input WriteReviewInput {
 
 """
 리뷰 첨부 미디어 입력. createReviewMediaUploadUrl로 먼저 업로드한 뒤 그 결과를 넘긴다.
-노출 순서는 배열에 담은 순서로 정해진다.
 """
 input WriteReviewMediaInput {
   """미디어 종류."""
@@ -168,9 +167,6 @@ input WriteReviewMediaInput {
   mediaUrl: String!
   """동영상 대표 프레임 URL."""
   thumbnailUrl: String
-  """
-  노출 순서. 현재 서버는 이 값을 쓰지 않고 배열에 담긴 순서를 그대로 저장한다 —
-  순서를 바꾸려면 배열 순서를 바꾼다.
-  """
+  """노출 순서. 서버는 이 값을 쓰지 않고 배열에 담긴 순서를 그대로 저장한다."""
   sortOrder: Int!
 }

--- a/src/features/user/user-review.graphql
+++ b/src/features/user/user-review.graphql
@@ -11,7 +11,7 @@ extend type Query {
 input MyReviewableOrderItemsInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 
@@ -54,7 +54,7 @@ extend type Mutation {
 input MyReviewsInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 
@@ -144,7 +144,7 @@ type ReviewMediaUploadUrl {
 
 """
 리뷰 작성 입력. 픽업 완료(PICKED_UP)된 주문 품목에만 쓸 수 있고, 품목당 1건이다.
-미디어는 이미지 최대 10장 또는 영상 1개까지 허용된다.
+미디어는 이미지 최대 10장과 영상 1개를 각각 셈하며, 둘을 섞어 최대 11개까지 넣을 수 있다.
 """
 input WriteReviewInput {
   """리뷰 대상 주문 품목 ID. myReviewableOrderItems가 준 값을 그대로 쓴다."""
@@ -157,7 +157,10 @@ input WriteReviewInput {
   media: [WriteReviewMediaInput!]
 }
 
-"""리뷰 첨부 미디어 입력. createReviewMediaUploadUrl로 먼저 업로드한 뒤 그 결과를 넘긴다."""
+"""
+리뷰 첨부 미디어 입력. createReviewMediaUploadUrl로 먼저 업로드한 뒤 그 결과를 넘긴다.
+노출 순서는 배열에 담은 순서로 정해진다.
+"""
 input WriteReviewMediaInput {
   """미디어 종류."""
   mediaType: ReviewMediaType!
@@ -165,6 +168,9 @@ input WriteReviewMediaInput {
   mediaUrl: String!
   """동영상 대표 프레임 URL."""
   thumbnailUrl: String
-  """노출 순서. 오름차순."""
+  """
+  노출 순서. 현재 서버는 이 값을 쓰지 않고 배열에 담긴 순서를 그대로 저장한다 —
+  순서를 바꾸려면 배열 순서를 바꾼다.
+  """
   sortOrder: Int!
 }

--- a/src/features/user/user-wishlist.graphql
+++ b/src/features/user/user-wishlist.graphql
@@ -16,7 +16,7 @@ extend type Mutation {
 input MyWishlistInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
   """특정 매장의 찜 상품만 조회(매장별 보기 → 매장 선택 화면)."""
   storeId: ID
@@ -63,7 +63,7 @@ type WishlistItemSummary {
 input MyWishlistStoreGroupsInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_USER_INPUT."""
   limit: Int = 20
 }
 

--- a/src/features/user/user-wishlist.graphql
+++ b/src/features/user/user-wishlist.graphql
@@ -16,7 +16,7 @@ extend type Mutation {
 input MyWishlistInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
   """특정 매장의 찜 상품만 조회(매장별 보기 → 매장 선택 화면)."""
   storeId: ID
@@ -63,7 +63,7 @@ type WishlistItemSummary {
 input MyWishlistStoreGroupsInput {
   """건너뛸 개수. 기본 0."""
   offset: Int = 0
-  """한 번에 가져올 개수. 기본 20."""
+  """한 번에 가져올 개수. 기본 20, 1~50만 허용하며 벗어나면 BAD_REQUEST."""
   limit: Int = 20
 }
 


### PR DESCRIPTION
## 배경

릴리즈 PR #289의 Codex 지적 13건을 분류한 결과 **12건이 같은 유형**이었다 — "SDL description이 코드가 보장하지 않는 동작을 단정한다". 유일한 예외인 첫 지적(seller 대화 커서 정렬 불일치)만 실제 코드 버그였고 #290에서 해소했다.

그 12건 안에서도 하위 유형이 반복됐다: sortOrder 의미 2회, null 배타 열거 2회, 본문/링크 필드 배타성 2회. **지적된 자리만 막고 유형을 안 훑은 게 라운드가 늘어난 원인**이라, CLAUDE.md 절차대로 개별 대응을 멈추고 전수 대조로 전환했다.

## 대조 방법

SDL description 1,352건에서 검증 가능한 동작 단정 376건을 추출해 코드와 대조했다. 검출기는 **양극성 probe**(잡혀야 할 자리 / 안 잡혀야 할 자리)로 자체 검증한 뒤 결과를 인용했다 — 초기 시도에서 정규식 이스케이프 오류로 정상 자리까지 전부 위반으로 찍힌 적이 있어, "0건"이든 "전건"이든 검출기부터 반증했다.

## 변경

**지적 2건 직접 반영**

- `WriteReviewInput` — "이미지 최대 10장 **또는** 영상 1개"는 배타로 읽히지만 `validateMedia`는 IMAGE/VIDEO를 독립적으로 센다. 혼합 11개까지 유효.
- `WriteReviewMediaInput.sortOrder` — `writeReview`가 `sort_order: i`(배열 인덱스)로 저장해 입력값을 버린다. 값을 존중하도록 바꾸면 중복·결번 입력의 정규화 규칙을 새로 정해야 해서 릴리즈 범위를 넘는다. 배열 순서가 곧 노출 순서라는 현재 계약을 명시하는 쪽을 택했다.

**전수 대조로 추가 발견 17건**

| 유형 | 건수 | 내용 |
| --- | --- | --- |
| limit 상한 미기재 | 16 | SDL 입력 31개 중 16개가 `@Max`를 안 적고 있었다. 상한은 DTO에만 있어 SDL에서 안 보이는데 초과 시 `ValidationPipe`가 BAD_REQUEST를 낸다 |
| sortOrder 기본값 | 2 | `SellerCreateFaqTopicInput`(모호), `SellerCreateBannerInput`(누락). 실제로는 둘 다 `?? 0`이라 맨 뒤가 아니다 |
| statusHistories 정렬 | 1 | 구매자 상세는 `changed_at asc`, 판매자 상세는 `desc`로 서로 반대인데 판매자 쪽만 "최신순"이 적혀 있었다 |

<sub>limit 16건 + sortOrder 2건 + 정렬 1건 = 19건이나, `MyReviewableOrderItemsInput`/`MyReviewsInput`이 같은 파일이라 파일 수는 13개.</sub>

반대 방향 확인도 했다 — `SellerAddProductImageInput.sortOrder`는 `?? count`라 "맨 뒤에 붙는다"가 정확해서 **그대로 뒀다**.

**대조했으나 코드와 일치해 손대지 않은 것**

- 스냅샷/시점 단정 59건 — 전부 `*_snapshot` 컬럼을 읽는 게 맞았다 (`NotificationItem.productName`의 "주문 알림만 스냅샷" 분기까지 일치)
- null 배타 열거 2건 — Codex가 짚은 그 2건이 전부였고 이미 수정됨
- 정렬 단정 62건 / 배타·택일 12건 — `orderBy`와 일치

## 기타

`docs:check` BASELINE을 현재 수치로 갱신했다. #290~#294 머지로 요소가 늘어(input 타입 72→73, input 필드 227→229, 출력 필드 603→618) 스냅샷이 낡아 있었다. 스크립트 주석이 "커버리지가 바뀌면 BASELINE도 함께 갱신한다"고 정해 둔 대로다.

## 검증

- `yarn validate` 통과 — 225 suites / 1875 tests
- 전체 스키마 `buildSchema` 통과 (42개 파일, 232개 타입) — 파일 단위 파싱이 놓치는 타입 누락 없음
- `docs:check` 8개 카테고리 전부 100% 유지

동작 변경 없음. SDL description과 그로부터 생성되는 타입 주석만 바뀐다. 테스트를 추가하지 않은 이유도 같다.

## 2차 반영 (Codex 리뷰 2건)

둘 다 이 PR에서 **내가 여러 자리에 동시에 퍼뜨린 문구**라, 지적된 자리가 아니라 문구 전체를 훑었다.

| 지적 | 확인 | 전수 결과 |
| --- | --- | --- |
| `BAD_REQUEST`는 FE가 받는 코드가 아니다 | `graphql-exception.filter.ts:21`이 400 → `BAD_USER_INPUT` 매핑 | **32건** 교체 — 이 PR에서 넣은 16건 + 기존 16건. `NOT_FOUND`·`FORBIDDEN`은 매핑과 이름이 같아 유지 |
| `(맨 뒤가 아니다)`는 보장 못 한다 | FAQ·배너는 `[sort_order asc, id asc]`라 기존이 전부 0이면 새 항목이 맨 뒤. `@Min` 없어 음수도 허용 | **5건** 재작성 — 같은 문구였지만 실제 정렬은 3종(옵션 3종 tie-break 없음 / FAQ id asc / 배너 구매자 조회 1건 선택) |

반복 수정으로 붙은 군더더기도 함께 걷어냈다: `(400)` 32건, `WriteReviewMediaInput` 타입·필드 설명 중복, 3줄짜리 sortOrder 설명 5건 → 기존 하우스 스타일(한 줄)로.

**별건 발견 (이 PR 범위 밖):** `ConflictException`(409)이 4곳에서 던져지는데 409가 `STATUS_TO_CODE`에 없어 `INTERNAL_SERVER_ERROR`로 나간다. FE가 "이미 리뷰함"과 서버 장애를 구분할 수 없다. 릴리즈 중인 문서 PR에서 에러 계약을 바꾸지 않고 별도 이슈로 올린다.

최종 변경 규모: 22개 파일, +46 / −44.
