### PR TITLE
fix: 릴리즈 리뷰 반영 (감사 로그 enum 값 설명을 실제 기록 경로로 한정)

### DIFF
--- a/src/features/seller/seller-content.graphql
+++ b/src/features/seller/seller-content.graphql
@@ -193,11 +193,11 @@ input SellerUpdateBannerInput {
 
 """감사 로그가 가리키는 대상 종류."""
 enum SellerAuditTargetType {
-  """매장 정보·영업시간·픽업 정책 등 매장 설정."""
+  """매장 정보·영업시간·픽업 정책·FAQ·배너 등 매장 단위 설정과 콘텐츠."""
   STORE
   """상품과 그 하위(이미지·옵션·커스텀 템플릿)."""
   PRODUCT
-  """주문. 주로 상태 변경이 기록된다."""
+  """주문. 상태 변경만 기록된다."""
   ORDER
   """구매자 문의 대화."""
   CONVERSATION
@@ -213,7 +213,7 @@ enum SellerAuditActionType {
   UPDATE
   """삭제(soft-delete 포함)."""
   DELETE
-  """상태 전이. 주문 상태 변경·노출 여부 전환이 여기 해당한다."""
+  """상태 전이. 주문 상태 변경과 전용 활성화 뮤테이션(sellerSetProductActive·sellerSetProductCustomTemplateActive)만 해당한다. 일반 수정 안의 isActive 변경은 UPDATE로 기록된다."""
   STATUS_CHANGE
 }
 


### PR DESCRIPTION
릴리즈 PR #289 Codex 지적. `SellerAuditActionType.STATUS_CHANGE`가 "노출 여부 전환"을 포괄한다고 적혀 있으나 FAQ·배너·옵션의 isActive 변경은 UPDATE로 기록된다.

enum 값 설명이 발생 경로를 과일반화하는 유형이라 `createAuditLog` 호출 36건을 (action, targetType, 뮤테이션) 표로 뽑아 enum 두 개의 값 설명 전체와 대조했다(표 행수 = 호출 수 일치 확인).

| 값 | 실제 | 조치 |
| --- | --- | --- |
| `STATUS_CHANGE` | 전용 활성화 뮤테이션 2개 + 주문 상태 변경(order.repository 트랜잭션) | 그 셋으로 한정, isActive 일반 수정은 UPDATE임을 명시 |
| `STORE` | 매장 설정 외에 FAQ·배너도 기록(전용 대상 없음) | 보강 |
| `ORDER` | 상태 변경 단일 경로 | "주로" 제거 |

`yarn validate` exit 0. 3곳 수정, 동작 변경 없음.