### PR TITLE
chore: 리뷰 대응 잔여 주석 정리

### DIFF
--- a/scripts/check-sdl-description-coverage.ts
+++ b/scripts/check-sdl-description-coverage.ts
@@ -86,7 +86,7 @@ function main(): void {
   const files = loadSdlFiles();
   if (files.length === 0) {
     // 검사 대상이 없으면 모든 카테고리가 0/0이 되고 percentOf가 100을 돌려줘
-    // 위반 없이 "통과"가 찍힌다. 이 게이트가 막으려는 것과 같은 종류의 거짓 안전이다.
+    // 위반 없이 "통과"가 찍힌다.
     console.error(
       `[docs:check] SDL 파일을 찾지 못했습니다: ${SDL_ROOT}. ` +
         '경로가 옳은지 확인하라 — 대상이 없으면 커버리지는 의미가 없다.',

--- a/scripts/sdl-description-coverage.ts
+++ b/scripts/sdl-description-coverage.ts
@@ -1,13 +1,8 @@
 /**
- * SDL description 커버리지 측정 로직.
+ * SDL description 커버리지 측정 로직 (순수 함수).
  *
- * 왜: SDL에 설명 없는 필드를 추가해도 `yarn validate`가 통과한다. dto:check가
- * SDL↔DTO 동기화를 도구로 강제하듯, 문서 커버리지도 사람 주의력이 아니라
- * 게이트로 받쳐야 한다. (이슈 #250)
- *
- * 이 파일은 순수 함수만 둔다 — 파일 시스템 접근과 CLI는
- * check-sdl-description-coverage.ts가 담당한다. 그래야 spec에서 SDL 문자열만으로
- * 검증할 수 있다.
+ * 파일 시스템 접근과 CLI는 check-sdl-description-coverage.ts가 담당한다 — 그래야
+ * spec에서 SDL 문자열만으로 검증할 수 있다. 도입 배경은 그쪽 헤더에.
  */
 
 import type {
@@ -102,7 +97,7 @@ export function isExemptFieldName(name: string): boolean {
  * 타입 이름을 되풀이하기만 하는 자동생성형 설명인지.
  *
  * `"""SellerOrderSummary 타입"""`처럼 이름만 되풀이하는 설명은 파서에 "문서화됨"으로
- * 잡히지만 전달되는 정보가 없다. 미기재로 세지 않으면 기준선이 거짓 안전을 준다.
+ * 잡히지만 전달되는 정보가 없다. 미기재로 세지 않으면 기준선이 실제보다 높게 잡힌다.
  */
 export function isPlaceholderDescription(
   typeName: string,

--- a/src/features/seller/dto/inputs/seller-conversation-list.input.ts
+++ b/src/features/seller/dto/inputs/seller-conversation-list.input.ts
@@ -1,11 +1,6 @@
 import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
-/**
- * 판매자 대화 목록 입력.
- *
- * 커서가 (updated_at, id) 복합이라 공용 SellerCursorInput(id 단독)과 분리했다 —
- * 정렬 키를 그대로 커서에 담지 않으면 목록에서 빠지는 대화가 생긴다.
- */
+/** 판매자 대화 목록 입력. 커서가 (updated_at, id) 복합이라 공용 SellerCursorInput(id 단독)과 분리했다. */
 export class SellerConversationListInput {
   @IsOptional()
   @IsInt()

--- a/src/features/seller/services/seller-conversation.service.ts
+++ b/src/features/seller/services/seller-conversation.service.ts
@@ -66,10 +66,7 @@ export class SellerConversationService extends SellerBaseService {
   ) {
     super(repo, auditLogs);
   }
-  /**
-   * 대화 목록은 (updated_at, id) desc 정렬이라 커서도 두 값을 함께 담는다.
-   * id 단독 커서로는 정렬 순서와 무관한 행을 잘라내 목록에서 빠지는 대화가 생긴다.
-   */
+  /** 정렬 키 (updated_at, id)를 그대로 커서에 담는다. 근거는 repository 쪽 주석. */
   async sellerConversations(
     accountId: bigint,
     input?: SellerConversationListInput,


### PR DESCRIPTION
릴리즈 #289에 포함된 작업(#290~#298) 전체를 훑어 반복 리뷰 대응으로 남은 군더더기를 정리한다. 동작 변경 없음.

| 항목 | 조치 |
| --- | --- |
| 복합 커서 근거가 repository·service·input **세 곳에 반복** | repository에만 남기고 나머지는 한 줄 |
| 커버리지 스크립트 두 파일의 헤더가 도입 배경을 **중복 서술** | lib 쪽은 역할만, 배경은 CLI 헤더로 |
| "거짓 안전" 등 판단성 표현 2곳 | 중립 서술 |

점검했으나 손대지 않은 것: 과도기성 코드·옛 enum 별칭 없음(spec 픽스처 문자열 1건은 임의 타입명이라 해당 없음), `findViolations`의 "왜 둘 다인가" 주석은 비자명한 근거라 유지.

4개 파일, +7 / −20. `yarn validate` exit 0.