### PR TITLE
fix: 릴리즈 리뷰 반영 (구매자 상품 통화 필드 계약 정정)

### DIFF
--- a/src/features/product/product-detail.graphql
+++ b/src/features/product/product-detail.graphql
@@ -22,7 +22,7 @@ type ProductDetail {
   salePrice: Int
   """할인율(0~100). salePrice 없으면 0."""
   discountRate: Int!
-  """통화 코드(ISO 4217). 현재는 KRW만 쓴다."""
+  """통화 코드(ISO 4217). 저장된 값을 그대로 돌려주며, 현재 KRW만 주문 가능하다."""
   currency: String!
   """후기 탭 카운트."""
   reviewCount: Int!

--- a/src/features/product/product-storefront.graphql
+++ b/src/features/product/product-storefront.graphql
@@ -67,7 +67,7 @@ type StoreProduct {
   salePrice: Int
   """할인율(0~100). salePrice 없으면 0."""
   discountRate: Int!
-  """통화 코드(ISO 4217). 현재는 KRW만 쓴다."""
+  """통화 코드(ISO 4217). 저장된 값을 그대로 돌려주며, 현재 KRW만 주문 가능하다."""
   currency: String!
   """소속 카테고리 ID(FE 섹션 그룹핑/스크롤 스파이용)."""
   categoryIds: [ID!]!


### PR DESCRIPTION
릴리즈 PR #289 Codex 지적. `ProductDetail.currency`·`StoreProduct.currency`가 "현재는 KRW만 쓴다"로 적혀 있으나, 판매자가 저장한 ISO 코드가 매퍼를 거쳐 그대로 반환된다. 체크아웃만 KRW 외를 거절한다.

통화 지적 3회째라 SDL 전체의 `currency`를 전수 확인했다 — 5곳: 판매자 3곳(#296에서 정정), 구매자 2곳(이번), 주문 타입에는 통화 필드 없음. 근본 해결은 판매자 쓰기에서 KRW 외 거절(동작 변경)이라 이슈로 남긴다.

`yarn validate` exit 0. 2곳 수정, 동작 변경 없음.